### PR TITLE
Refine AI tooling configuration for Claude, Junie, and JetBrains AI A…

### DIFF
--- a/.aiignore
+++ b/.aiignore
@@ -1,3 +1,4 @@
+# Keep in sync with .claudeignore — both files must have identical content.
 node_modules/
 .next/
 out/

--- a/.claude/commands/check-full.md
+++ b/.claude/commands/check-full.md
@@ -1,0 +1,1 @@
+Run full validation (lint + typecheck + typegen + unit tests + e2e): `pnpm check`. Report all failures with file paths and line numbers. Do not attempt to fix anything — just report.

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,1 @@
+Run fast validation (lint + typecheck + typegen): `pnpm check:fast`. Report all errors with file paths and line numbers. Do not attempt to fix anything — just report.

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,1 @@
+Run Biome lint and format check: `pnpm biome:lint && pnpm biome:format:check`. Report all issues grouped by file. Do not auto-fix — just report.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,1 @@
+Run unit tests: `pnpm test`. Report failures with test name, file path, and the assertion that failed. Do not attempt to fix anything — just report.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm biome:*)",
+      "Bash(pnpm typecheck*)",
+      "Bash(pnpm next:typegen)",
+      "Bash(pnpm check*)",
+      "Bash(pnpm test*)",
+      "Bash(pnpm knip)",
+      "Bash(pnpm db:*)",
+      "Bash(pnpm next:dev*)",
+      "Bash(pnpm clean*)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(git branch*)",
+      "Bash(git stash list)",
+      "Bash(find . *)",
+      "Bash(grep *)"
+    ],
+    "deny": [
+      "Bash(cat .env*)",
+      "Bash(grep * .env*)"
+    ]
+  }
+}

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,3 +1,4 @@
+# Keep in sync with .aiignore — both files must have identical content.
 node_modules/
 .next/
 out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ outdated — the docs are the source of truth.
 For detailed architecture, naming, error-handling, and UI rules, also consult the Markdown files in
 `.aiassistant/rules/` when they are relevant to the files you are changing.
 
+The rule files include `apply: by file patterns` frontmatter — this is a JetBrains AI Assistant feature for
+scoped application. Other tools (Claude, Junie, ChatGPT) should apply the rules by judgment based on the
+files being changed, not by parsing the frontmatter.
+
 ## Useful commands
 
 - Fast validation: `pnpm check:fast`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,3 +2,28 @@
 
 Follow the shared repository instructions in `AGENTS.md`.
 Also consult relevant detailed project standards in `.aiassistant/rules/`.
+
+## Claude-specific context
+
+### Slash commands
+
+Project-level slash commands are defined in `.claude/commands/`:
+
+| Command | Runs |
+|---|---|
+| `/check` | `pnpm check:fast` — lint + typecheck + typegen |
+| `/check-full` | `pnpm check` — full suite including tests and e2e |
+| `/lint` | `pnpm biome:lint && pnpm biome:format:check` |
+| `/test` | `pnpm test` — unit tests only |
+
+### Worktrees
+
+Claude Code may check out work in a git worktree under `.claude/worktrees/`. Changes committed there go to a separate branch and do not affect `main` until a PR is merged.
+
+### Memory
+
+Project-level memory is stored in `~/.claude/projects/.../memory/`. It persists context across conversations (user preferences, feedback, project state). Check it when resuming prior work.
+
+### `.aiassistant/rules/` frontmatter
+
+The rule files in `.aiassistant/rules/` include `apply: by file patterns` frontmatter. This is a JetBrains AI Assistant feature for scoped application. Claude does not enforce it automatically — use your judgment to apply the relevant rules based on the files you are editing.


### PR DESCRIPTION
…ssistant

- Added .claude/settings.json with a pnpm/git/find/grep permissions allowlist and a deny rule blocking direct reads of .env files.
- Added .claude/commands/ with /check, /check-full, /lint, and /test slash commands wired to existing pnpm scripts.
- Expanded CLAUDE.md with Claude-specific context: slash command table, worktree lifecycle, memory directory, and frontmatter note.
- Clarified in AGENTS.md that the apply: by file patterns frontmatter in .aiassistant/rules/ is a JetBrains AI Assistant feature, not Junie.
- Added sync comments to .aiignore and .claudeignore to flag that both files must be kept identical.