### PR TITLE
test(shared): result + errors unit tests (Phase 3 breadth)

### DIFF
--- a/src/shared/core/errors/__tests__/unit/app-error-entity.utils.test.ts
+++ b/src/shared/core/errors/__tests__/unit/app-error-entity.utils.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	deepFreeze,
+	validateAndMaybeSanitizeMetadata,
+} from "@/shared/core/errors/utils/app-error-entity.utils";
+
+/**
+ * Unit tests for the AppError entity utilities (app-error-entity.utils.ts).
+ *
+ * deepFreeze enforces the "errors are immutable" guarantee recursively;
+ * validateAndMaybeSanitizeMetadata validates metadata against its registry
+ * schema, then deterministically sorts keys and redacts non-serializable values
+ * so the result is always safe to freeze and log.
+ */
+describe("deepFreeze", () => {
+	it.each([
+		42,
+		"x",
+		true,
+		null,
+		undefined,
+	])("returns primitive %p unchanged", (value) => {
+		expect(deepFreeze(value)).toBe(value);
+	});
+
+	it("deep-freezes nested objects and returns the same reference", () => {
+		const obj = { a: 1, nested: { b: 2 } };
+
+		const result = deepFreeze(obj);
+
+		expect(result).toBe(obj);
+		expect(Object.isFrozen(obj)).toBe(true);
+		expect(Object.isFrozen(obj.nested)).toBe(true);
+	});
+
+	it("returns an already-frozen object untouched", () => {
+		const frozen = Object.freeze({ a: 1 });
+
+		expect(deepFreeze(frozen)).toBe(frozen);
+	});
+
+	it("handles circular references without infinite recursion", () => {
+		const circular: Record<string, unknown> = { a: 1 };
+		circular.self = circular;
+
+		expect(() => deepFreeze(circular)).not.toThrow();
+		expect(Object.isFrozen(circular)).toBe(true);
+	});
+});
+
+describe("validateAndMaybeSanitizeMetadata", () => {
+	it("passes valid metadata through with keys sorted deterministically", () => {
+		// Built in non-alphabetical insertion order to prove the function re-sorts.
+		const input: Record<string, string> = {};
+		input.reason = "b";
+		input.policy = "a";
+
+		const out = validateAndMaybeSanitizeMetadata("unknown", input);
+
+		expect(Object.keys(out)).toEqual(["policy", "reason"]);
+		expect(out).toEqual({ policy: "a", reason: "b" });
+	});
+
+	it("redacts non-serializable values (bigint becomes a string)", () => {
+		const out = validateAndMaybeSanitizeMetadata("unknown", { count: 5n });
+
+		expect(out).toEqual({ count: "5" });
+	});
+
+	it("is resilient: logs and returns the sanitized original when validation fails", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+		// missing_fields uses the validation schema, where `field` must be a string.
+		const out = validateAndMaybeSanitizeMetadata("missing_fields", {
+			field: 123,
+		});
+
+		expect(out).toEqual({ field: 123 });
+		expect(spy).toHaveBeenCalledTimes(1);
+
+		spy.mockRestore();
+	});
+});

--- a/src/shared/core/errors/__tests__/unit/app-error.entity.test.ts
+++ b/src/shared/core/errors/__tests__/unit/app-error.entity.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+	_isAppErrorDto,
+	AppError,
+	isAppError,
+} from "@/shared/core/errors/core/app-error.entity";
+import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
+
+/**
+ * Unit tests for the AppError entity (app-error.entity.ts).
+ *
+ * AppError is the structured error class threaded through every Result/Err. It
+ * derives layer/severity/retryable from the registry, freezes itself and its
+ * metadata, and serializes via toDto/fromDto so errors survive the Server Action
+ * boundary. These tests pin that contract plus the two type guards.
+ */
+describe("AppError entity", () => {
+	const makeConflict = (): AppError =>
+		makeAppError("conflict", {
+			cause: "ctx",
+			message: "duplicate key",
+			metadata: { pgCode: "23505" },
+		});
+
+	describe("construction", () => {
+		it("derives definition fields from the registry", () => {
+			const error = makeConflict();
+
+			expect(error.key).toBe("conflict");
+			expect(error.layer).toBe("API");
+			expect(error.severity).toBe("WARN");
+			expect(error.retryable).toBe(false);
+			expect(error.definitionDescription).toBe("Resource state conflict");
+			expect(error.message).toBe("duplicate key");
+			expect(error.cause).toBe("ctx");
+		});
+
+		it("is an Error subclass named AppError", () => {
+			const error = makeConflict();
+
+			expect(error).toBeInstanceOf(Error);
+			expect(error.name).toBe("AppError");
+		});
+
+		it("freezes the instance and its metadata", () => {
+			const error = makeConflict();
+
+			expect(Object.isFrozen(error)).toBe(true);
+			expect(Object.isFrozen(error.metadata)).toBe(true);
+		});
+	});
+
+	describe("serialization", () => {
+		it("toDto returns a flat, transport-safe shape", () => {
+			expect(makeConflict().toDto()).toEqual({
+				_isAppError: true,
+				description: "Resource state conflict",
+				key: "conflict",
+				layer: "API",
+				message: "duplicate key",
+				metadata: { pgCode: "23505" },
+				retryable: false,
+				severity: "WARN",
+			});
+		});
+
+		it("fromDto rehydrates an equivalent AppError (round-trip)", () => {
+			const original = makeConflict();
+
+			const hydrated = AppError.fromDto(original.toDto());
+
+			expect(hydrated).toBeInstanceOf(AppError);
+			expect(hydrated.key).toBe(original.key);
+			expect(hydrated.message).toBe(original.message);
+			expect(hydrated.metadata).toEqual(original.metadata);
+			expect(hydrated.cause).toBe("hydrated");
+		});
+	});
+
+	describe("isAppError", () => {
+		it("is true only for AppError instances", () => {
+			expect(isAppError(makeConflict())).toBe(true);
+		});
+
+		it.each([
+			new Error("x"),
+			{ key: "conflict" },
+			null,
+			"conflict",
+			42,
+		])("is false for non-AppError value %p", (value) => {
+			expect(isAppError(value)).toBe(false);
+		});
+	});
+
+	describe("_isAppErrorDto", () => {
+		it("accepts a real DTO and the minimal valid shape", () => {
+			expect(_isAppErrorDto(makeConflict().toDto())).toBe(true);
+			expect(
+				_isAppErrorDto({ _isAppError: true, key: "conflict", message: "m" }),
+			).toBe(true);
+		});
+
+		it.each([
+			{ key: "conflict", message: "m" }, // missing _isAppError flag
+			{ _isAppError: true, message: "m" }, // missing key
+			{ _isAppError: true, key: "conflict" }, // missing message
+			null,
+			"x",
+		])("rejects invalid DTO shape %p", (value) => {
+			expect(_isAppErrorDto(value)).toBe(false);
+		});
+	});
+});

