### PR TITLE
docs(diagrams): add error-handling, route-auth, session, and DI diagrams

### DIFF
--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -19,6 +19,10 @@ in a PR, and sitting right next to the code it describes.
 | [module-layers.md](module-layers.md) | "How is a module layered, and which way do dependencies point?" | Layered flowchart |
 | [auth-login-flow.md](auth-login-flow.md) | "Step by step, what happens when someone logs in?" | Sequence |
 | [request-flow-update-user.md](request-flow-update-user.md) | "How does a form submission travel through the layers?" | Sequence |
+| [error-handling-flow.md](error-handling-flow.md) | "How does a failure travel from the database to a red field error — without a `throw`?" | Sequence + type map |
+| [route-authorization.md](route-authorization.md) | "Before a page renders, what decides whether I'm allowed in?" | Sequence + decision |
+| [session-lifecycle.md](session-lifecycle.md) | "What states can a session be in, and what moves it between them?" | State machine |
+| [dependency-injection.md](dependency-injection.md) | "How do application contracts and infrastructure implementations actually get connected?" | Component graph |
 
 ## Pick the question first
 
@@ -60,6 +64,10 @@ A wrong diagram is worse than no diagram. When you change a flow or a table,
 either update the relevant file here, or ask Claude to regenerate it from the
 current code (e.g. *"redraw the login sequence from the actual auth module"*).
 
-These were generated on **2026-06-03** from the code on branch
-`claude/gallant-mccarthy-f13a40`. Treat them as a snapshot — verify against the
-code before trusting a fine detail.
+The first five were generated on **2026-06-03** (branch
+`claude/gallant-mccarthy-f13a40`); the last four — error handling, route
+authorization, session lifecycle, dependency injection — were added on
+**2026-06-04** (branch `claude/tender-shaw-ffdd33`), each verified against the
+code at the time (drawing the session diagram even turned up a stale "7 day"
+figure in the prose that should have read 15 minutes). Treat them all as a
+snapshot — verify against the code before trusting a fine detail.

--- a/docs/diagrams/c4-architecture.md
+++ b/docs/diagrams/c4-architecture.md
@@ -37,7 +37,7 @@ flowchart TD
     browser["Browser<br/>React Server + Client Components"]
 
     subgraph host["Vercel"]
-        next["Next.js 16 App Router<br/>· Server Components — render pages<br/>· Server Actions — handle mutations<br/>· Middleware — guard routes"]
+        next["Next.js 16 App Router<br/>· Server Components — render pages<br/>· Server Actions — handle mutations<br/>· Middleware (proxy.ts) — guard routes"]
     end
 
     db[("Neon Postgres<br/>users · customers · invoices")]

