### PR TITLE
docs: document feature modules and fix docs index coverage claim

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,11 @@ rules and the setup; the diagrams in [diagrams/](diagrams/) show the shapes. If
 you're new, start with [getting-started.md](getting-started.md) and work down.
 
 Each entry says *what question it answers*, so you can scan for the one you have.
-Module-level detail lives next to the code — every folder under `src/modules/**`
-and `src/shared/**` has its own `README.md`. This folder is for the cross-cutting,
-project-wide docs.
+Some of the code is documented in place, too: many folders under `src/modules/**`
+and `src/shared/**` carry a local `README.md` — most thoroughly the `auth` module,
+which documents each of its layers; the other feature modules — `invoices`,
+`users`, `customers`, and `banner` — each have a module-level overview. This
+folder is for the cross-cutting, project-wide docs.
 
 ## Getting started & local setup
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,6 +44,10 @@ Config: [`cypress.config.ts`](../cypress.config.ts) · specs: `cypress/e2e/**/*.
 support: `cypress/support/e2e.ts`. Cypress v15, wired up with
 `@testing-library/cypress` and `cypress-axe`.
 
+**What to cover** — [`checklist.md`](../cypress/e2e/checklist.md) is a practical
+guide to the E2E paths worth having as the suite grows: smoke + auth, CRUD,
+resilience, accessibility, and Cypress hygiene.
+
 **The easy way — one command (boots the server for you):**
 
 ```sh

--- a/src/modules/banner/README.md
+++ b/src/modules/banner/README.md
@@ -1,0 +1,81 @@
+# Banner Module
+
+A small, self-contained feature: a **one-time dismissible banner**. Once a user
+dismisses it, it stays dismissed — the choice is stored in a cookie (180 days)
+so it survives reloads and sessions.
+
+Unlike the other feature modules, banner is **not a data module**: it has no
+database table, no domain entity, and no `Result`/DTO machinery. Its "domain" is
+just the cookie's name and lifetime; everything else is a thin cookie adapter and
+a React component.
+
+---
+
+## Directory structure
+
+```
+banner/
+├── domain/banner.constants.ts           # BANNER_DISMISSED_COOKIE ("banner_dismissed_v1"), max-age (180d)
+├── infrastructure/
+│   ├── banner-cookie.adapter.ts         # BannerCookieAdapter — dismiss / isDismissed / clear (over the shared cookie service)
+│   └── banner-cookie.ts                 # functional facade: isBannerDismissed(), dismissBanner()
+└── presentation/
+    ├── one-time-banner.tsx              # <OneTimeBanner> client component (renders + Dismiss button)
+    └── actions/dismiss-banner.action.ts # dismissBannerAction() — sets the cookie, revalidates "/"
+```
+
+---
+
+## How it works
+
+```
+Server render ─▶ isBannerDismissed()  → false ⇒ render <OneTimeBanner/>
+                                       → true  ⇒ render nothing
+
+User clicks Dismiss ─▶ dismissBannerAction()  ─▶ dismissBanner() sets cookie ─▶ revalidatePath("/")
+```
+
+- **Gating is the caller's job.** `<OneTimeBanner>` always renders when mounted;
+  the server code that includes it should check `isBannerDismissed()` first and
+  skip mounting it when the cookie is set. The component owns only the dismiss
+  interaction (optimistic `useState` + `useTransition`).
+- **The adapter** (`BannerCookieAdapter`) wraps the shared cookie service
+  (`@/server/cookies`) and centralizes the cookie options; `banner-cookie.ts` is a
+  two-function facade so callers don't construct the adapter themselves.
+
+---
+
+## Key concepts
+
+### Versioned cookie = a re-show switch
+
+The cookie name carries a version suffix (`banner_dismissed_v1`). To show a *new*
+banner to everyone who already dismissed the old one, **bump the suffix** (e.g.
+`_v2`) — old cookies no longer match, so the banner reappears. The banner copy
+notes this too.
+
+### Cookie options (deliberate)
+
+Set in `banner-cookie.adapter.ts`:
+
+| Option | Value | Why |
+|---|---|---|
+| `httpOnly` | `false` | This is a non-secret UI flag; client JS may read it. |
+| `sameSite` | `lax` | Standard for a first-party preference cookie. |
+| `secure` | `isProd()` | HTTPS-only in production, relaxed in local dev. |
+| `maxAge` | `15_552_000` (180 days) | How long a dismissal sticks. |
+| `path` | `/` | Applies site-wide. |
+
+`httpOnly: false` is intentional here — keep it that way only for non-sensitive
+flags like this one.
+
+---
+
+## Related documentation
+
+- [project-structure.md](../../../docs/project-structure.md) — where code belongs across the repo.
+- Cookie service: `@/server/cookies` (the shared adapter this module builds on).
+
+---
+
+**Last updated:** 2026-06-04

