### PR TITLE
Fix blank-password user edit + add architecture diagram docs

### DIFF
--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,65 @@
+# Architecture diagrams
+
+A **visual** companion to the prose docs in this folder
+([../project-structure.md](../project-structure.md) and
+[../SHARED.ARCHITECTURE.md](../SHARED.ARCHITECTURE.md)). The prose explains the
+rules; these diagrams show the shapes. They exist for a simple reason: no one
+can hold a whole system in their head — we draw so we don't have to.
+
+Every diagram here is written in [Mermaid](https://mermaid.js.org) — plain text
+that renders as a picture. That keeps each diagram in version control, diffable
+in a PR, and sitting right next to the code it describes.
+
+## The diagrams
+
+| File | The question it answers | Diagram type |
+|---|---|---|
+| [c4-architecture.md](c4-architecture.md) | "How is the whole system carved into pieces?" | C4 (context → container → component) |
+| [database-erd.md](database-erd.md) | "What tables exist and how do they relate?" | Entity-relationship |
+| [module-layers.md](module-layers.md) | "How is a module layered, and which way do dependencies point?" | Layered flowchart |
+| [auth-login-flow.md](auth-login-flow.md) | "Step by step, what happens when someone logs in?" | Sequence |
+| [request-flow-update-user.md](request-flow-update-user.md) | "How does a form submission travel through the layers?" | Sequence |
+
+## Pick the question first
+
+The one habit that keeps diagrams from turning into spaghetti: **a diagram should
+answer exactly one question.** Decide the question, and the diagram type follows.
+
+| You want to know… | Draw a… |
+|---|---|
+| What calls what, in what order (a request, a bug) | **Sequence diagram** |
+| How the system is split into parts | **C4 / box diagram** |
+| How data changes shape as it moves | **Data-flow / sequence** |
+| What tables exist and how they link | **ERD** |
+| What states a thing can be in | **State diagram** |
+
+## The C4 model in one minute
+
+C4 is just four zoom levels. The discipline is **one level per diagram** — mixing
+levels is what makes architecture pictures confusing.
+
+1. **Context** — the app as a single box, plus who/what touches it (browser, Neon, Vercel).
+2. **Container** — the deployable things: the Next.js app, the Postgres database.
+3. **Component** — *inside* a container: the modules and layers.
+4. **Code** — class/function level. Don't hand-draw this; let WebStorm generate it.
+
+See [c4-architecture.md](c4-architecture.md) for levels 1–3 drawn from this repo.
+
+## How to see them render
+
+- **WebStorm / JetBrains** — open any `.md` file here and click the preview pane
+  (the split icon, top-right of the editor). Mermaid renders inline. If you see
+  raw text instead, enable it under
+  **Settings → Languages & Frameworks → Markdown → Mermaid**.
+- **GitHub** — renders Mermaid automatically in the file view.
+- **VS Code** — install the "Markdown Preview Mermaid Support" extension.
+
+## Keeping them honest
+
+A wrong diagram is worse than no diagram. When you change a flow or a table,
+either update the relevant file here, or ask Claude to regenerate it from the
+current code (e.g. *"redraw the login sequence from the actual auth module"*).
+
+These were generated on **2026-06-03** from the code on branch
+`claude/gallant-mccarthy-f13a40`. Treat them as a snapshot — verify against the
+code before trusting a fine detail.

--- a/docs/diagrams/auth-login-flow.md
+++ b/docs/diagrams/auth-login-flow.md
@@ -1,0 +1,99 @@
+# Auth flows — login, session check, signup
+
+> The question this answers: *"Step by step, what happens when someone logs in,
+> and how does a later request know they're logged in?"* This is the auth module
+> ([`src/modules/auth/`](../../src/modules/auth)) — the most layered part of the
+> codebase, so it's the best one to have a map for.
+
+## Login
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Action as login.action
+    participant Comp as auth.composition
+    participant WF as login.workflow
+    participant UC as LoginUseCase
+    participant Bcrypt as Bcrypt service
+    participant Sess as SessionService
+    participant JWT as SessionToken + jose
+    participant Cookie as Session cookie store
+
+    User->>Action: submit email + password
+    Action->>Comp: makeAuthComposition()
+    Comp-->>Action: wired workflows + services
+    Action->>WF: login(input)
+    WF->>UC: execute()
+    UC->>Bcrypt: compare(password, storedHash)
+    Bcrypt-->>UC: match? true / false
+    Note over UC: "no such user" and "wrong password"<br/>return the SAME error — see ADR-006
+    UC-->>WF: AuthenticatedUser — password stripped, ADR-004
+    WF->>Sess: establish(principal)
+    Sess->>JWT: issue + sign claims
+    JWT-->>Sess: signed JWT string
+    Sess->>Cookie: set httpOnly session cookie
+    WF-->>Action: Result — Ok
+    Action->>User: revalidate + redirect to dashboard
+```
+
+## Session verification (every protected page)
+
+```mermaid
+sequenceDiagram
+    participant Page as Protected page / Server Component
+    participant Verify as verifySessionOptimistic
+    participant Sess as SessionService
+    participant Read as ReadSessionUseCase
+    participant Cookie as Session cookie store
+    participant JWT as SessionToken + jose
+
+    Page->>Verify: check session
+    Note over Verify: wrapped in React cache() —<br/>runs once per render, not per call
+    Verify->>Sess: verify()
+    Sess->>Read: execute()
+    Read->>Cookie: read JWT from cookie
+    Cookie-->>Read: token (or none)
+    Read->>JWT: decode + verify signature
+    JWT-->>Read: claims
+    Note over Read: validate schema + time windows<br/>(iat / exp / nbf). No DB hit — that's why it's "optimistic"
+    Read-->>Sess: session state
+    Sess-->>Verify: verified principal, or null
+    Verify-->>Page: allow render, or redirect to login
+```
+
+## Signup
+
+Same shape as login, with one extra step **first**: create the user.
+
+1. `signup.action` → `signupWorkflow`
+2. `SignupUseCase.execute()` — hash the password (bcrypt), insert the user inside
+   a transaction (unit of work). A duplicate email/username maps to a friendly
+   field error rather than a raw database crash.
+3. Then the **identical session-establishment steps** as login (issue JWT → sign
+   → set cookie).
+
+## The files behind the boxes
+
+| Box | File |
+|---|---|
+| login.action / signup.action | [`presentation/authn/actions/`](../../src/modules/auth/presentation/authn/actions) |
+| verifySessionOptimistic | [`presentation/session/actions/verify-session-optimistic.action.ts`](../../src/modules/auth/presentation/session/actions/verify-session-optimistic.action.ts) |
+| auth.composition | [`infrastructure/composition/auth.composition.ts`](../../src/modules/auth/infrastructure/composition/auth.composition.ts) |
+| login.workflow / LoginUseCase | [`application/auth-user/`](../../src/modules/auth/application/auth-user) |
+| SessionService / ReadSessionUseCase | [`application/session/`](../../src/modules/auth/application/session) + [`infrastructure/session/`](../../src/modules/auth/infrastructure/session) |
+| Bcrypt service | [`infrastructure/crypto/services/bcrypt-password.service.ts`](../../src/modules/auth/infrastructure/crypto/services/bcrypt-password.service.ts) |
+
+## The "why" lives in the ADRs
+
+These diagrams show *what* happens; the decision records explain *why*. They sit
+in [`src/modules/auth/notes/adr/`](../../src/modules/auth/notes/adr):
+
+- [ADR-001](../../src/modules/auth/notes/adr/001-use-result-type-for-error-handling.md) — return `Result<T, E>` instead of throwing
+- [ADR-002](../../src/modules/auth/notes/adr/002-separate-commands-and-queries.md) — separate commands from queries (CQRS)
+- [ADR-003](../../src/modules/auth/notes/adr/003-use-branded-types-for-ids.md) — branded types for IDs
+- [ADR-004](../../src/modules/auth/notes/adr/004-strip-passwords-at-application-boundary.md) — strip passwords at the application boundary
+- [ADR-005](../../src/modules/auth/notes/adr/005-use-jwt-for-session-tokens.md) — JWT for session tokens
+- [ADR-006](../../src/modules/auth/notes/adr/006-prevent-credential-enumeration.md) — prevent credential enumeration
+
+Pairing a **diagram (what)** with an **ADR (why)** is the combo worth keeping up —
+the diagram orients you fast, the ADR stops you from re-litigating an old decision.

--- a/docs/diagrams/c4-architecture.md
+++ b/docs/diagrams/c4-architecture.md
@@ -1,0 +1,101 @@
+# C4 architecture — the map of the territory
+
+Three zoom levels of the same system. Read them top to bottom: each one steps
+*inside* the main box of the previous. (What is C4? See
+[README.md](README.md#the-c4-model-in-one-minute).)
+
+---
+
+## Level 1 — Context: who and what touches the app
+
+> One box for the whole system, plus the people and external systems around it.
+> This is the "explain it to a non-engineer" view.
+
+```mermaid
+flowchart TD
+    user["User / recruiter<br/>web browser"]
+    app["Next.js Dashboard<br/>this application"]
+    db[("Postgres database<br/>hosted on Neon")]
+
+    user -->|"HTTPS — views dashboard,<br/>manages invoices and users"| app
+    app -->|"SQL via Drizzle ORM"| db
+```
+
+The app is hosted on **Vercel**; the database is **Neon Postgres**. There are no
+third-party identity providers — authentication is built in-house (see
+[auth-login-flow.md](auth-login-flow.md)).
+
+---
+
+## Level 2 — Container: the deployable pieces
+
+> Step inside the system box. A "container" is something that runs and can be
+> deployed independently — here, the Next.js app and the database.
+
+```mermaid
+flowchart TD
+    browser["Browser<br/>React Server + Client Components"]
+
+    subgraph host["Vercel"]
+        next["Next.js 16 App Router<br/>· Server Components — render pages<br/>· Server Actions — handle mutations<br/>· Middleware — guard routes"]
+    end
+
+    db[("Neon Postgres<br/>users · customers · invoices")]
+
+    browser -->|"HTTPS<br/>httpOnly JWT session cookie"| next
+    next -->|"Drizzle ORM"| db
+```
+
+The session is a **signed JWT stored in an httpOnly cookie** — there is no
+server-side session table. See [auth-login-flow.md](auth-login-flow.md).
+
+---
+
+## Level 3 — Component: inside the Next.js app
+
+> Step inside the Next.js container. These are the top-level folders under
+> `src/`. Arrows mean **"depends on / may import from."**
+
+```mermaid
+flowchart TD
+    app["app/<br/>routes, server-component entry points"]
+    shell["shell/<br/>composition: layouts, nav, role guards"]
+
+    subgraph modules["modules/ — domain slices"]
+        auth["auth"]
+        invoices["invoices"]
+        users["users"]
+        customers["customers"]
+        banner["banner"]
+    end
+
+    server["server/<br/>db, crypto, infrastructure"]
+    shared["shared/<br/>Result, errors, forms, telemetry"]
+    ui["ui/<br/>atoms, molecules"]
+
+    app --> shell
+    app --> modules
+    shell --> modules
+    modules --> shared
+    modules --> ui
+    shell --> shared
+    shell --> ui
+    modules --> server
+    shell --> server
+    app --> server
+```
+
+The **one-way dependency rule** (from
+[../project-structure.md](../project-structure.md)):
+
+```
+shared / ui  →  modules  →  shell  →  app
+```
+
+Lower layers never import from higher ones — `shared` and `ui` know nothing about
+`modules`, and `modules` never import from `shell`. `server` (infrastructure) is
+usable from `modules`, `shell`, and `app` as needed.
+
+The five modules are **not** all built the same way — `auth` uses full layering
+while `customers` and `banner` are simpler. That heterogeneity is intentional and
+is mapped in [module-layers.md](module-layers.md).

--- a/docs/diagrams/database-erd.md
+++ b/docs/diagrams/database-erd.md
@@ -1,0 +1,70 @@
+# Database ERD — tables and relationships
+
+> The question this answers: *"What tables exist, what's in them, and how do they
+> link?"* Drawn from the Drizzle schema in [`database/schema/`](../../database/schema).
+
+```mermaid
+erDiagram
+    customers ||--o{ invoices : "has many"
+
+    users {
+        uuid id PK "branded UserId"
+        varchar email UK "not null"
+        varchar username UK "not null"
+        varchar password "bcrypt hash, not null"
+        role role "ADMIN, USER, GUEST — default USER"
+        varchar sensitive_data "demo column"
+    }
+
+    customers {
+        uuid id PK "branded CustomerId"
+        varchar email UK "not null"
+        varchar name "not null"
+        varchar image_url "not null"
+        varchar sensitive_data "demo column"
+    }
+
+    invoices {
+        uuid id PK "branded InvoiceId"
+        uuid customer_id FK "references customers.id, cascade"
+        bigint amount "cents, must be >= 0 (check)"
+        date date "not null"
+        date revenue_period "must equal month(date) (check)"
+        status status "pending, paid — default pending"
+        varchar sensitive_data "demo column"
+    }
+
+    demo_user_counters {
+        serial id PK
+        integer count "default 0"
+        role role "default GUEST"
+    }
+```
+
+## How to read this
+
+- `||--o{` means **one-to-many**: one `customer` has zero-or-more `invoices`;
+  each `invoice` belongs to exactly one `customer`.
+- `PK` = primary key, `FK` = foreign key, `UK` = unique key.
+- A table with no connector (here `users`, `demo_user_counters`) has no foreign
+  keys to the others — it stands alone by design.
+
+## Things worth remembering
+
+- **Three independent islands, not one connected graph.** Only
+  `customers → invoices` are linked. `users` (authentication) is deliberately
+  separate from the business data — logging in doesn't depend on invoices, and
+  invoices don't reference a user. `demo_user_counters` stands alone too; it
+  powers the demo-login feature.
+- **Money is stored as integer cents in a `bigint`**, never a float. `amount` has
+  a check constraint (`>= 0`), and `revenue_period` is constrained to the first
+  day of `date`'s month. The database enforces these — they can't drift.
+- **Branded IDs** (`UserId`, `CustomerId`, `InvoiceId`) are TypeScript types over
+  `uuid`. They stop you from accidentally passing a `CustomerId` where an
+  `InvoiceId` is expected — a compile-time error, not a runtime bug. See
+  [ADR-003](../../src/modules/auth/notes/adr/003-use-branded-types-for-ids.md).
+- The `sensitive_data` columns look like teaching/demo placeholders rather than
+  real domain fields.
+
+> Tip: run **Drizzle Studio** (`pnpm drizzle-kit studio`) for a live, clickable
+> version of this — useful for browsing actual rows while debugging.

--- a/docs/diagrams/module-layers.md
+++ b/docs/diagrams/module-layers.md
@@ -1,0 +1,82 @@
+# Module layers — how a slice is built
+
+> The question this answers: *"What are the layers inside a module, and which way
+> do the dependencies point?"* The `auth` module is the fullest example, so it's
+> the one drawn here.
+
+## The four layers (auth as the example)
+
+```mermaid
+flowchart TD
+    subgraph pres["presentation/ — entry points and UI"]
+        p1["login.action.ts — server action"]
+        p2["login-form.tsx — React form"]
+        p3["verify-session-optimistic.action.ts"]
+    end
+
+    subgraph app["application/ — orchestration"]
+        a1["login.workflow.ts"]
+        a2["LoginUseCase, EstablishSessionUseCase"]
+        a3["contracts — interfaces the infra must satisfy"]
+    end
+
+    subgraph dom["domain/ — rules and entities"]
+        d1["auth-user.entity.ts"]
+        d2["password.policy.ts"]
+        d3["session.entity.ts"]
+    end
+
+    subgraph infra["infrastructure/ — concrete implementations"]
+        i1["auth-user.repository.ts — Drizzle"]
+        i2["bcrypt-password.service.ts"]
+        i3["session-token.service.ts — jose JWT"]
+        i4["auth.composition.ts — wires everything"]
+    end
+
+    pres --> app
+    app --> dom
+    infra --> dom
+    infra -.->|"implements contracts from"| app
+```
+
+## How to read it — "dependencies point inward"
+
+This is the core idea of the layered ("clean") style:
+
+- **`domain`** is the center. It depends on **nothing** — pure rules and types.
+- **`application`** depends only on `domain`. It defines *contracts* (interfaces)
+  for the things it needs, like "something that can hash a password."
+- **`infrastructure`** depends inward too: it *implements* those contracts with
+  real tech (Drizzle, bcrypt, jose). Application code never imports infrastructure
+  directly — the **composition root** (`auth.composition.ts`) plugs the concrete
+  pieces in at runtime.
+- **`presentation`** sits on the outside: forms and server actions that call into
+  `application`.
+
+The payoff: you can read a use case without knowing whether the database is
+Postgres or the hasher is bcrypt — those are swappable details behind contracts.
+
+| Layer | Owns | Examples |
+|---|---|---|
+| `presentation` | entry points, forms, error → UI mapping | `login.action.ts`, `login-form.tsx` |
+| `application` | use cases, workflows, contracts, DTOs | `login.workflow.ts`, `LoginUseCase` |
+| `domain` | entities, policies, value objects — no I/O | `auth-user.entity.ts`, `password.policy.ts` |
+| `infrastructure` | DB, crypto, JWT, cookies, composition root | `auth-user.repository.ts`, `bcrypt-password.service.ts` |
+
+## Not every module has every layer (and that's on purpose)
+
+`auth` is the learning ground for these patterns. The other modules are
+deliberately simpler — adding an `application` layer to a thin CRUD slice would
+be ceremony, not value. Here's the honest map:
+
+| Module | presentation | application | domain | infrastructure | Notes |
+|---|:---:|:---:|:---:|:---:|---|
+| `auth` | ✅ | ✅ | ✅ | ✅ | full layering; has ADRs + the most tests |
+| `invoices` | ✅ | ✅ | ✅ | ✅ | layered |
+| `users` | ✅ | ✅ | ✅ | ✅ | layered; has tests |
+| `customers` | ✅ | — | ✅ | ✅ | simpler CRUD — no `application` layer |
+| `banner` | ✅ | — | ✅ | ✅ | the thinnest slice |
+
+When you open a module and it looks different from `auth`, this is why — it's a
+conscious trade-off, not an inconsistency to "fix." The decisions behind auth's
+shape are recorded in its [ADRs](../../src/modules/auth/notes/adr).

--- a/docs/diagrams/request-flow-update-user.md
+++ b/docs/diagrams/request-flow-update-user.md
@@ -1,0 +1,61 @@
+# Request flow — editing a user
+
+> The question this answers: *"When I submit a form, what actually happens, and
+> in what order?"* This traces one real path — the **edit-user** form — from the
+> browser down to the database and back.
+>
+> It's also the flow behind a real bug: leaving the password blank used to fail
+> validation. The fix lived at the **schema** hop below, and this diagram makes
+> *why* obvious.
+
+## How to read a sequence diagram
+
+- Each vertical line is a **participant** (a file/component). Time flows **down**.
+- A solid arrow (`→`) is a **call**; a dashed arrow (`⇠`) is a **return**.
+- The boxes labelled *Note* say what's happening at that step — often where the
+  interesting logic (or the bug) lives.
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Form as EditUserForm
+    participant Action as updateUserAction
+    participant Schema as EditUserFormSchema
+    participant Service as UserService
+    participant Repo as UserRepository
+    participant DB as Postgres
+
+    Admin->>Form: edit user, leave password blank
+    Form->>Action: submit FormData — password is ""
+    Action->>Schema: validateForm(formData)
+    Note over Schema: "" becomes undefined, then .optional() accepts it.<br/>The bug fed undefined into a REQUIRED password schema.
+    Schema-->>Action: { password: undefined, ...changed fields }
+    Action->>Action: buildPatch() drops the empty password
+    Action->>Service: updateUser(id, patch)
+    Note over Service: hashes only if a password is present
+    Service->>Repo: update(id, finalPatch)
+    Repo->>DB: UPDATE users SET ...
+    DB-->>Repo: updated row
+    Repo-->>Service: Ok(user)
+    Service-->>Action: Result — Ok
+    Action-->>Form: FormResult — success
+```
+
+## The files behind each hop
+
+| Step | File |
+|---|---|
+| Form | [`edit-user-form.tsx`](../../src/modules/users/presentation/forms/edit-user-form.tsx) |
+| Server action | [`update-user.action.ts`](../../src/modules/users/presentation/actions/update-user.action.ts) |
+| Validation | [`user.schema.ts`](../../src/modules/users/domain/schemas/user.schema.ts) |
+| Service | [`user.service.ts`](../../src/modules/users/application/services/user.service.ts) |
+
+## The lesson
+
+When a bug spans layers, **draw the layers first**, then ask: *what is the data at
+each hop?* Here the data was `""` at the form, should have become `undefined` at
+the schema, and the schema was the one hop doing the wrong thing. Tracing the
+transformation pointed straight at the fix — no guessing.
+
+This is the everyday payoff of sequence diagrams: they turn "somewhere in this
+pile of files" into "this specific arrow."

--- a/src/modules/users/domain/schemas/__tests__/user.schema.test.ts
+++ b/src/modules/users/domain/schemas/__tests__/user.schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { EditUserFormSchema } from "@/modules/users/domain/schemas/user.schema";
+
+/**
+ * Regression coverage for the "leave password blank to keep current" behavior
+ * on the edit-user form. A blank (or omitted) password must validate as
+ * "unchanged" rather than being fed into the required password policy schema.
+ */
+describe("EditUserFormSchema", () => {
+	const baseValidFields = {
+		email: "editor@example.com",
+		role: "USER",
+		username: "editoruser",
+	} as const;
+
+	it("treats a blank password as 'keep current' (no validation error)", async () => {
+		const result = await EditUserFormSchema.safeParseAsync({
+			...baseValidFields,
+			password: "",
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.password).toBeUndefined();
+		}
+	});
+
+	it("treats an omitted password the same as a blank one", async () => {
+		const result = await EditUserFormSchema.safeParseAsync(baseValidFields);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.password).toBeUndefined();
+		}
+	});
+
+	it("accepts and preserves a valid new password", async () => {
+		const result = await EditUserFormSchema.safeParseAsync({
+			...baseValidFields,
+			password: "passw0rd!",
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.password).toBe("passw0rd!");
+		}
+	});
+
+	it("still rejects a provided-but-invalid password", async () => {
+		const result = await EditUserFormSchema.safeParseAsync({
+			...baseValidFields,
+			password: "a1!", // below the minimum length
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/modules/users/domain/schemas/user.schema.ts
+++ b/src/modules/users/domain/schemas/user.schema.ts
@@ -10,7 +10,11 @@ const toUndefinedIfEmptyString = (v: unknown) =>
 
 // biome-ignore lint/nursery/useExplicitType: fix later
 function optionalEdit<T extends z.ZodType>(schema: T) {
-	return z.preprocess(toUndefinedIfEmptyString, schema).optional();
+	// Empty string means "leave unchanged": preprocess turns "" into undefined,
+	// and the inner .optional() accepts that undefined. Without the inner
+	// optional, a blank field would feed undefined into the required base schema
+	// and fail validation. The outer .optional() lets the key be absent entirely.
+	return z.preprocess(toUndefinedIfEmptyString, schema.optional()).optional();
 }
 
 /**

--- a/src/modules/users/presentation/forms/edit-user-form.tsx
+++ b/src/modules/users/presentation/forms/edit-user-form.tsx
@@ -81,7 +81,6 @@ function EditUserFormFields({
 				type="email"
 			/>
 
-			{/* TODO: LEAVING PASSWORD BLANK WILL CAUSE AN ERROR */}
 			<InputFieldMolecule
 				autoComplete="off"
 				dataCy="user-password-input"


### PR DESCRIPTION
## Summary

Two independent changes on this branch (separable if you'd prefer two PRs):

### 1. Fix — blank password on user edit (`4d76e5f5`)
The edit-user form advertises *"leave blank to keep current password,"* but submitting it blank failed validation. In `EditUserFormSchema.optionalEdit`, `.optional()` wrapped the **outside** of the Zod `preprocess`, so a blank field (`""`) was converted to `undefined` and then validated against the **required** `PasswordSchema`, which rejected it.

- Moved `.optional()` onto the **inner** schema so the preprocessed `undefined` is accepted as "field unchanged."
- The action (`buildPatch`) and service (`updateUser`) already handled an absent password — the schema was the only broken hop.
- Removed the now-stale `TODO` in the form.
- Added a regression test (`user.schema.test.ts`) covering blank / omitted / valid / invalid passwords.

### 2. Docs — architecture diagram set (`1a682614`)
A visual companion under `docs/diagrams/`, grounded in the current code: C4 architecture (context → container → component), DB ERD, module layers, auth login/session/signup flows, and the edit-user request flow. Includes a README that teaches matching a diagram type to a question. GitHub renders the Mermaid inline on the **Files changed** tab.

## Test plan
- `pnpm test user.schema` → 4/4 pass
- `pnpm check:fast` (lint + typecheck + typegen) → green
- Diagrams: confirm they render on the **Files changed** tab

## Notes
- The docs change is markdown-only (no runtime impact).
- Pre-existing integration tests that need DB env vars (e.g. `AUTH_BCRYPT_SALT_ROUNDS`) still fail at boot — unrelated to this PR.
