### PR TITLE
fixed Cypress path alias resolution and corrected test and config issues

### DIFF
--- a/cypress/db/node-db.ts
+++ b/cypress/db/node-db.ts
@@ -21,10 +21,6 @@ function createNodeDb(connectionString: string) {
 }
 
 function getNodeDb() {
-	if (!DATABASE_URL) {
-		throw new Error("DATABASE_URL is not set.");
-	}
-
 	if (!dbSingleton) {
 		dbSingleton = createNodeDb(DATABASE_URL);
 	}

--- a/cypress/e2e/auth/access-control.cy.ts
+++ b/cypress/e2e/auth/access-control.cy.ts
@@ -14,7 +14,8 @@ describe("Access control", () => {
 	it("redirects authenticated user away from login to dashboard", () => {
 		cy.loginAsDemoUser();
 
-		// Visiting login should bounce to dashboard
+		// Visiting login while authenticated should bounce to dashboard
+		cy.visit(LOGIN_PATH);
 		cy.url().should("include", DASHBOARD_PATH);
 		cy.findByRole("heading", { name: UI_MATCHERS_REGEX.dashboardH1 }).should(
 			"be.visible",

--- a/cypress/e2e/shared/deterministic-seeds.ts
+++ b/cypress/e2e/shared/deterministic-seeds.ts
@@ -1,1 +1,0 @@
-console.log("deterministic seeds");

--- a/cypress/e2e/shared/selectors.ts
+++ b/cypress/e2e/shared/selectors.ts
@@ -17,7 +17,6 @@ export const AUTH_SEL = {
 	//  For a "pure" fundamental level, lean more heavily on Testing Library queries (which you already have installed).
 	//  Instead of cy.get('#email'), use cy.findByLabelText(/email/i). This makes tests less dependent on code structure
 	//  and more on user experience.
-	loginEmailV2: "[findByLabelText(/email/i)]",
 	loginPassword: '[data-cy="login-password-input"]',
 	loginSubmit: '[data-cy="login-submit-button"]',
 	nextjsCourseLink: '[data-testid="nextjs-course-link"]',

--- a/cypress/e2e/smoke/db-reset.cy.ts
+++ b/cypress/e2e/smoke/db-reset.cy.ts
@@ -1,4 +1,4 @@
-import { createTestUser } from "@cypress/e2e/shared/users";
+import { createTestUser, DEMO_USER } from "@cypress/e2e/shared/users";
 
 describe("task: db:reset", () => {
 	it("clears users (verified by db:userExists)", () => {
@@ -13,22 +13,16 @@ describe("task: db:reset", () => {
 	});
 });
 
-// TypeScript
 describe("Invoices", () => {
-	const user = createTestUser();
+	const loginCreds = { email: DEMO_USER.email, password: DEMO_USER.password };
 
 	before(() => {
-		// You can also use cy.dbResetAndSeed() if you prefer one call:
-		// cy.dbResetAndSeed();
 		cy.dbReset();
 		cy.dbSeed();
 	});
 
 	beforeEach(() => {
-		// If you rely on session caching:
-		// cy.session("login", () => { cy.loginProgrammatically(); });
-		// Or just log in
-		cy.login(user);
+		cy.login(loginCreds);
 	});
 
 	it("shows seeded invoices", () => {

--- a/cypress/node/config/cypress-env.schema.ts
+++ b/cypress/node/config/cypress-env.schema.ts
@@ -9,6 +9,7 @@ const DATABASE_ENVIRONMENT_TUPLE = [
 const DatabaseEnvironmentSchema = z.enum(DATABASE_ENVIRONMENT_TUPLE);
 
 export const CypressEnvShape = z.object({
+	authBcryptSaltRounds: z.coerce.number().int().positive(),
 	databaseEnv: DatabaseEnvironmentSchema,
 	databaseUrl: z.string().min(1),
 	// biome-ignore lint/style/noMagicNumbers: good enough

--- a/cypress/node/config/cypress-env.ts
+++ b/cypress/node/config/cypress-env.ts
@@ -2,6 +2,7 @@ import process from "node:process";
 import { CypressEnvShape } from "./cypress-env.schema";
 
 const envToValidate = {
+	authBcryptSaltRounds: process.env.AUTH_BCRYPT_SALT_ROUNDS,
 	databaseEnv: process.env.DATABASE_ENV,
 	databaseUrl: process.env.DATABASE_URL,
 	port: process.env.PORT,
@@ -17,6 +18,7 @@ if (!parsed.success) {
 	);
 }
 
+export const AUTH_BCRYPT_SALT_ROUNDS: number = parsed.data.authBcryptSaltRounds;
 export const CYPRESS_BASE_URL: string = `http://localhost:${parsed.data.port}`;
 export const DATABASE_ENV = parsed.data.databaseEnv;
 export const DATABASE_URL: string = parsed.data.databaseUrl;

--- a/cypress/node/tasks/create-user.task.ts
+++ b/cypress/node/tasks/create-user.task.ts
@@ -1,4 +1,5 @@
 import { nodeDb } from "@cypress/db/node-db";
+import { AUTH_BCRYPT_SALT_ROUNDS } from "@cypress/node/config/cypress-env";
 import {
 	normalizeUserEmail,
 	normalizeUsername,
@@ -14,7 +15,7 @@ function toHash(value: string): Hash {
 }
 
 async function hashPassword(password: string): Promise<Hash> {
-	const salt = await bcryptjs.genSalt(10);
+	const salt = await bcryptjs.genSalt(AUTH_BCRYPT_SALT_ROUNDS);
 	const hashedPassword = await bcryptjs.hash(password, salt);
 	return toHash(hashedPassword);
 }

--- a/cypress/node/tasks/upsert-e2e-user.task.ts
+++ b/cypress/node/tasks/upsert-e2e-user.task.ts
@@ -1,4 +1,5 @@
 import { nodeDb } from "@cypress/db/node-db";
+import { AUTH_BCRYPT_SALT_ROUNDS } from "@cypress/node/config/cypress-env";
 import {
 	normalizeUserEmail,
 	normalizeUserPassword,
@@ -16,7 +17,7 @@ function toHash(value: string): Hash {
 }
 
 async function hashPassword(password: string): Promise<Hash> {
-	const salt = await bcryptjs.genSalt(10);
+	const salt = await bcryptjs.genSalt(AUTH_BCRYPT_SALT_ROUNDS);
 	const hashedPassword = await bcryptjs.hash(password, salt);
 	return toHash(hashedPassword);
 }

--- a/devtools/config/tooling-env.schema.ts
+++ b/devtools/config/tooling-env.schema.ts
@@ -9,7 +9,6 @@ const DATABASE_ENVIRONMENT_TUPLE = [
 const DatabaseEnvironmentSchema = z.enum(DATABASE_ENVIRONMENT_TUPLE);
 
 export const ToolingEnvShape = z.object({
-	cypressBaseUrl: z.url(),
 	databaseEnv: DatabaseEnvironmentSchema,
 	databaseUrl: z.string().min(1),
 	sessionSecret: z.string().min(1),

--- a/devtools/config/tooling-env.ts
+++ b/devtools/config/tooling-env.ts
@@ -3,7 +3,6 @@ import { ToolingEnvShape } from "@devtools/config/tooling-env.schema";
 
 // Build a normalized object from process.env (use UPPER_SNAKE names)
 const envToValidate = {
-	cypressBaseUrl: process.env.CYPRESS_BASE_URL,
 	databaseEnv: process.env.DATABASE_ENV,
 	databaseUrl: process.env.DATABASE_URL,
 	sessionSecret: process.env.SESSION_SECRET,
@@ -21,7 +20,6 @@ if (!parsed.success) {
 	);
 }
 
-export const CYPRESS_BASE_URL: string = parsed.data.cypressBaseUrl;
 export const DATABASE_ENV = parsed.data.databaseEnv;
 export const DATABASE_URL: string = parsed.data.databaseUrl;
 export const SESSION_SECRET: string = parsed.data.sessionSecret;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
 		"noPropertyAccessFromIndexSignature": false, // disabling from strictest base
 		"noUnusedLocals": false, // disabling from strictest base
 		// Modules
+		"baseUrl": ".", // required for Cypress to resolve path aliases via webpack
+		"ignoreDeprecations": "6.0", // silences TS5101 for baseUrl
 		"paths": {
 			"@/*": ["./src/*"],
 			"@cypress/*": ["./cypress/*"],


### PR DESCRIPTION
- restored `baseUrl` and `ignoreDeprecations: "6.0"` to tsconfig.json so Cypress's internal webpack bundler resolves `@cypress/*`, `@database/*`, and other path aliases (removed in a prior simplification commit)
- removed broken `CYPRESS_BASE_URL` validation from `tooling-env.ts/schema.ts`; the var is not in any env file and `nodeDb` only needs `DATABASE_URL`
- added `AUTH_BCRYPT_SALT_ROUNDS` to `cypress-env.ts/schema.ts` and wired it into `create-user.task.ts` and `upsert-e2e-user.task.ts` replacing hardcoded `10`
- fixed `db-reset.cy.ts` Invoices suite to log in as `DEMO_USER` (a seeded account) instead of a `createTestUser()` who never gets inserted
- fixed `access-control.cy.ts` redirect test to actually visit the login page while authenticated, so the redirect is genuinely exercised
- removed invalid `loginEmailV2` CSS selector (was a Testing Library call written as a string) from `selectors.ts`
- deleted `deterministic-seeds.ts` placeholder (contained only a console.log)
- removed dead `if (!DATABASE_URL)` null-check in `node-db.ts`; the value is guaranteed non-empty by Zod validation in `cypress-env.ts`