### PR TITLE
ci: add basic GitHub Actions CI and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot keeps dependencies up to date by opening small, reviewable PRs.
+# This is a config file (not an Actions workflow), but it's one of the most
+# essential basics for any GitHub repo.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  # Keep your app/library dependencies (package.json + pnpm-lock.yaml) current.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # Keep the action versions used inside .github/workflows current
+  # (e.g. actions/checkout@v4, pnpm/action-setup@v4).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+# Continuous Integration (CI)
+#
+# Runs fast, dependency-free checks on every push to `main` and every pull
+# request that targets `main`. These are the same checks as `pnpm check:fast`
+# (lint + type-check + Next.js typegen), so if that passes on your machine,
+# this should pass here too.
+#
+# Note: tests, the production build, and Cypress e2e are intentionally NOT here.
+# They need a real database + secret env vars and would fail in a plain CI run.
+# See the README / your `pnpm check` script for how to run those locally.
+
+name: CI
+
+# When should this workflow run?
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+# If you push again before a run finishes, cancel the old run (saves CI minutes).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: this workflow only needs to read the repository.
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Lint & type-check
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Check out your repository code onto the runner.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2. Install pnpm. The version is read automatically from the
+      #    "packageManager" field in package.json, so it stays in sync.
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      # 3. Install Node.js and cache the pnpm store so installs are faster.
+      #    (pnpm must be set up BEFORE this step for the cache to work.)
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "26" # matches "engines.node" in package.json
+          cache: pnpm
+
+      # 4. Install dependencies exactly as pinned in pnpm-lock.yaml.
+      #    --frozen-lockfile fails the build if the lockfile is out of date.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # 5. Lint, formatting, and import-order checks (Biome).
+      - name: Lint
+        run: pnpm biome:lint
+
+      # 6. TypeScript type-checking.
+      - name: Type-check
+        run: pnpm typecheck
+
+      # 7. Generate Next.js route types and type-check the app against them.
+      - name: Next.js typegen
+        run: pnpm next:typegen


### PR DESCRIPTION
## Summary

Adds the repo's first `.github/` automation: a beginner-level, essential CI workflow and automated dependency updates.

- **`.github/workflows/ci.yml`** — runs on push/PR to `main` and `develop`. Steps mirror the existing `pnpm check:fast` gate: set up pnpm (version auto-read from `packageManager`) + Node 26 with pnpm cache → `pnpm install --frozen-lockfile` → `biome:lint` → `typecheck` → `next:typegen`. Includes `concurrency` cancellation of superseded runs and least-privilege `contents: read` permissions.
- **`.github/dependabot.yml`** — weekly update PRs for npm/pnpm dependencies and for the GitHub Actions versions used in the workflow.

## Why this scope

The CI deliberately stops at **dependency-free checks** so it stays green out of the box:

- [`src/shared/core/config/server/env-server.ts`](https://github.com/andrewpetersondev/nextjs-dashboard/blob/claude/awesome-maxwell-5b48c0/src/shared/core/config/server/env-server.ts) validates environment variables at **module load** and throws when `DATABASE_URL` / `SESSION_SECRET` are missing.
- 5 of the 11 test files are **DB-backed integration tests**, and `pnpm test` runs them via `dotenv -e .env.test.local`.

So `pnpm test`, `next build`, and Cypress e2e all require a real Postgres + secret env vars. Wiring them into a basic CI would make it fail red on every push — undesirable. Those can be added later as a separate workflow with a `postgres` service container + GitHub secrets.

Rule of thumb: **if `pnpm check:fast` passes locally, this CI passes.**

## Reviewer notes

- The `develop` branch doesn't exist yet; the trigger is harmless until it's created (Actions just won't fire for it).
- Node version is pinned to `26` to match `engines.node`; pnpm version is auto-detected from the `packageManager` field, so it stays in sync.
- Heads-up: GitHub already reports 3 Dependabot security alerts on `main` (2 high, 1 moderate) — the new `dependabot.yml` will start opening update PRs for these.