--- a/src/shared/core/errors/__tests__/unit/app-error.factory.test.ts
+++ b/src/shared/core/errors/__tests__/unit/app-error.factory.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { isAppError } from "@/shared/core/errors/core/app-error.entity";
+import {
+	makeAppError,
+	makeUnexpectedError,
+	normalizeUnknownError,
+} from "@/shared/core/errors/core/factories/app-error.factory";
+
+/**
+ * Unit tests for the AppError factories (app-error.factory.ts).
+ *
+ * These are the supported construction paths: makeAppError (the primary one),
+ * normalizeUnknownError (catch-block normalization that preserves an existing
+ * AppError), and makeUnexpectedError (bug wrapper).
+ */
+describe("AppError factories", () => {
+	describe("makeAppError", () => {
+		it("builds an AppError for the given key with registry-derived fields", () => {
+			const error = makeAppError("not_found", {
+				cause: "ctx",
+				message: "missing",
+				metadata: {},
+			});
+
+			expect(isAppError(error)).toBe(true);
+			expect(error.key).toBe("not_found");
+			expect(error.layer).toBe("API");
+			expect(error.severity).toBe("INFO");
+		});
+	});
+
+	describe("normalizeUnknownError", () => {
+		it("returns an existing AppError unchanged (same instance)", () => {
+			const existing = makeAppError("conflict", {
+				cause: "c",
+				message: "dup",
+				metadata: { pgCode: "23505" },
+			});
+
+			expect(normalizeUnknownError(existing, "unexpected")).toBe(existing);
+		});
+
+		it("wraps a native Error, keeping its message and attaching it as cause", () => {
+			const err = new Error("kaboom");
+
+			const normalized = normalizeUnknownError(err, "unexpected");
+
+			expect(normalized.key).toBe("unexpected");
+			expect(normalized.message).toBe("kaboom");
+			expect(normalized.cause).toBe(err);
+		});
+
+		it("captures the original type when wrapping a thrown string", () => {
+			const normalized = normalizeUnknownError("just a string", "unknown");
+
+			expect(normalized.key).toBe("unknown");
+			expect(normalized.message).toBe("just a string");
+			expect(normalized.metadata).toMatchObject({
+				originalType: "string",
+				originalValue: "just a string",
+			});
+		});
+
+		it("stringifies a thrown number into the message", () => {
+			const normalized = normalizeUnknownError(404, "unknown");
+
+			expect(normalized.message).toBe("404");
+			expect(normalized.metadata).toMatchObject({ originalType: "number" });
+		});
+	});
+
+	describe("makeUnexpectedError", () => {
+		it("uses the provided message and merges override metadata", () => {
+			const inner = new Error("inner");
+
+			const error = makeUnexpectedError(inner, {
+				message: "outer message",
+				overrideMetadata: { operation: "saveUser" },
+			});
+
+			expect(error.key).toBe("unexpected");
+			expect(error.message).toBe("outer message");
+			expect(error.metadata).toMatchObject({ operation: "saveUser" });
+			expect(error.cause).toBe(inner);
+		});
+
+		it("normalizes a non-Error trigger into metadata", () => {
+			const error = makeUnexpectedError("raw failure", { message: "wrapped" });
+
+			expect(error.key).toBe("unexpected");
+			expect(error.message).toBe("wrapped");
+			expect(error.metadata).toMatchObject({ originalType: "string" });
+		});
+	});
+});