--- a/docs/diagrams/dependency-injection.md
+++ b/docs/diagrams/dependency-injection.md
@@ -1,0 +1,105 @@
+# Dependency injection — where contracts meet implementations
+
+> The question this answers: *"The [module-layers diagram](module-layers.md) says
+> 'application code never imports infrastructure directly.' So how do the two ever
+> actually get connected?"* The answer is a single place called the **composition
+> root** ([`auth.composition.ts`](../../src/modules/auth/infrastructure/composition/auth.composition.ts)).
+
+This is the mechanism behind the "dependencies point inward" rule. A use case
+depends on an *interface* (a contract); the concrete database/crypto class that
+satisfies that interface is plugged in at runtime — and the plugging happens here,
+nowhere else.
+
+## The shape of it
+
+```mermaid
+flowchart TD
+    caller["Server Action / proxy.ts<br/>(presentation)"] -->|"calls"| comp["makeAuthComposition()<br/>— the composition root —"]
+
+    subgraph fac["infrastructure/composition/factories"]
+        f1["loginUseCaseFactory"]
+        f2["sessionServiceFactory"]
+        f3["authUnitOfWorkFactory"]
+    end
+
+    comp -->|"calls each factory once per request"| fac
+
+    comp -->|"returns a wired bundle"| bundle["{ workflows, services, loggers, request }"]
+    bundle --> caller
+
+    caller -.->|"runs"| wf["workflow(input)"]
+    wf -.->|"uses"| uc["use case"]
+```
+
+`makeAuthComposition()` runs once per request. It reads request metadata, builds a
+**scoped logger** (tagged with a `requestId`, IP, and user-agent so every log line
+in that request is traceable), opens the DB handle, then asks the factories to
+assemble the use cases and services. What comes back is a ready-to-run bundle of
+workflows — the caller never sees a single `new SomeRepository(...)`.
+
+## Inside one factory — the contract/implementation handshake
+
+Here's `loginUseCaseFactory`, which is the whole pattern in miniature:
+
+```mermaid
+flowchart TD
+    subgraph infra["infrastructure (concrete tech)"]
+        repo["AuthUserRepository<br/>— talks to Drizzle / Postgres"]
+        adapter["AuthUserRepositoryAdapter<br/>— wraps the repo"]
+        hasher["passwordHasherFactory()<br/>— bcrypt"]
+    end
+
+    subgraph app["application (pure, tech-agnostic)"]
+        contract["AuthUserRepositoryContract<br/>— an interface, no runtime"]
+        uc["LoginUseCase"]
+    end
+
+    repo --> adapter
+    adapter -->|"satisfies"| contract
+    uc -->|"depends on"| contract
+    hasher -->|"injected into"| uc
+
+    style contract stroke-dasharray: 5 5
+```
+
+Read it as a sentence: **`LoginUseCase` asks for "something shaped like
+`AuthUserRepositoryContract`."** The factory hands it an `AuthUserRepositoryAdapter`
+wrapping a Drizzle-backed `AuthUserRepository`. The use case never learns the word
+"Drizzle" — swap Postgres for anything else and only the factory changes; the use
+case and all its tests stay untouched.
+
+```typescript
+// the punchline of login-use-case.factory.ts
+const repo = new AuthUserRepository(db, scopedLogger, requestId);   // infra
+const repoContract = new AuthUserRepositoryAdapter(repo);           // → contract
+return new LoginUseCase(repoContract, passwordHasherFactory(), log); // app core
+```
+
+## Why bother with the adapter in the middle?
+
+It looks like an extra hop, and it's a fair thing to question. The repository is
+free to expose a rich, Drizzle-flavoured API; the **adapter** narrows it to exactly
+the contract the application asked for. That keeps the contract small and honest,
+and it's the seam where a swap or a test-double slots in. The dashed interface box
+above is the only thing the application layer is allowed to know about.
+
+## The files behind the boxes
+
+| Box | File |
+|---|---|
+| composition root | [`auth.composition.ts`](../../src/modules/auth/infrastructure/composition/auth.composition.ts) |
+| a use-case factory | [`login-use-case.factory.ts`](../../src/modules/auth/infrastructure/composition/factories/auth-user/login-use-case.factory.ts) |
+| the contract (interface) | [`session-service.contract.ts`](../../src/modules/auth/application/session/contracts/session-service.contract.ts) |
+| a concrete implementation | [`session-token.service.ts`](../../src/modules/auth/infrastructure/session/services/session-token.service.ts) |
+
+## The payoff (and the honest cost)
+
+- **Testability** — a use case takes its dependencies as constructor arguments, so
+  a unit test passes in fakes and never touches a database. This is why `auth` has
+  the most tests in the repo.
+- **Swappability** — bcrypt, jose, Drizzle, the cookie store: each sits behind a
+  contract and is chosen in exactly one factory.
+- **The cost** — more files and one layer of indirection to trace. That's why only
+  the layered modules (`auth`, `invoices`, `users`) pay for it; `customers` and
+  `banner` skip composition entirely, as the [module map](module-layers.md#not-every-module-has-every-layer-and-thats-on-purpose)
+  spells out. Wiring is worth it when the wiring buys you something.

--- a/docs/diagrams/error-handling-flow.md
+++ b/docs/diagrams/error-handling-flow.md
@@ -1,0 +1,138 @@
+# Error handling — the failure spine
+
+> The question this answers: *"When something goes wrong deep in the app, how
+> does that failure travel — without ever being `throw`n — all the way up to a
+> red message under a form field?"* This is the one flow that ties together the
+> three things people ask about most: **results**, **errors**, and **forms**.
+
+The key insight: these aren't three systems. They're **one currency for
+failure**, used everywhere. The code says so literally —
+
+```
+FormResult<T>  =  Result<FormSuccessPayload<T>, AppError>
+```
+
+A form result is just a `Result` whose error is always an `AppError`. So if you
+learn the spine once, every module reads the same way.
+
+## The shapes (read this first)
+
+```mermaid
+flowchart TD
+    subgraph res["Result — the universal return type"]
+        ok["Ok — { ok: true, value }"]
+        err["Err — { ok: false, error }"]
+    end
+
+    subgraph ae["AppError — the only thing an Err carries"]
+        reg["key → registry lookup<br/>adds layer · severity · retryable · metadata schema<br/>then deep-freezes the error"]
+    end
+
+    subgraph fr["FormResult — Result, specialised for the UI"]
+        fok["Ok → { data, message }"]
+        ferr["Err → AppError → field + form errors"]
+    end
+
+    err -->|"error is always an"| ae
+    fr -.->|"is a"| res
+```
+
+- **`Result`** is a frozen discriminated union: either `Ok` (has `value`) or
+  `Err` (has `error`). Nothing throws; failure is a *value you return*.
+- **`AppError`** is the only error type an `Err` ever holds. Its `key` (one of 13,
+  e.g. `conflict`, `validation`, `not_found`) is looked up in a **registry** that
+  stamps on the layer, severity, retry-ability, and the schema its metadata must
+  match. It's an `Error` subclass, so it still has a stack — but it's structured.
+- **`FormResult`** is `Result` with the success side carrying `{ data, message }`.
+
+## The life of a failure — a duplicate email on signup
+
+```mermaid
+sequenceDiagram
+    participant DB as Postgres
+    participant Repo as AuthUserRepository
+    participant DAL as executeDalResult
+    participant Norm as normalizePgError
+    participant Action as Server Action
+    participant UI as Signup form
+
+    Repo->>DB: INSERT user (email already taken)
+    DB-->>Repo: throws — SQLSTATE 23505
+    Note over Repo,DAL: the repo runs its query inside executeDalResult,<br/>so the throw is caught at the boundary — not bubbled up
+    Repo->>DAL: executeDalResult(thunk)
+    DAL->>Norm: catch(err) → normalizePgError(err)
+    Note over Norm: toPgError: 23505 → key "conflict"<br/>makeAppError("conflict", { cause, metadata })<br/>registry adds layer/severity/retryable + freezes
+    Norm-->>DAL: AppError(conflict)
+    DAL->>DAL: logger.error(operation.failed, { error })
+    DAL-->>Repo: Err(AppError)
+    Repo-->>Action: Result is Err — propagates upward, no throw
+    Note over Action: isErr → turn the AppError into a FormResult
+    Action-->>UI: FormResult (crosses the server→client boundary)
+    Note over UI: AppError.toDto() reduces the error to plain JSON<br/>so a typed error can survive the Server Action hop
+    Note over UI: toFormErrorPayload(error) →<br/>{ message, fieldErrors, formData }
+    UI->>UI: red text under "email", inputs re-filled from formData
+```
+
+The Postgres code → error-key mapping is a small, honest table (in
+[`pg-error.constants.ts`](../../src/shared/core/errors/server/adapters/postgres/pg-error.constants.ts)):
+
+| Postgres failure | SQLSTATE | becomes `AppError` key |
+|---|---|---|
+| unique violation (duplicate email) | `23505` | `conflict` |
+| check violation (e.g. `amount >= 0`) | `23514` | `integrity` |
+| foreign-key violation | `23503` | `integrity` |
+| not-null violation | `23502` | `integrity` |
+| anything unrecognised | — | `unexpected` |
+
+## The other on-ramp: form validation
+
+A *bad* email (wrong shape) and a *duplicate* email (DB conflict) come from
+totally different places — but they arrive at the form in the **identical
+shape**. That's the whole point.
+
+[`validateForm`](../../src/shared/forms/server/validate-form.ts) runs the
+`FormData` through a Zod schema. On failure it doesn't throw either — it calls
+`makeFormError({ key: "validation", fieldErrors, formData })`, producing the same
+`FormResult` an `Err` would. So the form component has exactly one branch to
+handle, no matter where the failure was born:
+
+```mermaid
+flowchart LR
+    z["Zod schema fails<br/>(bad email format)"] --> fe["makeFormError(validation)"]
+    db["DB / service Err(AppError)<br/>(email already exists)"] --> map["toFormErrorPayload"]
+    fe --> shape["FormResult — { message, fieldErrors, formData }"]
+    map --> shape
+    shape --> render["one render path → field + form errors"]
+```
+
+## The files behind each hop
+
+| Hop | File |
+|---|---|
+| `Result` core (`Ok` / `Err`, frozen) | [`result.ts`](../../src/shared/core/result/result.ts) |
+| `AppError` entity + `toDto` / `fromDto` | [`app-error.entity.ts`](../../src/shared/core/errors/core/app-error.entity.ts) |
+| Error registry (the 13 keys) | [`app-error.registry.ts`](../../src/shared/core/errors/core/catalog/app-error.registry.ts) |
+| DB boundary — catch → `Result` | [`execute-dal-result.ts`](../../src/shared/core/errors/server/adapters/dal/execute-dal-result.ts) |
+| Postgres → `AppError` | [`normalize-pg-error.ts`](../../src/shared/core/errors/server/adapters/postgres/normalize-pg-error.ts) · [`to-pg-error.ts`](../../src/shared/core/errors/server/adapters/postgres/to-pg-error.ts) |
+| `FormResult` type | [`form-result.dto.ts`](../../src/shared/forms/core/types/form-result.dto.ts) |
+| Form validation on-ramp | [`validate-form.ts`](../../src/shared/forms/server/validate-form.ts) |
+| `AppError` → UI payload | [`form-error-payload.mapper.ts`](../../src/shared/forms/presentation/mappers/form-error-payload.mapper.ts) |
+
+## The lesson
+
+Three rules make the whole thing hang together:
+
+1. **Failure is a value, not an exception.** Functions return `Result`; the
+   `try/catch` lives only at the edges (the DB boundary, an async refinement).
+   The compiler then *forces* you to handle the `Err` case. This is recorded in
+   [ADR-001](../../src/modules/auth/notes/adr/001-use-result-type-for-error-handling.md).
+2. **One error currency.** Everything fails as an `AppError`, built from a single
+   registry. A raw Postgres crash and a failed Zod parse become the same kind of
+   thing, so the UI never has to care where a failure came from.
+3. **The boundary is explicit.** An `AppError` is a class instance; it can't ride
+   a Server Action to the browser as-is. `toDto()` flattens it to JSON on the way
+   out — which is exactly why a typed error can show up as a typed field error in
+   the client.
+
+The everyday payoff: a new feature gets correct, consistent error handling almost
+for free, just by returning `Result` and letting the spine do the rest.

--- a/docs/diagrams/route-authorization.md
+++ b/docs/diagrams/route-authorization.md
@@ -1,0 +1,108 @@
+# Route authorization — the gate before the page
+
+> The question this answers: *"Before a page even starts rendering, what decides
+> whether I'm allowed to see it — and where do I get sent if I'm not?"* This is the
+> **edge middleware** ([`src/proxy.ts`](../../src/proxy.ts)), the first code that
+> runs on every request.
+
+A note on the filename: Next.js 16 renamed the middleware entry point from
+`middleware.ts` to **`proxy.ts`** — same job, new name. (The
+[C4 container diagram](c4-architecture.md#level-2--container-the-deployable-pieces)
+calls this box "Middleware"; it's this file.)
+
+## Step by step — one request hitting the gate
+
+```mermaid
+sequenceDiagram
+    actor Browser
+    participant Proxy as proxy.ts (edge)
+    participant Routes as routes.ts
+    participant Auth as authorizeRequestHelper
+    participant Token as SessionTokenService
+    participant Policy as evaluateRouteAccessPolicy
+
+    Browser->>Proxy: GET /dashboard/users
+    Proxy->>Routes: classify path
+    Note over Routes: compute three mutually exclusive flags:<br/>isAdminRoute · isProtectedRoute · isPublicRoute
+    Routes-->>Proxy: isAdminRoute = true
+    Note over Proxy: none matched? → NextResponse.next()<br/>(assets are already excluded by config.matcher)
+    Proxy->>Auth: authorize({ cookie, flags, path })
+    Auth->>Token: decode(cookie) — jose verifies signature + exp/nbf
+    Token-->>Auth: claims (or a decode/expired failure)
+    Auth->>Token: validate(claims) — schema + semantics
+    Token-->>Auth: SessionTokenClaimsDto
+    Note over Auth: isAuthenticated = Boolean(claims.sub)
+    Auth->>Policy: evaluate(routeType, { isAuthenticated, role })
+    Policy-->>Auth: { allowed: false, reason: NOT_AUTHORIZED }
+    Auth-->>Proxy: { kind: "redirect", to: /dashboard, reason }
+    Proxy->>Browser: 307 redirect to /dashboard
+```
+
+## The decision, as a table
+
+The policy ([`evaluate-route-access.policy.ts`](../../src/modules/auth/domain/session/policies/authorization/evaluate-route-access.policy.ts))
+is a **pure function** — it takes the route type and who you are, and returns
+allow / deny. It deliberately knows *nothing* about redirects; the middleware
+turns a denial into a destination.
+
+| Route type | Anonymous | Authenticated (USER) | Authenticated (ADMIN) |
+|---|---|---|---|
+| **public** (`/`, `/auth/login`, `/auth/signup`) | ✅ allow | ↪︎ redirect to `/dashboard` | ↪︎ redirect to `/dashboard` |
+| **protected** (`/dashboard/**`) | ↪︎ redirect to `/auth/login` | ✅ allow | ✅ allow |
+| **admin** (`/dashboard/users/**`) | ↪︎ redirect to `/auth/login` | ↪︎ redirect to `/dashboard` | ✅ allow |
+
+Reading it as a flow:
+
+```mermaid
+flowchart TD
+    start["request path"] --> rt{route type?}
+
+    rt -->|public| pub{authenticated?}
+    pub -->|yes| toDash["↪︎ /dashboard<br/>(already logged in — keep them out of login)"]
+    pub -->|no| allow1["✅ render"]
+
+    rt -->|protected| prot{authenticated?}
+    prot -->|no| toLogin1["↪︎ /auth/login"]
+    prot -->|yes| allow2["✅ render"]
+
+    rt -->|admin| adminAuth{authenticated?}
+    adminAuth -->|no| toLogin2["↪︎ /auth/login"]
+    adminAuth -->|yes| isAdmin{role = ADMIN?}
+    isAdmin -->|no| toDash2["↪︎ /dashboard"]
+    isAdmin -->|yes| allow3["✅ render"]
+```
+
+## Three things worth noticing
+
+- **Public routes bounce *authenticated* users away.** A logged-in user visiting
+  `/auth/login` is redirected to the dashboard — the login page is "public" in the
+  sense of *"for people without a session."*
+- **Exactly one route flag may be true.** [`get-route-type.policy.ts`](../../src/modules/auth/domain/session/policies/authorization/get-route-type.policy.ts)
+  counts the flags and treats "zero or two-plus" as a bug, not a default — a
+  misclassified route fails closed (redirect to login) instead of silently
+  guessing. Admin is checked first, so `/dashboard/users` is admin, not protected.
+- **The gate runs on the edge, with no database.** Authorization here rests
+  entirely on the **signed JWT in the cookie** — decode, verify, read `sub` and
+  `role`. No DB round-trip, which is what keeps middleware fast. (The deeper
+  question of *what the JWT is trusted to carry* is its own write-up:
+  [`jwt-claims-decoupling-summary.md`](../jwt-claims-decoupling-summary.md).)
+
+## The files behind the boxes
+
+| Box | File |
+|---|---|
+| edge entry point | [`proxy.ts`](../../src/proxy.ts) |
+| route classification | [`routes.ts`](../../src/shared/routing/routes.ts) |
+| orchestration (decode → policy → outcome) | [`authorize-request.helper.ts`](../../src/modules/auth/application/shared/helpers/authorize-request.helper.ts) |
+| "exactly one flag" guard | [`get-route-type.policy.ts`](../../src/modules/auth/domain/session/policies/authorization/get-route-type.policy.ts) |
+| the allow/deny decision | [`evaluate-route-access.policy.ts`](../../src/modules/auth/domain/session/policies/authorization/evaluate-route-access.policy.ts) |
+| token decode + validate | [`session-token.service.ts`](../../src/modules/auth/infrastructure/session/services/session-token.service.ts) |
+
+## How this differs from the login diagram
+
+[auth-login-flow.md](auth-login-flow.md) shows how a session gets *created* and how
+a Server Component *optimistically* re-checks it during render. This diagram is the
+layer **before** that: the edge gate that runs on every navigation and decides
+whether the request is even allowed through. Same JWT, different moment — the gate
+is the bouncer at the door; the optimistic check is the host double-checking your
+wristband once you're inside.

--- a/docs/diagrams/session-lifecycle.md
+++ b/docs/diagrams/session-lifecycle.md
@@ -1,0 +1,104 @@
+# Session lifecycle — the states a session moves through
+
+> The question this answers: *"From the moment someone logs in to the moment their
+> session is gone, what states can it be in, and what moves it between them?"* The
+> [login diagram](auth-login-flow.md) shows the *sequence* of a single login; this
+> shows the **state machine** that governs the session afterwards.
+
+There's a prose companion to this in
+[`session-lifecycle.md`](../../src/modules/auth/notes/flows/session-lifecycle.md)
+(the "why"); this is the picture (the "what"). Where the two disagree on numbers,
+**trust the picture** — it was read straight from the constants (see the note at
+the bottom).
+
+## The states
+
+```mermaid
+stateDiagram-v2
+    [*] --> Anonymous
+
+    Anonymous --> Active: login / signup / demo
+    Anonymous --> Anonymous: visit a public route
+
+    Active --> Active: protected request (re-validate token)
+    Active --> ApproachingExpiry: under 2 min left
+    ApproachingExpiry --> Active: rotate (issueRotated)
+
+    Active --> Expired: clock reaches exp
+    ApproachingExpiry --> Expired: clock reaches exp
+    Expired --> Anonymous: next request rejected, to login
+
+    Active --> Terminated: logout
+    ApproachingExpiry --> Terminated: logout
+
+    Terminated --> [*]
+    Expired --> [*]
+```
+
+## What each transition really does
+
+| From → To | Trigger | What happens in code |
+|---|---|---|
+| Anonymous → Active | login / signup / demo | `issue()` mints a JWT (`sid`, `jti`, `iat`, `exp = iat + 15 min`, `nbf`), signs it (jose / HS256), sets an httpOnly cookie |
+| Active → Active | a protected request | cookie decoded + verified, claims validated — no new token issued |
+| Active → ApproachingExpiry | ≤ 2 min remaining | `isSessionApproachingExpiry()` against the refresh threshold |
+| ApproachingExpiry → Active | rotate | `issueRotated()` keeps the same `sid`, issues a fresh `jti`/`iat`/`exp` — a sliding extension |
+| → Expired | wall clock passes `exp` | nothing runs *at* expiry; it's caught on the **next** decode |
+| Active → Terminated | logout | `terminate("logout")` deletes the cookie (`maxAge` 0) |
+
+## The validation gauntlet (the Active → Active self-loop)
+
+Every protected request re-checks the token in two stages — and they fail for
+different reasons, which is deliberate:
+
+```mermaid
+flowchart TD
+    cookie["cookie → token"] --> decode{"decode<br/>(jose verify)"}
+    decode -->|"bad signature / expired / not-yet-valid"| reject1["✗ reject → redirect to login"]
+    decode -->|ok| validate{"validate<br/>(Zod schema)"}
+    validate -->|"wrong shape"| reject2["✗ invalid_schema"]
+    validate -->|ok| semantics{"semantic checks"}
+    semantics -->|"iat in future · nbf in future<br/>exp ≤ iat · nbf &gt; exp · nbf &gt; iat"| reject3["✗ invalid_semantics"]
+    semantics -->|ok| accept["✓ trusted claims"]
+```
+
+The split matters: **jose** owns cryptographic truth (signature) and time
+(`exp`/`nbf`, with a ±5 s clock tolerance), so an *expired* token is rejected at
+the `decode` step. **`validate()`** then owns structural and logical truth — the
+right fields, and cross-field sanity like "expiry must be after issuance." A
+schema failure and an expiry failure are never confused for one another.
+
+## The numbers that govern it
+
+From [`session-config.constants.ts`](../../src/modules/auth/domain/shared/constants/session-config.constants.ts)
+and [`session-token.constants.ts`](../../src/modules/auth/infrastructure/session/config/session-token.constants.ts):
+
+| Knob | Value | Meaning |
+|---|---|---|
+| `SESSION_DURATION_SEC` | **900 s — 15 minutes** | how long a freshly issued token lives |
+| `SESSION_REFRESH_THRESHOLD_SEC` | **120 s — 2 minutes** | "approaching expiry" window where rotation kicks in |
+| `MAX_ABSOLUTE_SESSION_SEC` | **2,592,000 s — 30 days** | hard ceiling on age via `iat`, even with rotation |
+| `SESSION_TOKEN_CLOCK_TOLERANCE_SEC` | **5 s** | slack for clock skew between machines |
+
+So a session slides forward in 15-minute leases, renewed as long as you stay
+active, but can never outlive its original issuance by more than 30 days.
+
+## Why it's stateless (and what that costs)
+
+There is **no sessions table**. The JWT *is* the session — everything needed to
+trust a request rides in the signed cookie. That's why the
+[ERD](database-erd.md) has no session entity, and why the
+[route gate](route-authorization.md) can authorize on the edge with no DB hit.
+
+The honest trade-off: because state lives in the token, you can't revoke a single
+session server-side without extra machinery (a denylist or a key rotation). Logout
+deletes *this* browser's cookie; it doesn't reach out and kill a token copied
+elsewhere. That's the classic stateless-JWT bargain — speed and simplicity now, in
+exchange for weaker instant-revocation. See
+[ADR-005](../../src/modules/auth/notes/adr/005-use-jwt-for-session-tokens.md).
+
+---
+
+> **Drift caught while drawing this.** The prose companion still says sessions last
+> *7 days*; the code says **15 minutes**. Numbers in docs rot — these were taken
+> from the constants on 2026-06-04. If you change a constant, change this table.


### PR DESCRIPTION
## What

Extends the architecture diagram set in [`docs/diagrams/`](docs/diagrams) from five diagrams to nine. Follow-up to the original set (#20): a session reviewing the codebase identified the next-highest-value things to draw. Each new diagram answers exactly one question and was verified against the current code, not the prose docs.

| New diagram | The question it answers | Type |
|---|---|---|
| `error-handling-flow.md` | How does a failure travel from the database to a red field error — without a `throw`? | Sequence + type map |
| `route-authorization.md` | Before a page renders, what decides whether I'm allowed in? | Sequence + decision |
| `session-lifecycle.md` | What states can a session be in, and what moves it between them? | State machine |
| `dependency-injection.md` | How do application contracts and infrastructure implementations actually get connected? | Component graph |

Plus two small edits:
- `README.md` — index now lists all nine diagrams, with updated provenance.
- `c4-architecture.md` — the "Middleware" box now points at the real `proxy.ts` (Next 16 renamed `middleware.ts` → `proxy.ts`).

## Why

The three subsystems most often asked about — **results, errors, forms** — turned out to be one spine, not three: `FormResult<T>` is literally `Result<FormSuccessPayload<T>, AppError>`. The error-handling diagram makes that explicit so every module reads the same way. The other three cover the request-authorization gate, the session state machine, and the DI/composition pattern that the existing `module-layers.md` only hinted at.

## Reviewer notes

- **Best viewed in GitHub's Mermaid preview** (renders inline in the file view).
- **Accuracy**: examples are pulled from real code — e.g. Postgres `23505` → `AppError(conflict)`, the route decision matrix, and the real session constants (`SESSION_DURATION_SEC = 900`, i.e. 15 min).
- **Drift caught**: the prose doc `src/modules/auth/notes/flows/session-lifecycle.md` still claims **7-day** sessions; the code is **15 minutes**. These diagrams use the correct values; reconciling the prose doc is tracked as a separate task (not in this PR, to keep it diagrams-only).
- **Portability**: Mermaid node labels contain no raw `<`/`>`; state-transition labels are single-line (older renderers print `<br/>` literally in state diagrams); all relative links verified to resolve.
- Docs-only change — no code, no tests affected.