--- a/src/modules/customers/README.md
+++ b/src/modules/customers/README.md
@@ -1,0 +1,145 @@
+# Customers Module
+
+The customers module is **read-only**. It supplies customer data to the rest of
+the dashboard — it never creates, updates, or deletes customers (those are
+seeded). Concretely, it powers three things:
+
+- the **customers table** (`/dashboard/customers`), with per-customer invoice
+  aggregates (total invoices, total paid, total pending);
+- the **customer-select dropdown** used by the invoice create/edit forms; and
+- the **total customer count**.
+
+It is also the **owner of `CustomerId`** — the branded type the `invoices` module
+imports for its `customerId` field.
+
+Because it only reads, it is the lightest data module: **no application/service
+layer and no writes**, just `domain → infrastructure → presentation`.
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#overview)
+- [Directory structure](#directory-structure)
+- [Key concepts](#key-concepts)
+- [Request flow](#request-flow)
+- [Error handling](#error-handling)
+- [Related documentation](#related-documentation)
+
+---
+
+## Overview
+
+The defining feature is a **three-tier data shaping** pipeline — each tier is a
+distinct type, and each hop has a clear owner:
+
+```
+Raw DB rows ──(repository)──▶ Server DTOs ──(action)──▶ Formatted UI rows
+CustomerAggregatesRowRaw      CustomerAggregatesServerDto   FormattedCustomersTableRow
+  totals: number | null         branded id, totals: number    totals: string (currency)
+```
+
+- **Raw** (`*RowRaw`) mirrors the exact DB projection; SUM() totals can be `null`.
+- **Server DTO** (`*ServerDto`) brands the `id` and normalizes nullable sums to `0`.
+- **Formatted row** (`FormattedCustomersTableRow`, `CustomerField`) is the
+  feature/UI shape — currency is formatted to a string here, at the action boundary.
+
+---
+
+## Directory structure
+
+```
+customers/
+├── domain/                              # Types, branded id, labels, messages
+│   ├── types.ts                         #   Raw / ServerDto / Formatted row types (+ CustomerField)
+│   ├── types/customer-id.brand.ts       #   CustomerId branded type (owned here; used by invoices)
+│   ├── customer-id.factory.ts           #   build a CustomerId
+│   ├── customer-id.mappers.ts           #   toCustomerId(raw) → CustomerId
+│   ├── mappers.ts                       #   toFormattedCustomersTableRow (server DTO → UI row)
+│   ├── constants.ts                     #   CUSTOMER_LABELS, CUSTOMER_TABLE_HEADERS
+│   └── messages.ts                      #   CUSTOMER_SERVER_ERROR_MESSAGES
+│
+├── infrastructure/                      # Database access + raw→DTO mapping
+│   ├── repository/customer.repository.ts      #   CustomersRepository + createCustomersRepository(db)
+│   ├── repository/dal/                  #   fetch-filtered-customers, fetch-customers-select, fetch-total-count
+│   └── adapters/customer.mapper.ts      #   raw row → server DTO (brand id, normalize sums)
+│
+└── presentation/                        # Next.js server actions + React UI
+    ├── actions/                         #   read-filtered-customers, read-customers, read-total-customers-count
+    └── components/                      #   customers-table (+ desktop / mobile / row variants)
+```
+
+There is intentionally no `application/` layer — without writes or business rules
+there is nothing for a service to orchestrate, so actions talk to the repository
+directly.
+
+---
+
+## Key concepts
+
+### Read-only by design
+
+The DAL exposes only `fetch*` queries; the repository exposes only `fetchSelect`,
+`fetchFiltered`, and `fetchTotalCount`. There is no create/update/delete path.
+
+### Aggregates join the invoices table
+
+`fetchFilteredCustomersDal` left-joins `invoices` to compute, per customer:
+`totalInvoices` (a `COUNT`), `totalPaid`, and `totalPending` (filtered `SUM`s by
+invoice status). This is the module's one cross-table dependency — it reads the
+`invoices` table but not the invoices *module*.
+
+### Composition
+
+`createCustomersRepository(db)` is a small factory; the repository takes an
+`AppDatabase` and delegates to the DAL functions, mapping each raw row to a server
+DTO with `customer.mapper.ts`.
+
+### Owns `CustomerId`
+
+`CustomerId` is a `Brand<string, …>` defined here. The `invoices` module imports
+it for `InvoiceEntity.customerId`, so this module is the source of truth for that
+identity.
+
+---
+
+## Request flow
+
+All three actions follow the same read-only shape — for example the table:
+
+1. `readFilteredCustomersAction(query)` opens a db handle and builds the repo with
+   `createCustomersRepository(getAppDb())`.
+2. `repo.fetchFiltered(query)` runs the DAL query and maps each raw row to a
+   `CustomerAggregatesServerDto` (branded id, normalized totals).
+3. The action maps those to `FormattedCustomersTableRow[]` with
+   `toFormattedCustomersTableRow` — formatting currency at the boundary.
+
+`readCustomersAction` (select options → `CustomerField[]`) and
+`readTotalCustomersCountAction` (a `number`) are the same pattern, shorter.
+
+---
+
+## Error handling
+
+The DAL **throws** `makeAppError(APP_ERROR_KEYS.database, …)` on a query failure
+(using `CUSTOMER_SERVER_ERROR_MESSAGES`); the error propagates up to the action /
+page. This is the same throw-based model as the `invoices` DAL — note it differs
+from `users`, which returns `Result` end-to-end. See
+[when-to-use-app-error.md](../../../docs/when-to-use-app-error.md).
+
+> No automated tests yet. The mappers (`mapCustomerAggregatesRawToDto`'s null→0
+> normalization) and the filtered-aggregate query are the highest-value things to
+> cover first.
+
+---
+
+## Related documentation
+
+- [Database ERD](../../../docs/diagrams/database-erd.md) — the `customers` table and its relation to `invoices`.
+- [Module layering](../../../docs/diagrams/module-layers.md) — which layer may import which.
+- [project-structure.md](../../../docs/project-structure.md) — where code belongs across the repo.
+- Sibling module: [`invoices`](../invoices/README.md) — consumes `CustomerId` and shares the aggregate data.
+
+---
+
+**Last updated:** 2026-06-04

--- a/src/modules/invoices/README.md
+++ b/src/modules/invoices/README.md
@@ -1,0 +1,249 @@
+# Invoices Module
+
+The invoices module owns everything about invoices — the dashboard's central
+billing record. It covers the full lifecycle (create, edit, delete), the
+searchable, paginated invoices table, and the aggregate figures on the dashboard
+overview (totals, latest invoices).
+
+It follows the same clean-architecture layering as the rest of `src/modules/**`
+(`domain → application → infrastructure → presentation`), but with a **lighter
+application layer than `auth`**: a single `InvoiceService` rather than the
+CQRS use-cases/workflows split. Where it diverges from the auth module, this
+README says so explicitly.
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#overview)
+- [Architecture at a glance](#architecture-at-a-glance)
+- [Directory structure](#directory-structure)
+- [Key concepts](#key-concepts)
+- [Layer responsibilities](#layer-responsibilities)
+- [Request flows](#request-flows)
+- [Error handling](#error-handling)
+- [Conventions & known rough edges](#conventions--known-rough-edges)
+- [Related documentation](#related-documentation)
+
+---
+
+## Overview
+
+An invoice is the most data-heavy entity in the app, and the module reflects
+that: a small write surface (CRUD) sits alongside a comparatively large **read**
+surface that feeds the dashboard. The domain entity is:
+
+```typescript
+interface InvoiceEntity {
+  readonly amount: number;          // integer cents (never dollars)
+  readonly customerId: CustomerId;  // branded; references the customers module
+  readonly date: Date;
+  readonly id: InvoiceId;           // branded
+  readonly revenuePeriod: Period;   // branded; derived from `date` (first-of-month)
+  readonly sensitiveData: string;
+  readonly status: InvoiceStatus;   // "pending" | "paid"
+}
+```
+
+---
+
+## Architecture at a glance
+
+There are **two distinct paths** through the module:
+
+```
+Command path (single record):
+  Server Action ─▶ InvoiceService ─▶ InvoiceRepository ─▶ DAL ─▶ Postgres
+  (create / read-by-id / update / delete)
+
+Read path (lists & aggregates):
+  Server Action ─▶ DAL ─▶ Postgres
+  (filtered list, page count, latest, totals/summary — bypasses the service)
+```
+
+How invoices differs from the `auth` module — worth knowing up front:
+
+| Concern | `auth` | `invoices` |
+|---|---|---|
+| Application layer | CQRS: commands / queries / workflows | One `InvoiceService` class with CRUD methods |
+| Composition | DI composition root + factories | Actions build `new InvoiceService(new InvoiceRepository(getAppDb()))` inline |
+| Repo error style | Returns `Result<T, AppError>` | **Throws** `AppError`; caught in the action's `try/catch` |
+| Reads | Through use-cases | List/aggregate reads call DAL **directly** from the action |
+
+Neither approach is "wrong" — invoices is simpler than auth and is wired more
+directly. The table is here so the difference doesn't read as an inconsistency.
+
+---
+
+## Directory structure
+
+```
+invoices/
+├── domain/                              # Framework-agnostic core: types, rules, i18n
+│   ├── entities/invoice.entity.ts       #   InvoiceEntity + Service/Form/Partial variants
+│   ├── statuses/invoice.statuses.ts     #   INVOICE_STATUSES = ["pending", "paid"]
+│   ├── schema/invoice.schema.ts         #   Zod CreateInvoiceSchema + field-name lists
+│   ├── types/invoice-id.brand.ts        #   InvoiceId branded type
+│   ├── i18n/                            #   invoice-messages.ts, en-invoices.ts, translator.ts
+│   ├── invoice-id.factory.ts            #   build / validate an InvoiceId
+│   ├── invoice-id.mappers.ts            #   toInvoiceId(string) → InvoiceId
+│   ├── invoice-status.validator.ts      #   status guard
+│   ├── invoice.codecs.ts               #   domain-level codecs
+│   ├── invoice.constants.ts             #   ITEMS_PER_PAGE_INVOICES (10), date regexes
+│   ├── invoice.date-utils.ts            #   date helpers
+│   └── invoice.types.ts                 #   InvoiceListFilter (invoice joined with customer)
+│
+├── application/                         # Orchestration / business rules
+│   ├── dto/invoice.dto.ts               #   InvoiceDto, InvoiceFormDto, InvoicesSummary
+│   ├── services/invoice.service.ts      #   InvoiceService — CRUD, returns Result<…, AppError>
+│   └── utils/error-messages.ts          #   toInvoiceErrorMessage()
+│
+├── infrastructure/                      # Database + data transformation
+│   ├── adapters/
+│   │   ├── codecs/invoice-codecs.ts     #   DTO ⇄ entity codecs (entityToInvoiceDto, …)
+│   │   └── mappers/invoice.mapper.ts    #   form → service entity (derives revenuePeriod)
+│   └── repository/
+│       ├── base-repository.ts           #   abstract BaseRepository<TDto, TId, TCreate, TUpdate>
+│       ├── invoice.repository.ts        #   InvoiceRepository — CRUD; throws AppError
+│       └── dal/                         #   one function per query (4 CRUD + 6 dashboard reads)
+│
+└── presentation/                        # Next.js server actions + React UI
+    ├── actions/                         #   9 server actions (commands + reads)
+    ├── components/                      #   tables (desktop/mobile/status), latest, skeletons, links
+    ├── forms/                           #   create/edit forms + field inputs
+    └── constants/invoice-form.constants.ts
+```
+
+---
+
+## Key concepts
+
+### Money is stored in cents
+
+The UI works in dollars; the system stores **integer cents**. `InvoiceService`
+converts on the way in (`dollarsToCents`, using `CENTS_IN_DOLLAR` from
+`@/shared/primitives/money`). `InvoiceDto.amount` is always integer cents — format
+to dollars only at the very edge (UI).
+
+### Dates and the revenue period
+
+- `date` is a `Date` in the entity and an ISO `YYYY-MM-DD` string in the DTO.
+- `revenuePeriod` is a branded `Period`, **derived from `date`** (the first day of
+  its month, transported as `YYYY-MM-01`). It is *not* a form field — the mapper
+  computes it server-side, which is why `InvoiceFormEntity` / `InvoiceFormDto`
+  omit it.
+
+### Branded IDs
+
+`InvoiceId` (and the cross-module `CustomerId`) are branded types — a raw `string`
+won't type-check where an ID is expected. Convert at the boundary with
+`toInvoiceId()`.
+
+### The entity / DTO family
+
+| Type | Shape | Used for |
+|---|---|---|
+| `InvoiceEntity` | full record | the domain truth (includes `id`, `revenuePeriod`) |
+| `InvoiceServiceEntity` | `Omit<…, "id">` | service layer before the DB assigns an id |
+| `InvoiceFormEntity` | `Omit<…, "id" \| "revenuePeriod">` | a form submission |
+| `InvoiceFormPartialEntity` | `Partial<InvoiceFormEntity>` | partial updates |
+| `InvoiceDto` | plain, serializable | transport to UI/API (amount in cents) |
+| `InvoiceFormDto` | `Omit<InvoiceDto, "id" \| "revenuePeriod">` | form input DTO |
+| `InvoicesSummary` | `{ totalInvoices, totalPaid, totalPending }` | the overview cards |
+| `InvoiceListFilter` | invoice + joined customer fields | the invoices table rows |
+
+### Validation, forms, and i18n
+
+- Input is validated with a Zod schema (`CreateInvoiceSchema` +
+  `CREATE_INVOICE_FIELDS_LIST`) in `domain/schema/invoice.schema.ts`.
+- Actions return a `FormResult` (`makeFormOk` / `makeFormError` from
+  `@/shared/forms`), with Zod issues mapped to per-field errors.
+- User-facing strings come from `INVOICE_MSG` and are rendered through
+  `translator()` (`domain/i18n/`); domain/infra errors are mapped to a message via
+  `toInvoiceErrorMessage()`.
+
+---
+
+## Layer responsibilities
+
+- **domain/** — what an invoice *is* and what's always true of it: entity + its
+  variants, the `pending|paid` status, branded `InvoiceId`, the Zod schema, date
+  utilities, and the i18n message catalog. No Next.js, no Drizzle.
+- **application/** — `InvoiceService` applies business rules (dollars→cents, date
+  validation) and orchestrates codecs/mappers and the repository. Returns
+  `Result<InvoiceDto, AppError>`.
+- **infrastructure/** — `InvoiceRepository` (CRUD) over `BaseRepository`, the
+  per-query DAL functions, and the codecs/mappers that translate between DTOs,
+  entities, and database rows. This is the only layer that touches the DB.
+- **presentation/** — `"use server"` actions that adapt `FormData` ⇄ DTOs and call
+  the service or DAL, plus the React table/form/skeleton components.
+
+---
+
+## Request flows
+
+### Create / update / delete (command path)
+
+1. The action parses `FormData` and validates it with the Zod schema.
+2. It constructs `new InvoiceService(new InvoiceRepository(getAppDb()))`.
+3. `InvoiceService` applies business rules (dollars→cents, date format), runs the
+   codec/mapper chain, and calls the repository.
+4. `InvoiceRepository` calls the matching DAL function and maps the row back to an
+   `InvoiceDto`.
+5. The action `revalidatePath(ROUTES.dashboard.invoices)` and returns a
+   `FormResult`.
+
+### Lists & aggregates (read path)
+
+`readInvoicesSummaryAction`, `readFilteredInvoicesAction`,
+`readInvoicesPagesAction`, and `readLatestInvoicesAction` skip the service: they
+take (or open) a `db` handle and call their DAL function directly, returning a
+plain shape (`InvoicesSummary`, `InvoiceListFilter[]`, …). Page size is
+`ITEMS_PER_PAGE_INVOICES` (10).
+
+---
+
+## Error handling
+
+This module uses two styles, and you'll see both in a single action:
+
+- **The service returns `Result`** — its own validation failures come back as
+  `Err(AppError)` and are turned into field-level `FormResult` errors.
+- **The repository and DAL throw `AppError`** — those propagate up as exceptions
+  and are caught by the action's `try/catch`, then mapped with
+  `toInvoiceErrorMessage()` and logged.
+
+For when something should be an `AppError` versus a domain outcome, see
+[when-to-use-app-error.md](../../../docs/when-to-use-app-error.md) and the
+[error-handling flow diagram](../../../docs/diagrams/error-handling-flow.md).
+
+---
+
+## Conventions & known rough edges
+
+Kept honest on purpose — a doc that hides the warts isn't worth much.
+
+- **No automated tests yet.** Unlike `auth` and `users`, this module has no
+  `__tests__/`. The service's business rules (cents conversion, date validation,
+  partial-update assembly) and the DAL queries are the highest-value things to
+  cover first.
+- **Composition is inline.** Actions `new` up the service and repository directly
+  rather than resolving them from a composition root (as `auth` does). Fine while
+  the graph is small; revisit if wiring grows.
+- **`sensitiveData` crosses the boundary.** The field flows through to `InvoiceDto`
+  and `InvoiceListFilter` unredacted — the opposite of how `auth` strips passwords
+  at the domain→application boundary. If it ever holds anything truly sensitive,
+  that boundary needs the same treatment.
+
+---
+
+## Related documentation
+
+- [Module layering](../../../docs/diagrams/module-layers.md) — which layer may import which.
+- [Database ERD](../../../docs/diagrams/database-erd.md) — the `invoices` table and its relations.
+- [Dependency injection](../../../docs/diagrams/dependency-injection.md) — the DI pattern the rest of the app uses.
+- [project-structure.md](../../../docs/project-structure.md) — where code belongs across the repo.
+
+---
+
+**Last updated:** 2026-06-04

--- a/src/modules/users/README.md
+++ b/src/modules/users/README.md
@@ -1,0 +1,281 @@
+# Users Module
+
+The users module is the **admin-facing CRUD for user accounts** — the
+`/dashboard/users` screens where an administrator lists, searches, creates,
+edits, and deletes users and sets their role.
+
+It is **distinct from the `auth` module**: `auth` answers *"who is signing in,
+and is their session valid?"* (login, signup, sessions); `users` answers
+*"manage the people who have accounts."* The two operate on the same user
+records and share the role, password-hashing, and validation primitives, but
+cover different concerns.
+
+Of the three service-based feature modules, this is the **most structured**: it
+uses dependency inversion (a repository contract + adapter), factory-based
+composition, `Result` end-to-end, transaction support, and it has real tests.
+Where it differs from its siblings, this README says so.
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#overview)
+- [Architecture at a glance](#architecture-at-a-glance)
+- [Directory structure](#directory-structure)
+- [Key concepts](#key-concepts)
+- [Layer responsibilities](#layer-responsibilities)
+- [Request flows](#request-flows)
+- [Error handling](#error-handling)
+- [Testing](#testing)
+- [Related documentation](#related-documentation)
+
+---
+
+## Overview
+
+The domain entity carries the full record, including sensitive fields:
+
+```typescript
+interface UserEntity {
+  readonly email: string;
+  readonly id: UserId;          // branded
+  readonly password: Hash;      // branded; already hashed
+  readonly role: UserRole;      // from the shared user-role policy
+  readonly sensitiveData: string;
+  readonly username: string;
+}
+```
+
+The transport DTO **deliberately drops the sensitive fields** — `toUserDto`
+returns only `{ id, email, role, username }`. Password hashes and
+`sensitiveData` never cross into the UI/API, the same discipline the `auth`
+module applies to passwords (and the opposite of the current `invoices`
+behaviour — see its [rough edges](../invoices/README.md#conventions--known-rough-edges)).
+
+---
+
+## Architecture at a glance
+
+Everything — reads *and* writes — flows through the service:
+
+```
+Server Action ─▶ createUserService(db)  [factory]
+                      │
+                      ▼
+                 UserService ─▶ UserRepositoryContract  [port, defined in application/]
+                      │              ▲
+                      │              │ implements
+                      │       UserRepositoryAdapter ─▶ UserRepositoryImpl ─▶ DAL ─▶ Postgres
+                      ▼
+                 toUserDto (strips password / sensitiveData)
+```
+
+The repository is wired as **ports and adapters**:
+
+- `UserRepositoryContract` (in `application/`) is the **port** — the interface the
+  service depends on.
+- `UserRepositoryImpl` (in `infrastructure/`) is the concrete repo that calls the
+  per-query DAL functions.
+- `UserRepositoryAdapter` binds the impl to the contract, so the application layer
+  never imports the concrete class — only the interface.
+
+### How it compares to the sibling modules
+
+| Concern | `auth` | `users` | `invoices` |
+|---|---|---|---|
+| Application style | CQRS use-cases + workflows | single `UserService` | single `InvoiceService` |
+| Dependency inversion | yes (contracts) | **yes (contract + adapter)** | no (service holds the concrete repo) |
+| Composition | DI composition root | **factory function** | inline in each action |
+| Error model | `Result` end-to-end | **`Result` end-to-end** | service `Result`; repo/DAL throw |
+| Reads | via use-cases | **via the service** | list/aggregate reads bypass the service |
+| Tests | yes | **yes** (service / schema / action) | none yet |
+
+`users` sits between `invoices` (simplest) and `auth` (richest): cleaner than
+invoices, lighter than auth.
+
+---
+
+## Directory structure
+
+```
+users/
+├── domain/                              # Framework-agnostic core
+│   ├── entities/user.entity.ts          #   UserEntity, CreateUserProps, UpdateUserProps
+│   ├── schemas/user.schema.ts           #   Zod create/edit form schemas (built from shared policies)
+│   ├── types/user-id.brand.ts           #   UserId branded type
+│   ├── constants/user.constants.ts      #   ITEMS_PER_PAGE_USERS (10), error/success messages
+│   ├── user-id.factory.ts               #   build a UserId
+│   ├── user-id.mappers.ts               #   toUserId(string) → UserId
+│   └── user-id.schema.ts                #   UserId zod schema
+│
+├── application/                         # Orchestration + ports
+│   ├── contracts/user-repository.contract.ts  #   UserRepositoryContract (the port)
+│   ├── dtos/user.dto.ts                 #   UserDto (no password / sensitiveData)
+│   └── services/user.service.ts         #   UserService — CRUD, hashing, logging; returns Result
+│
+├── infrastructure/                      # Database + composition
+│   ├── factories/user-service.factory.ts      #   createUserService(db) — wires the graph
+│   ├── mappers/                         #   to-user-dto.mapper.ts, to-user-entity.mapper.ts
+│   └── repository/
+│       ├── user.repository.ts           #   UserRepositoryImpl (calls the DAL)
+│       ├── user-repository.adapter.ts   #   UserRepositoryAdapter (impl → contract)
+│       └── dal/                         #   one function per query (create/read/update/delete + list/count)
+│
+└── presentation/                        # Next.js server actions + React UI
+    ├── actions/                         #   7 server actions (create/update/delete + reads)
+    ├── components/                      #   users-table, user-info-panel, user-action-buttons, user-role-select
+    ├── forms/                           #   create / edit / delete-button
+    └── constants/user-form.constants.ts
+
+__tests__/                               # Vitest unit tests (service); see also the co-located schema/action tests
+```
+
+---
+
+## Key concepts
+
+### Relationship to the `auth` module
+
+Both touch "users," so the split matters:
+
+- **`auth`** — credential verification and sessions (login, signup, JWT session
+  lifecycle). See [`auth/application/README.md`](../auth/application/README.md).
+- **`users`** — administrative management of the accounts themselves.
+
+They share the same user records and the same shared primitives
+(`@/shared/policies/user-role`, `@/server/crypto/hashing`,
+`@/shared/policies/{email,password,username}`), but neither imports the other's
+use-cases.
+
+### Ports and adapters (dependency inversion)
+
+The service depends only on `UserRepositoryContract`, never on a concrete class.
+The factory supplies a `UserRepositoryAdapter` wrapping `UserRepositoryImpl`. This
+is why the unit test can hand the service a fully mocked repo. See the
+[dependency-injection diagram](../../../docs/diagrams/dependency-injection.md).
+
+### `Result` end-to-end + error normalization
+
+Every layer returns `Result<T, AppError>`. The service wraps each operation in
+`try/catch` and converts anything unexpected with `normalizeUnknownError(err,
+APP_ERROR_KEYS.*)`, so failures are always a typed `Err`, never a thrown
+exception escaping the service. Actions then turn `Result` into a `FormResult`
+(writes) or unwrap it to a plain value with `unwrapOrNull` (reads).
+
+### Password hashing & sensitive-data stripping
+
+- Passwords are hashed by the injected `HashingService` **before** they reach the
+  repository (on create, and on update only when a new password is supplied).
+- `toUserDto` is the boundary that removes `password` and `sensitiveData`. Keep new
+  sensitive fields out of `UserDto`.
+
+### Validation: shared policies, create vs edit
+
+Form schemas (`user.schema.ts`) are composed from the shared policy schemas
+(`EmailSchema`, `PasswordSchema`, `UsernameSchema`, `UserRoleFormSchema`) and use
+`strictObject` to reject unknown keys. The **edit** schema makes every field
+optional with a preprocessing step where an empty string means *"leave
+unchanged"* rather than *"set to empty."* Roles are parsed/validated via
+`toUserRole` from the shared user-role policy.
+
+### The entity / DTO family
+
+| Type | Shape | Used for |
+|---|---|---|
+| `UserEntity` | full record | the domain truth (includes `password`, `sensitiveData`) |
+| `CreateUserProps` | `{ email, password: Hash, role, username }` | repository create input (password pre-hashed) |
+| `UpdateUserProps` | all fields optional | repository partial update |
+| `UserDto` | `{ id, email, role, username }` | transport to UI/API (no secrets) |
+| `CreateUserData` / `EditUserData` | `z.output` of the form schemas | validated input into the service |
+
+### Transactions
+
+`UserRepositoryContract.withTransaction(fn)` runs `fn` against a transaction-scoped
+repository; the adapter re-wraps the tx repo so the callback still receives the
+contract type. Page size for listings is `ITEMS_PER_PAGE_USERS` (10).
+
+---
+
+## Layer responsibilities
+
+- **domain/** — what a user *is*: the entity and its create/update prop shapes, the
+  branded `UserId`, the Zod form schemas, and the message constants. No Next.js, no
+  Drizzle.
+- **application/** — the `UserRepositoryContract` port and the `UserService` that
+  orchestrates hashing, the repository, mapping, and logging. Returns
+  `Result<…, AppError>`.
+- **infrastructure/** — `UserRepositoryImpl` over the DAL, the `UserRepositoryAdapter`,
+  the DTO/entity mappers, and the `createUserService` factory. The only layer that
+  touches the DB.
+- **presentation/** — `"use server"` actions that validate `FormData`, call the
+  service through the factory, and adapt `Result` into `FormResult` / plain values,
+  plus the React table/form components.
+
+---
+
+## Request flows
+
+### Create / update / delete (command path)
+
+1. The action validates `FormData` against the Zod schema (`validateForm`).
+2. It builds the service with `createUserService(getAppDb())`.
+3. `UserService` hashes the password if present, calls the repository (through the
+   contract → adapter → impl → DAL), and maps the row with `toUserDto`.
+4. The action returns a `FormResult` (`makeFormOk` / `makeFormError`).
+
+### Reads (list / by-id / page count)
+
+Same path — the read actions also go through `createUserService(...)` and call
+`readFilteredUsers` / `readUserById` / `readUserPageCount`, then unwrap the
+`Result` to a plain shape at the action boundary (e.g. `unwrapOrNull(result) ?? []`).
+
+The **update** flow has a dedicated visual companion:
+[request-flow-update-user.md](../../../docs/diagrams/request-flow-update-user.md).
+
+---
+
+## Error handling
+
+- The service never throws: each method is wrapped in `try/catch`, and unexpected
+  errors are normalized to a typed `AppError` via `normalizeUnknownError` with an
+  `APP_ERROR_KEYS` code (`database`, `not_found`, `unexpected`, …).
+- Repository/DAL also return `Result`, so an `Err` propagates cleanly upward — no
+  mixed throw/return model (contrast `invoices`).
+- Actions map `Err` to a `FormResult` with the appropriate key and a user-facing
+  message from `USER_ERROR_MESSAGES`.
+
+For when something should be an `AppError`, see
+[when-to-use-app-error.md](../../../docs/when-to-use-app-error.md) and the
+[error-handling flow diagram](../../../docs/diagrams/error-handling-flow.md).
+
+---
+
+## Testing
+
+This module **has tests** (Vitest) — the most-covered of the feature modules:
+
+- `__tests__/unit/application/services/user.service.test.ts` — `UserService` with a
+  fully mocked `UserRepositoryContract`, `HashingService`, and logger; covers
+  `readUserById` (found / null / repo-error) and `createUser` (ok / repo-error).
+- `domain/schemas/__tests__/user.schema.test.ts` — form-schema validation.
+- `presentation/actions/__tests__/create-user.action.test.ts` — the create action.
+
+Run them with `pnpm test` (see [testing.md](../../../docs/testing.md)).
+
+**Coverage gaps worth filling:** `updateUser` / `deleteUser` / `readFilteredUsers`
+in the service, the DAL functions, and the update/delete actions are not yet unit-tested.
+
+---
+
+## Related documentation
+
+- [Update-user request flow](../../../docs/diagrams/request-flow-update-user.md) — the visual companion for this module.
+- [Dependency injection](../../../docs/diagrams/dependency-injection.md) — the port/adapter/factory pattern used here.
+- [Module layering](../../../docs/diagrams/module-layers.md) — which layer may import which.
+- [Database ERD](../../../docs/diagrams/database-erd.md) — the `users` table and its relations.
+- [project-structure.md](../../../docs/project-structure.md) — where code belongs across the repo.
+- Sibling modules: [`invoices`](../invoices/README.md) · [`auth`](../auth/application/README.md).
+
+---
+
+**Last updated:** 2026-06-04


### PR DESCRIPTION
## What

Adds a module-level `README.md` to every feature module that lacked one, and corrects an inaccurate claim in the docs index.

| Module | README | Highlights |
|---|---|---|
| `invoices` | new | single `InvoiceService`; mixed error model (service returns `Result`, repo/DAL throw); two request paths (command vs direct-DAL reads) |
| `users` | new | ports/adapters (repository contract + adapter); factory composition; `Result` end-to-end; has tests; strips `password`/`sensitiveData` at the DTO boundary |
| `customers` | new | read-only reference module; three-tier `raw → serverDTO → formatted` shaping; owns the `CustomerId` that `invoices` consumes |
| `banner` | new | cookie-backed one-time dismissible banner; no DB or domain entity |

Plus two docs fixes:
- **`docs/README.md`** — removed a false claim that *every* folder under `src/modules/**` / `src/shared/**` has its own `README.md`; reworded to reflect real coverage and list the now-documented modules.
- **`docs/testing.md`** — linked the previously orphaned `cypress/e2e/checklist.md`.

## Why

`auth` was thoroughly documented (per-layer READMEs + ADRs) while every other feature module had nothing. This evens out coverage so anyone browsing `src/modules/<x>/` gets the same orientation everywhere — and removes a docs-index claim that no longer matched reality.

## Notes for reviewers

- Each README was written **from the code**, and deliberately documents where modules **diverge** (service vs CQRS, `Result` vs throw, ports/adapters vs inline composition, read-only shaping) rather than implying uniformity. Honest "rough edges" are called out — e.g. `invoices` has no tests yet and currently passes `sensitiveData` through to DTOs, whereas `users` does both correctly.
- **Docs-only — no application code changed.** All cross-document links were verified to resolve.
- CI note: `pnpm check:fast` currently fails on a Biome formatting nit in the **gitignored, untracked** `.claude/settings.local.json`; Biome ignores Markdown, so the files in this PR are unaffected.