--- a/src/shared/core/errors/__tests__/unit/app-error.registry.test.ts
+++ b/src/shared/core/errors/__tests__/unit/app-error.registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+	APP_ERROR_KEYS,
+	getAppErrorDefinition,
+	getMetadataSchemaForKey,
+} from "@/shared/core/errors/core/catalog/app-error.registry";
+
+/**
+ * Unit tests for the AppError registry (app-error.registry.ts).
+ *
+ * The registry is the single source of truth mapping each error key to its
+ * layer, severity, description and metadata schema. These tests guard a known
+ * entry and assert the registry stays complete and self-consistent for every
+ * key (so a new key can't be added without its definition).
+ */
+describe("AppError registry", () => {
+	it("returns the definition for a known key", () => {
+		expect(getAppErrorDefinition("conflict")).toMatchObject({
+			description: "Resource state conflict",
+			layer: "API",
+			retryable: false,
+			severity: "WARN",
+		});
+	});
+
+	it("has a complete, self-consistent definition for every key", () => {
+		for (const key of Object.values(APP_ERROR_KEYS)) {
+			const definition = getAppErrorDefinition(key);
+
+			expect(definition).toBeDefined();
+			expect(typeof definition.description).toBe("string");
+			expect(definition.metadataSchema).toBeDefined();
+		}
+	});
+
+	it("exposes a usable zod schema per key", () => {
+		const schema = getMetadataSchemaForKey("validation");
+
+		expect(schema.parse({ reason: "x" })).toEqual({ reason: "x" });
+	});
+});

--- a/src/shared/core/errors/__tests__/unit/error-metadata.value.test.ts
+++ b/src/shared/core/errors/__tests__/unit/error-metadata.value.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+	isPgMetadata,
+	isValidationMetadata,
+} from "@/shared/core/errors/core/metadata/error-metadata.value";
+
+/**
+ * Unit tests for the metadata type guards (error-metadata.value.ts).
+ *
+ * These narrow an AppError's metadata so callers can safely read
+ * validation-specific (fieldErrors/formErrors) or Postgres-specific (pgCode)
+ * fields.
+ */
+describe("isValidationMetadata", () => {
+	it.each([
+		{ fieldErrors: { email: ["bad"] } },
+		{ formErrors: ["bad"] },
+	])("is true when validation fields are present: %p", (metadata) => {
+		expect(isValidationMetadata(metadata)).toBe(true);
+	});
+
+	it.each([
+		{},
+		{ reason: "x" },
+		{ pgCode: "23505" },
+	])("is false otherwise: %p", (metadata) => {
+		expect(isValidationMetadata(metadata)).toBe(false);
+	});
+});
+
+describe("isPgMetadata", () => {
+	it("is true when pgCode is present", () => {
+		expect(isPgMetadata({ pgCode: "23505" })).toBe(true);
+	});
+
+	it.each([
+		{},
+		{ constraint: "x" },
+		{ reason: "x" },
+	])("is false when pgCode is absent: %p", (metadata) => {
+		expect(isPgMetadata(metadata)).toBe(false);
+	});
+});

--- a/src/shared/core/errors/__tests__/unit/normalize-pg-error.test.ts
+++ b/src/shared/core/errors/__tests__/unit/normalize-pg-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isAppError } from "@/shared/core/errors/core/app-error.entity";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+import { normalizePgError } from "@/shared/core/errors/server/adapters/postgres/normalize-pg-error";
+import { PG_CODES } from "@/shared/core/errors/server/adapters/postgres/pg-error.constants";
+
+/**
+ * Unit tests for normalizePgError (normalize-pg-error.ts).
+ *
+ * This is the Postgres boundary adapter: it composes toPgError + makeAppError to
+ * turn a raw driver error into a structured AppError with the right key,
+ * condition message, and pg metadata.
+ */
+describe("normalizePgError", () => {
+	it("produces a conflict AppError for a unique violation", () => {
+		const error = normalizePgError({
+			code: PG_CODES.UNIQUE_VIOLATION,
+			constraint: "users_email_key",
+		});
+
+		expect(isAppError(error)).toBe(true);
+		expect(error.key).toBe(APP_ERROR_KEYS.conflict);
+		expect(error.message).toBe("pg_unique_violation");
+		expect(error.metadata).toMatchObject({
+			constraint: "users_email_key",
+			pgCode: PG_CODES.UNIQUE_VIOLATION,
+		});
+	});
+
+	it("produces an unexpected AppError for an unknown error, preserving the cause", () => {
+		const cause = new Error("connection refused");
+
+		const error = normalizePgError(cause);
+
+		expect(error.key).toBe(APP_ERROR_KEYS.unexpected);
+		expect(error.message).toBe("pg_unexpected_error");
+		expect(error.metadata).toMatchObject({
+			pgCode: PG_CODES.UNEXPECTED_INTERNAL_ERROR,
+		});
+		expect(error.cause).toBe(cause);
+	});
+
+	it("returns a frozen AppError instance", () => {
+		const error = normalizePgError({ code: PG_CODES.NOT_NULL_VIOLATION });
+
+		expect(error.key).toBe(APP_ERROR_KEYS.integrity);
+		expect(Object.isFrozen(error)).toBe(true);
+	});
+});

--- a/src/shared/core/errors/__tests__/unit/pg-error.utils.test.ts
+++ b/src/shared/core/errors/__tests__/unit/pg-error.utils.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
+import { getPgConstraintFromAppError } from "@/shared/core/errors/server/adapters/postgres/pg-error.utils";
+
+/**
+ * Unit tests for getPgConstraintFromAppError (pg-error.utils.ts).
+ *
+ * Conflict messaging (e.g. "email already taken") keys off the violated pg
+ * constraint name. This helper digs that name out of an AppError's pg metadata,
+ * walking the AppError cause chain when the constraint lives on a wrapped error.
+ */
+describe("getPgConstraintFromAppError", () => {
+	it("returns the constraint from direct pg metadata", () => {
+		const error = makeAppError("conflict", {
+			cause: "root",
+			message: "pg_unique_violation",
+			metadata: { constraint: "users_email_key", pgCode: "23505" },
+		});
+
+		expect(getPgConstraintFromAppError(error)).toBe("users_email_key");
+	});
+
+	it("returns undefined when pg metadata has no constraint", () => {
+		const error = makeAppError("conflict", {
+			cause: "root",
+			message: "pg_unique_violation",
+			metadata: { pgCode: "23505" },
+		});
+
+		expect(getPgConstraintFromAppError(error)).toBeUndefined();
+	});
+
+	it("returns undefined for non-pg metadata", () => {
+		const error = makeAppError("validation", {
+			cause: "root",
+			message: "bad input",
+			metadata: { reason: "too short" },
+		});
+
+		expect(getPgConstraintFromAppError(error)).toBeUndefined();
+	});
+
+	it("walks the AppError cause chain to find a wrapped constraint", () => {
+		const inner = makeAppError("conflict", {
+			cause: "root",
+			message: "pg_unique_violation",
+			metadata: { constraint: "customers_pkey", pgCode: "23505" },
+		});
+		const outer = makeAppError("unexpected", {
+			cause: inner,
+			message: "wrapped failure",
+			metadata: {},
+		});
+
+		expect(getPgConstraintFromAppError(outer)).toBe("customers_pkey");
+	});
+});

--- a/src/shared/core/errors/__tests__/unit/serialization.test.ts
+++ b/src/shared/core/errors/__tests__/unit/serialization.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { redactNonSerializable } from "@/shared/core/errors/utils/serialization";
+
+/**
+ * Unit tests for redactNonSerializable (serialization.ts).
+ *
+ * This is the safety net that keeps error metadata loggable: primitives pass
+ * through, BigInt/Date/Error get normalized, JSON-safe objects are returned
+ * untouched, and anything that can't be serialized is replaced with a small
+ * descriptor so logging never throws.
+ */
+describe("redactNonSerializable", () => {
+	it.each([
+		null,
+		undefined,
+		"text",
+		42,
+		0,
+		true,
+		false,
+	])("returns primitive %p unchanged", (value) => {
+		expect(redactNonSerializable(value)).toBe(value);
+	});
+
+	it("stringifies bigint (JSON cannot represent it)", () => {
+		expect(redactNonSerializable(10n)).toBe("10");
+	});
+
+	it("normalizes an Error to a plain object without a stack outside development", () => {
+		const out = redactNonSerializable(new Error("boom"));
+
+		expect(out).toMatchObject({ message: "boom", name: "Error" });
+		// NODE_ENV is "test" in the unit lane → stack is intentionally omitted.
+		expect((out as { stack?: unknown }).stack).toBeUndefined();
+	});
+
+	it("converts a Date to an ISO string", () => {
+		const date = new Date("2026-01-02T03:04:05.000Z");
+
+		expect(redactNonSerializable(date)).toBe("2026-01-02T03:04:05.000Z");
+	});
+
+	it("returns a JSON-serializable object by reference (fast path)", () => {
+		const obj = { a: 1, nested: { b: 2 } };
+
+		expect(redactNonSerializable(obj)).toBe(obj);
+	});
+
+	it("redacts a circular object into a descriptor instead of throwing", () => {
+		const circular: Record<string, unknown> = {};
+		circular.self = circular;
+
+		const out = redactNonSerializable(circular);
+
+		expect(out).toMatchObject({
+			note: "non-serializable",
+			originalType: "object",
+		});
+	});
+});

--- a/src/shared/core/errors/__tests__/unit/to-pg-error.test.ts
+++ b/src/shared/core/errors/__tests__/unit/to-pg-error.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+import {
+	PG_CODES,
+	PG_CONDITIONS,
+} from "@/shared/core/errors/server/adapters/postgres/pg-error.constants";
+import { toPgError } from "@/shared/core/errors/server/adapters/postgres/to-pg-error";
+
+/**
+ * Unit tests for toPgError (to-pg-error.ts).
+ *
+ * toPgError is the classifier the DAL relies on to turn a raw driver error into
+ * an app-level mapping. The integration suite already proved that a unique
+ * violation (23505) must surface as a "conflict" — these tests pin that mapping
+ * and the chain-walking behavior directly, fast, without a database.
+ */
+describe("toPgError", () => {
+	it("maps a unique violation (23505) to a conflict", () => {
+		const mapping = toPgError({ code: PG_CODES.UNIQUE_VIOLATION });
+
+		expect(mapping.appErrorKey).toBe(APP_ERROR_KEYS.conflict);
+		expect(mapping.pgCondition).toBe(PG_CONDITIONS.pg_unique_violation);
+		expect(mapping.pgErrorMetadata.pgCode).toBe(PG_CODES.UNIQUE_VIOLATION);
+	});
+
+	it.each([
+		[PG_CODES.FOREIGN_KEY_VIOLATION, PG_CONDITIONS.pg_foreign_key_violation],
+		[PG_CODES.NOT_NULL_VIOLATION, PG_CONDITIONS.pg_not_null_violation],
+		[PG_CODES.CHECK_VIOLATION, PG_CONDITIONS.pg_check_violation],
+	])("maps integrity violation %s to %s", (code, condition) => {
+		const mapping = toPgError({ code });
+
+		expect(mapping.appErrorKey).toBe(APP_ERROR_KEYS.integrity);
+		expect(mapping.pgCondition).toBe(condition);
+	});
+
+	it("extracts native pg fields (constraint/table/detail) when present", () => {
+		const mapping = toPgError({
+			code: PG_CODES.UNIQUE_VIOLATION,
+			constraint: "users_email_key",
+			detail: "Key (email)=(a@b.c) already exists.",
+			table: "users",
+		});
+
+		expect(mapping.pgErrorMetadata).toMatchObject({
+			constraint: "users_email_key",
+			detail: "Key (email)=(a@b.c) already exists.",
+			pgCode: PG_CODES.UNIQUE_VIOLATION,
+			table: "users",
+		});
+	});
+
+	it("walks the cause chain (BFS) to find a buried pg code", () => {
+		const wrapped = {
+			cause: { code: PG_CODES.UNIQUE_VIOLATION },
+			message: "wrapper with no code of its own",
+		};
+
+		const mapping = toPgError(wrapped);
+
+		expect(mapping.appErrorKey).toBe(APP_ERROR_KEYS.conflict);
+	});
+
+	it("ignores non-string field values when extracting metadata", () => {
+		const mapping = toPgError({
+			code: PG_CODES.UNIQUE_VIOLATION,
+			constraint: 12_345, // not a string → must be dropped, not coerced
+		});
+
+		expect(mapping.pgErrorMetadata.constraint).toBeUndefined();
+	});
+
+	it("falls back to an unexpected mapping for an unknown code", () => {
+		const mapping = toPgError({ code: "99999" });
+
+		expect(mapping.appErrorKey).toBe(APP_ERROR_KEYS.unexpected);
+		expect(mapping.pgCondition).toBe(PG_CONDITIONS.pg_unexpected_error);
+		expect(mapping.pgErrorMetadata.pgCode).toBe(
+			PG_CODES.UNEXPECTED_INTERNAL_ERROR,
+		);
+	});
+
+	it("falls back for an Error with no code, keeping its message as detail", () => {
+		const mapping = toPgError(new Error("connection refused"));
+
+		expect(mapping.appErrorKey).toBe(APP_ERROR_KEYS.unexpected);
+		expect(mapping.pgErrorMetadata.detail).toBe("connection refused");
+	});
+
+	it.each([
+		null,
+		undefined,
+		"raw string",
+		7,
+	])("falls back to unexpected for non-object input %p", (input) => {
+		expect(toPgError(input).appErrorKey).toBe(APP_ERROR_KEYS.unexpected);
+	});
+});

--- a/src/shared/core/result/README.md
+++ b/src/shared/core/result/README.md
@@ -1,164 +1,87 @@
-# Result Pattern Utilities
+# Result pattern
 
-A professional, type-safe implementation of the Result pattern for TypeScript, designed to eliminate exceptions in favor
-of explicit error handling.
+A small, type-safe success/error wrapper used across the codebase to make
+failure explicit in return types instead of relying on `throw` / `try`-`catch`.
 
-## Core Philosophy
+## Philosophy
 
-The `Result` pattern replaces `throw` and `try/catch` with a predictable return type that represents either success (
-`Ok`) or failure (`Err`). This promotes:
+`Result<TValue, TError>` is a discriminated union of `Ok` (success) and `Err`
+(failure). Callers narrow on the `ok` flag, which forces the error case to be
+handled:
 
-- **Exhaustiveness**: TypeScript forces you to handle the error case.
-- **Discoverability**: Functions explicitly declare what errors they can return.
-- **Safety**: No more unhandled runtime exceptions from forgotten catch blocks.
+- **Exhaustiveness** — TypeScript makes you check `ok` before reaching `.value`
+  or `.error`.
+- **Discoverability** — a function's return type states which errors it can
+  produce.
+- **Safety** — no unhandled exceptions from forgotten `catch` blocks.
 
----
+## API
 
-## Module Overview
+This module deliberately exposes a minimal surface. There is no barrel file —
+import directly from the specific module:
 
-The library is split into logical modules to maintain a clean API and small bundle size:
+| Import                                                    | From                                  | Purpose                                                            |
+| -------------------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------- |
+| `Ok`, `Err`, `unwrapOrNull`                              | `@/shared/core/result/result`         | Construct results; non-throwing unwrap to `value \| null`.        |
+| `Result`, `OkResult`, `ErrResult`, `OkType`, `ErrType`   | `@/shared/core/result/result.dto`     | Types.                                                             |
+| `safeExecute`                                            | `@/shared/core/result/safe-execute`   | Run an async thunk, converting thrown values into a logged `Err`. |
 
-- `integrations/safe-execute.ts`: Application-level integration for logging and error normalization.
-- `result.async.ts`: Asynchronous transformation operators and `pipeAsync`.
-- `result.collection.ts`: Utilities for working with arrays or iterables of Results.
-- `result.factory.ts`: Creation utilities (Entry points from other data types).
-- `result.operators.ts`: Synchronous transformation operators (map, flatMap, tap).
-- `result.ts`: Core primitives and type guards.
-- `result.types.ts`: Shared TypeScript types and interfaces.
+### Creating and reading results
 
----
-
-## Importing
-
-This project avoids a barrel file. Import directly from the specific module you need:
-
-```typescript
-import {Ok, Err, isOk, isErr} from '@/shared/results/result';
-import {fromNullable, tryCatch} from '@/shared/results/result.factory';
-import {map, flatMap, match} from '@/shared/results/result.operators';
-import {mapAsync, pipeAsync, tapAsync} from '@/shared/results/result.async';
-import {collectAll, collectTuple} from '@/shared/results/result.collection';
-```
-
----
-
-## Basic Usage
-
-### Creating Results
-
-```typescript
-import {Ok, Err} from '@/shared/results/result';
+```ts
+import { makeUnexpectedError } from "@/shared/core/errors/core/factories/app-error.factory";
+import { Err, Ok } from "@/shared/core/result/result";
 
 const success = Ok(42);
-const failure = Err({code: 'NOT_FOUND', message: 'User not found'});
-```
+const failure = Err(makeUnexpectedError(cause, { message: "Something failed" }));
 
-### Checking Results
-
-```typescript
-import {isOk, isErr} from '@/shared/results/result';
-
-if (isOk(result)) {
-    console.log(result.value);
+// Narrow on the `ok` discriminant — there are no isOk/isErr helpers.
+if (result.ok) {
+  // result.value is available here
 } else {
-    console.error(result.error);
+  // result.error is available here (always an AppError)
 }
 ```
 
----
+> `Err` accepts an `AppError` instance (a class built via the error factories in
+> `@/shared/core/errors`), **not** a plain `{ code, message }` object.
 
-## Factory Utilities (`result.factory.ts`)
+### safeExecute
 
-Utilities for wrapping existing logic into the Result domain.
+```ts
+import { safeExecute } from "@/shared/core/result/safe-execute";
 
-```typescript
-import {fromNullable, tryCatch} from '@/shared/results/result.factory';
-
-// From a nullable value
-const res1 = fromNullable(maybeUser, () => ({code: 'NOT_FOUND', message: '...'}));
-
-// From a throwing function
-const res2 = tryCatch(
-    () => JSON.parse(jsonString),
-    (err) => ({code: 'PARSE_ERROR', message: String(err)})
-);
+const result = await safeExecute(() => myDomainOperation(), {
+  logger,
+  message: "Failed to fetch user data",
+  operation: "GetUserData",
+});
 ```
 
----
+A resolved `Ok`/`Err` is returned verbatim with no logging. A _thrown_ `AppError`
+is logged and returned as-is; any other thrown value is normalized to an
+`unexpected` `AppError` and logged.
 
-## Synchronous Operators (`result.operators.ts`)
+## Dormant combinator modules
 
-Transformation utilities that work on Results. Most operators are curried for use in pipelines.
+This module also ships a fuller combinator library that is **not currently
+exported or imported by anything** — every function is module-private:
 
-```typescript
-import {map, flatMap, tap, match} from '@/shared/results/result.operators';
-// import { pipe } from '@/shared/utils/pipe'; // If a pipe utility is available
+- `result.factory.ts` — constructors (`tryCatch`, `fromNullable`,
+  `fromPredicate`, `fromGuard`, `fromCondition`, `tryCatchAsync`).
+- `result.operators.ts` — sync transforms (`map`, `flatMap`, `mapErr`, `tap`,
+  `unwrapOr` / `unwrapOrElse`, `match`, …).
+- `result.async.ts` — async mirrors plus a typed multi-step `pipeAsync`.
+- `result.collection.ts` — aggregation (`collectAll`, `collectTuple`,
+  `firstOkOrElse`, `iterateOk`).
 
-const result = map(n => n * 2)(Ok(10));
-
-// Extracting values
-const output = match(
-    result,
-    (val) => `Success: ${val}`,
-    (err) => `Error: ${err.message}`
-);
-```
-
----
-
-## Asynchronous Operators (`result.async.ts`)
-
-Utilities for handling Promises and asynchronous flows.
-
-```typescript
-import {mapAsync, pipeAsync, tapAsync} from '@/shared/results/result.async';
-
-const result = await pipeAsync(
-    Ok("user_id_123"),
-    async (r) => mapAsync(async (id: string) => await fetchUser(id))(r),
-    async (r) => tapAsync(async (user: User) => await logVisit(user.id))(r)
-);
-```
-
----
-
-## Working with Collections (`result.collection.ts`)
-
-Utilities for processing multiple Results at once.
-
-```typescript
-import {collectAll, collectTuple} from '@/shared/results/result.collection';
-
-// Combine an array of Results into a single Result
-const results = [Ok(1), Ok(2), Ok(3)];
-const allOk = collectAll(results); // Result<readonly number[], AppError>
-
-// Combine heterogeneous Results into a tuple
-const tuple = collectTuple(Ok(1), Ok("hello")); // Result<readonly [number, string], AppError>
-```
-
----
-
-## Safe Execution Integration (`integrations/safe-execute.ts`)
-
-A high-level utility for executing operations with automatic logging and normalization.
-
-```typescript
-import {safeExecute} from '@/shared/results/integrations/safe-execute';
-
-const result = await safeExecute(
-    async () => await myDomainOperation(),
-    {
-        logger,
-        operation: 'GetUserData',
-        message: 'Failed to fetch user data'
-    }
-);
-```
-
----
+They're kept dormant as a ready-made foundation for railway-oriented error
+handling, to be wired up (exported + tested) if and when a real caller needs
+them. Until then they intentionally surface as unused files in `pnpm knip`. If
+that day never comes, delete them — git preserves the full implementation.
 
 ## Tooling
 
-- Use `pnpm biome:check` to run linting/formatting diagnostics.
-- Use `pnpm typecheck` to run TypeScript checks.
+- `pnpm biome:check` — lint/format diagnostics.
+- `pnpm typecheck` — TypeScript checks.
+```

--- a/src/shared/core/result/__tests__/unit/result.test.ts
+++ b/src/shared/core/result/__tests__/unit/result.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { makeUnexpectedError } from "@/shared/core/errors/core/factories/app-error.factory";
+import { Err, Ok, unwrapOrNull } from "@/shared/core/result/result";
+
+/**
+ * Unit tests for the live Result API (`result.ts`).
+ *
+ * Result is the foundational success/error wrapper threaded through form
+ * factories, env access, DAL adapters, services and use-cases. The exported
+ * surface is intentionally tiny — `Ok`, `Err`, `unwrapOrNull` — after the unused
+ * combinator helpers were removed. These tests pin the three things callers
+ * depend on: construction shape, immutability, and unwrap semantics.
+ */
+describe("Result core", () => {
+	describe("Ok", () => {
+		it("wraps a value as a success result", () => {
+			const result = Ok(42);
+
+			expect(result).toEqual({ ok: true, value: 42 });
+		});
+
+		it("preserves the exact value reference for objects", () => {
+			const payload = { id: 1 };
+
+			const result = Ok(payload);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toBe(payload);
+			}
+		});
+
+		it.each([
+			0,
+			"",
+			null,
+			undefined,
+			false,
+			Number.NaN,
+		])("wraps falsy value %p without coercion", (value) => {
+			const result = Ok(value);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toBe(value);
+			}
+		});
+
+		it("returns a frozen object (immutable result)", () => {
+			expect(Object.isFrozen(Ok(1))).toBe(true);
+		});
+	});
+
+	describe("Err", () => {
+		it("wraps an error as a failure result, preserving the instance", () => {
+			const error = makeUnexpectedError(new Error("boom"), {
+				message: "boom",
+			});
+
+			const result = Err(error);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).toBe(error);
+			}
+		});
+
+		it("returns a frozen object (immutable result)", () => {
+			const error = makeUnexpectedError(new Error("boom"), {
+				message: "boom",
+			});
+
+			expect(Object.isFrozen(Err(error))).toBe(true);
+		});
+	});
+
+	describe("unwrapOrNull", () => {
+		it("returns the value for an Ok result", () => {
+			expect(unwrapOrNull(Ok("hello"))).toBe("hello");
+		});
+
+		it("returns null for an Err result", () => {
+			const error = makeUnexpectedError(new Error("boom"), {
+				message: "boom",
+			});
+
+			expect(unwrapOrNull(Err(error))).toBeNull();
+		});
+
+		it("returns null for Ok(null) — null value is indistinguishable from absence", () => {
+			expect(unwrapOrNull(Ok(null))).toBeNull();
+		});
+
+		it("returns falsy-but-present values unchanged (not collapsed to null)", () => {
+			expect(unwrapOrNull(Ok(0))).toBe(0);
+			expect(unwrapOrNull(Ok(""))).toBe("");
+			expect(unwrapOrNull(Ok(false))).toBe(false);
+		});
+	});
+});

--- a/src/shared/core/result/__tests__/unit/safe-execute.test.ts
+++ b/src/shared/core/result/__tests__/unit/safe-execute.test.ts
@@ -1,0 +1,91 @@
+import { makeMockLogger } from "@test-support/mocks/logger.mock";
+import { describe, expect, it } from "vitest";
+import { isAppError } from "@/shared/core/errors/core/app-error.entity";
+import { makeUnexpectedError } from "@/shared/core/errors/core/factories/app-error.factory";
+import { Err, Ok } from "@/shared/core/result/result";
+import { safeExecute } from "@/shared/core/result/safe-execute";
+
+/**
+ * Unit tests for `safeExecute` (`safe-execute.ts`).
+ *
+ * safeExecute is the async boundary wrapper: it runs a thunk returning a Result
+ * and converts any *thrown* value into a logged `Err`. Contract under test:
+ *  - resolved Results (Ok or Err) pass through verbatim, with NO logging;
+ *  - a thrown AppError is logged and returned as-is (never re-wrapped);
+ *  - an unknown throw is normalized to an 'unexpected' AppError and logged.
+ */
+describe("safeExecute", () => {
+	const baseOptions = {
+		message: "operation failed",
+		operation: "test.op",
+	} as const;
+
+	it("returns an Ok result unchanged and does not log", async () => {
+		const logger = makeMockLogger();
+
+		const result = await safeExecute(() => Promise.resolve(Ok("value")), {
+			...baseOptions,
+			logger,
+		});
+
+		expect(result).toEqual({ ok: true, value: "value" });
+		expect(logger.errorWithDetails).not.toHaveBeenCalled();
+	});
+
+	it("returns a resolved Err verbatim and does not log (only throws are caught)", async () => {
+		const logger = makeMockLogger();
+		const error = makeUnexpectedError(new Error("inner"), {
+			message: "inner",
+		});
+
+		const result = await safeExecute(() => Promise.resolve(Err(error)), {
+			...baseOptions,
+			logger,
+		});
+
+		expect(result).toEqual({ error, ok: false });
+		expect(logger.errorWithDetails).not.toHaveBeenCalled();
+	});
+
+	it("passes a thrown AppError through untouched and logs it once", async () => {
+		const logger = makeMockLogger();
+		const thrown = makeUnexpectedError(new Error("boom"), {
+			message: "boom",
+		});
+
+		const result = await safeExecute(() => Promise.reject(thrown), {
+			...baseOptions,
+			logger,
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			// Same instance — not normalized/re-wrapped.
+			expect(result.error).toBe(thrown);
+		}
+		expect(logger.errorWithDetails).toHaveBeenCalledTimes(1);
+		expect(logger.errorWithDetails).toHaveBeenCalledWith(
+			"operation failed",
+			thrown,
+			{ operation: "test.op" },
+		);
+	});
+
+	it("normalizes an unknown thrown value into an unexpected AppError and logs it", async () => {
+		const logger = makeMockLogger();
+
+		const result = await safeExecute(
+			() => Promise.reject(new Error("raw failure")),
+			{ ...baseOptions, logger },
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(isAppError(result.error)).toBe(true);
+			// message comes from options, not the raw thrown error.
+			expect(result.error.message).toBe("operation failed");
+			expect(result.error.metadata).toMatchObject({ operation: "test.op" });
+		}
+		expect(logger.errorWithDetails).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## What

First slice of **Phase 3 breadth** for the Vitest suite: unit-test coverage for the `shared/core/result` and `shared/core/errors` modules. Recovered from a stranded worktree and rebuilt into a clean, honest history.

- **`docs(result)`** — rewrite the `result/` README to document the actual live public API (`Ok`/`Err`/`unwrapOrNull`, `safeExecute`, types). The prior version had drifted (bogus `@/shared/results/*` import paths, a plain-object `Err`, non-existent `isOk`/`isErr` helpers).
- **`test(result)`** — unit tests for the live surface: `Ok`, `Err`, `unwrapOrNull` (`result.ts`) and `safeExecute` (`safe-execute.ts`).
- **`test(errors)`** — unit tests for the errors module: app-error entity/factory/registry + entity utils, error-metadata value object, pg-error utils, `normalize-pg-error`, `to-pg-error`, and cross-boundary serialization.

## Combinators kept (parked, not deleted)

The four `result/` combinator modules (`result.{factory,operators,async,collection}.ts`) are a competent hand-rolled Result/Either combinator library that is currently unexported/unwired. **Decision: keep them dormant** as a foundation for future railway-oriented error handling rather than delete — git would otherwise bury them. The README's new "Dormant combinator modules" section documents this intent.

## Tooling note

Because those four files are unused, `pnpm knip` (and `pnpm check:repo`) will continue to list them — intentionally, and now documented. knip is **not** CI-enforced (CI runs `check:fast`), and the repo already reports 16 unused files, so this is consistent existing backlog, not a new regression.

## Verification

- `pnpm check:fast` — biome clean (582 files), typecheck + typegen clean
- `pnpm test:unit` — **18 files / 134 tests passing** (up from 36 after Phase 2)
