### PR TITLE
feat(auth): enforce action-level authorization on invoice/user server actions

### DIFF
--- a/src/modules/auth/__tests__/unit/presentation/session/session-access.guard.test.ts
+++ b/src/modules/auth/__tests__/unit/presentation/session/session-access.guard.test.ts
@@ -1,0 +1,75 @@
+import { redirect } from "next/navigation";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import type { SessionVerificationDto } from "@/modules/auth/application/session/dtos/responses/session-verification.dto";
+import { verifySessionOptimistic } from "@/modules/auth/presentation/session/actions/verify-session-optimistic.action";
+import {
+	requireAdmin,
+	requireSession,
+} from "@/modules/auth/presentation/session/guards/session-access.guard";
+import {
+	ADMIN_ROLE,
+	USER_ROLE,
+} from "@/shared/policies/user-role/user-role.constants";
+import { ROUTES } from "@/shared/routing/routes";
+
+// `next/navigation` is globally mocked in vitest.setup.ts so that `redirect`
+// throws a NEXT_REDIRECT error (mirroring real Next.js). Only the session check
+// the guards delegate to needs a local mock here.
+vi.mock(
+	"@/modules/auth/presentation/session/actions/verify-session-optimistic.action",
+	() => ({ verifySessionOptimistic: vi.fn() }),
+);
+
+const adminSession: SessionVerificationDto = {
+	isAuthorized: true,
+	role: ADMIN_ROLE,
+	userId: "admin-1",
+};
+
+const userSession: SessionVerificationDto = {
+	isAuthorized: true,
+	role: USER_ROLE,
+	userId: "user-1",
+};
+
+describe("session-access guards", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("requireSession", () => {
+		it("returns the verified session principal", async () => {
+			(verifySessionOptimistic as Mock).mockResolvedValue(userSession);
+
+			await expect(requireSession()).resolves.toEqual(userSession);
+			expect(redirect).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("requireAdmin", () => {
+		it("returns the session when the caller is an admin", async () => {
+			(verifySessionOptimistic as Mock).mockResolvedValue(adminSession);
+
+			await expect(requireAdmin()).resolves.toEqual(adminSession);
+			expect(redirect).not.toHaveBeenCalled();
+		});
+
+		it("redirects to the dashboard root when the caller is not an admin", async () => {
+			(verifySessionOptimistic as Mock).mockResolvedValue(userSession);
+
+			await expect(requireAdmin()).rejects.toThrow("NEXT_REDIRECT");
+			expect(redirect).toHaveBeenCalledWith(ROUTES.dashboard.root);
+		});
+
+		it("propagates the login redirect raised when there is no session", async () => {
+			// verifySessionOptimistic redirects to login on no session; that
+			// control-flow error must bubble straight through requireAdmin.
+			(verifySessionOptimistic as Mock).mockRejectedValue(
+				new Error("NEXT_REDIRECT"),
+			);
+
+			await expect(requireAdmin()).rejects.toThrow("NEXT_REDIRECT");
+			expect(redirect).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/modules/auth/presentation/session/guards/session-access.guard.ts
+++ b/src/modules/auth/presentation/session/guards/session-access.guard.ts
@@ -1,0 +1,54 @@
+import "server-only";
+import { redirect } from "next/navigation";
+import type { SessionVerificationDto } from "@/modules/auth/application/session/dtos/responses/session-verification.dto";
+import { verifySessionOptimistic } from "@/modules/auth/presentation/session/actions/verify-session-optimistic.action";
+import { ADMIN_ROLE } from "@/shared/policies/user-role/user-role.constants";
+import { ROUTES } from "@/shared/routing/routes";
+
+/**
+ * Authorization guards for server actions.
+ *
+ * Server Actions are independently invocable RPC endpoints: a crafted request
+ * can reach an action without navigating through the page that hosts it, so the
+ * route-level checks in `proxy.ts` (middleware) are not sufficient on their own.
+ * These guards make each action enforce its own authorization — defense in
+ * depth, and the real boundary for role-restricted operations (without them a
+ * non-admin could replay a user-management action against a route they can
+ * reach and escalate privileges).
+ *
+ * Both guards reuse {@link verifySessionOptimistic} (the canonical optimistic
+ * session check) so there is a single source of truth for "is there a session".
+ * Because that check is wrapped in React `cache`, repeated guard calls within a
+ * single request resolve to one verification.
+ */
+
+/**
+ * Requires a valid session. Redirects to the login page when none exists.
+ *
+ * @returns The verified session principal (role + userId).
+ * @redirects {ROUTES.auth.login} when there is no valid session.
+ */
+export function requireSession(): Promise<SessionVerificationDto> {
+	return verifySessionOptimistic();
+}
+
+/**
+ * Requires a valid session that belongs to an admin.
+ *
+ * Redirects to login when unauthenticated (via {@link verifySessionOptimistic}),
+ * or to the dashboard root when authenticated without the admin role. This is
+ * what stops a non-admin from invoking a user-management action directly.
+ *
+ * @returns The verified admin session principal.
+ * @redirects {ROUTES.auth.login} when unauthenticated.
+ * @redirects {ROUTES.dashboard.root} when authenticated but not an admin.
+ */
+export async function requireAdmin(): Promise<SessionVerificationDto> {
+	const session = await verifySessionOptimistic();
+
+	if (session.role !== ADMIN_ROLE) {
+		redirect(ROUTES.dashboard.root);
+	}
+
+	return session;
+}

--- a/src/modules/invoices/presentation/actions/create-invoice.action.ts
+++ b/src/modules/invoices/presentation/actions/create-invoice.action.ts
@@ -1,5 +1,6 @@
 "use server";
 import { revalidatePath } from "next/cache";
+import { requireSession } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import { InvoiceService } from "@/modules/invoices/application/services/invoice.service";
 import { toInvoiceErrorMessage } from "@/modules/invoices/application/utils/error-messages";
 import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
@@ -32,6 +33,10 @@ export async function createInvoiceAction(
 	_prevState: FormResult<CreateInvoicePayload>,
 	formData: FormData,
 ): Promise<FormResult<CreateInvoicePayload>> {
+	// Authorization: any authenticated user may manage invoices. Kept above the
+	// try/catch below so a no-session redirect propagates instead of being caught.
+	await requireSession();
+
 	// 1. Parse Input: Leverage infrastructure for consistent extraction
 	const rawInput = resolveRawFieldPayload(formData, CREATE_INVOICE_FIELDS_LIST);
 	const parsed = CreateInvoiceSchema.safeParse(rawInput);

--- a/src/modules/invoices/presentation/actions/delete-invoice.action.ts
+++ b/src/modules/invoices/presentation/actions/delete-invoice.action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { requireSession } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import type { InvoiceDto } from "@/modules/invoices/application/dto/invoice.dto";
 import { InvoiceService } from "@/modules/invoices/application/services/invoice.service";
 import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
@@ -24,6 +25,10 @@ import { logger } from "@/shared/telemetry/logging/infrastructure/logging.client
 export async function deleteInvoiceAction(
 	id: string,
 ): Promise<Result<InvoiceDto, AppError>> {
+	// Authorization: any authenticated user may manage invoices. Kept above the
+	// try/catch so a no-session redirect propagates instead of being caught.
+	await requireSession();
+
 	try {
 		// Input validation -> return Err instead of throwing
 		if (!id) {

--- a/src/modules/invoices/presentation/actions/update-invoice.action.ts
+++ b/src/modules/invoices/presentation/actions/update-invoice.action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { requireSession } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import { InvoiceService } from "@/modules/invoices/application/services/invoice.service";
 import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
 import {
@@ -62,6 +63,10 @@ export async function updateInvoiceAction(
 	id: string,
 	formData: FormData,
 ): Promise<FormResult<UpdateInvoicePayload>> {
+	// Authorization: any authenticated user may manage invoices. Kept above the
+	// try/catch so a no-session redirect propagates instead of being caught.
+	await requireSession();
+
 	try {
 		const input = {
 			amount: formData.get("amount"),

--- a/src/modules/users/__tests__/unit/application/services/user.service.test.ts
+++ b/src/modules/users/__tests__/unit/application/services/user.service.test.ts
@@ -98,4 +98,36 @@ describe("UserService", () => {
 			expect(result.ok).toBe(false);
 		});
 	});
+
+	describe("updateUser", () => {
+		// Regression coverage for "leave password blank to keep current": a patch
+		// without a password must skip hashing and forward the other fields as-is.
+		it("does not hash and forwards the patch when no password is provided", async () => {
+			mockRepo.update.mockResolvedValue(Ok(mockUser));
+
+			const result = await userService.updateUser(mockUser.id, {
+				username: "new-name",
+			});
+
+			expect(result.ok).toBe(true);
+			expect(mockHasher.hash).not.toHaveBeenCalled();
+			expect(mockRepo.update).toHaveBeenCalledWith(mockUser.id, {
+				username: "new-name",
+			});
+		});
+
+		it("hashes the password before forwarding when a new one is provided", async () => {
+			mockRepo.update.mockResolvedValue(Ok(mockUser));
+
+			const result = await userService.updateUser(mockUser.id, {
+				password: TEST_PASSWORD,
+			});
+
+			expect(result.ok).toBe(true);
+			expect(mockHasher.hash).toHaveBeenCalledWith(TEST_PASSWORD);
+			expect(mockRepo.update).toHaveBeenCalledWith(mockUser.id, {
+				password: TEST_PASSWORD_HASH,
+			});
+		});
+	});
 });

--- a/src/modules/users/__tests__/unit/presentation/actions/create-user.action.test.ts
+++ b/src/modules/users/__tests__/unit/presentation/actions/create-user.action.test.ts
@@ -4,6 +4,7 @@ import {
 	TEST_USERNAME,
 } from "@test-support/fixtures/user.fixtures";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { requireAdmin } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import {
 	USER_ERROR_MESSAGES,
 	USER_SUCCESS_MESSAGES,
@@ -27,6 +28,16 @@ import { validateForm } from "@/shared/forms/server/validate-form";
 vi.mock("@/shared/forms/server/validate-form");
 vi.mock("@/modules/users/infrastructure/factories/user-service.factory");
 vi.mock("@/server/db/db.connection");
+vi.mock(
+	"@/modules/auth/presentation/session/guards/session-access.guard",
+	() => ({
+		requireAdmin: vi.fn().mockResolvedValue({
+			isAuthorized: true,
+			role: "ADMIN",
+			userId: "admin-1",
+		}),
+	}),
+);
 vi.mock(
 	"@/shared/forms/logic/factories/form-result.factory",
 	async (importOriginal) => {
@@ -134,5 +145,21 @@ describe("createUserAction", () => {
 			expect(result.error.key).toBe(APP_ERROR_KEYS.unexpected);
 			expect(result.error.message).toBe(USER_ERROR_MESSAGES.unexpected);
 		}
+	});
+
+	it("enforces admin authorization before creating a user", async () => {
+		const validData = {
+			email: TEST_EMAIL,
+			password: TEST_PASSWORD,
+			role: "USER" as const,
+			username: TEST_USERNAME,
+		};
+
+		(validateForm as Mock).mockResolvedValue(makeFormOk(validData, ""));
+		mockService.createUser.mockResolvedValue(Ok({ id: "1", ...validData }));
+
+		await createUserAction(prevState, formData);
+
+		expect(requireAdmin).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/modules/users/presentation/actions/create-user.action.ts
+++ b/src/modules/users/presentation/actions/create-user.action.ts
@@ -1,4 +1,5 @@
 "use server";
+import { requireAdmin } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import {
 	USER_ERROR_MESSAGES,
 	USER_SUCCESS_MESSAGES,
@@ -28,6 +29,10 @@ export async function createUserAction(
 	_prevState: FormResult<unknown>,
 	formData: FormData,
 ): Promise<FormResult<unknown>> {
+	// Authorization: user management is admin-only. Kept above the try/catch so
+	// the redirect for a non-admin/anonymous caller is not swallowed.
+	await requireAdmin();
+
 	const db = getAppDb();
 
 	const allowed = resolveCanonicalFieldNames<

--- a/src/modules/users/presentation/actions/delete-user.action.ts
+++ b/src/modules/users/presentation/actions/delete-user.action.ts
@@ -1,6 +1,7 @@
 "use server";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
+import { requireAdmin } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import { USER_ERROR_MESSAGES } from "@/modules/users/domain/constants/user.constants";
 import { toUserId } from "@/modules/users/domain/user-id.mappers";
 import { createUserService } from "@/modules/users/infrastructure/factories/user-service.factory";
@@ -14,6 +15,10 @@ import { ROUTES } from "@/shared/routing/routes";
  * Deletes a user by ID, revalidates and redirects.
  */
 export async function deleteUserAction(id: string): Promise<FormResult<never>> {
+	// Authorization: user management is admin-only. Kept above the try/catch so
+	// the redirect for a non-admin/anonymous caller is not swallowed.
+	await requireAdmin();
+
 	try {
 		const db = getAppDb();
 		const service = createUserService(db);

--- a/src/modules/users/presentation/actions/read-filtered-users.action.ts
+++ b/src/modules/users/presentation/actions/read-filtered-users.action.ts
@@ -1,4 +1,5 @@
 "use server";
+import { requireAdmin } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import type { UserDto } from "@/modules/users/application/dtos/user.dto";
 import { createUserService } from "@/modules/users/infrastructure/factories/user-service.factory";
 import { getAppDb } from "@/server/db/db.connection";
@@ -11,6 +12,10 @@ export async function readFilteredUsersAction(
 	query: string = "",
 	currentPage: number = 1,
 ): Promise<UserDto[]> {
+	// Authorization: user records are admin-only (PII). This action is a
+	// "use server" endpoint, so it must guard itself, not rely on the route.
+	await requireAdmin();
+
 	const db = getAppDb();
 	const service = createUserService(db);
 	const result = await service.readFilteredUsers(query, currentPage);

--- a/src/modules/users/presentation/actions/read-user.action.ts
+++ b/src/modules/users/presentation/actions/read-user.action.ts
@@ -1,4 +1,5 @@
 "use server";
+import { requireAdmin } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import type { UserDto } from "@/modules/users/application/dtos/user.dto";
 import { toUserId } from "@/modules/users/domain/user-id.mappers";
 import { createUserService } from "@/modules/users/infrastructure/factories/user-service.factory";
@@ -9,6 +10,10 @@ import { unwrapOrNull } from "@/shared/core/result/result";
  * Fetches a user by plain string id for UI consumption.
  */
 export async function readUserAction(id: string): Promise<UserDto | null> {
+	// Authorization: user records are admin-only (PII). This action is a
+	// "use server" endpoint, so it must guard itself, not rely on the route.
+	await requireAdmin();
+
 	const db = getAppDb();
 	const service = createUserService(db);
 	const result = await service.readUserById(toUserId(id));

--- a/src/modules/users/presentation/actions/read-users-page-count.action.ts
+++ b/src/modules/users/presentation/actions/read-users-page-count.action.ts
@@ -1,4 +1,5 @@
 "use server";
+import { requireAdmin } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import { createUserService } from "@/modules/users/infrastructure/factories/user-service.factory";
 import { getAppDb } from "@/server/db/db.connection";
 import { unwrapOrNull } from "@/shared/core/result/result";
@@ -9,6 +10,10 @@ import { unwrapOrNull } from "@/shared/core/result/result";
 export async function readUsersPageCountAction(
 	query: string = "",
 ): Promise<number> {
+	// Authorization: user records are admin-only (PII). This action is a
+	// "use server" endpoint, so it must guard itself, not rely on the route.
+	await requireAdmin();
+
 	const db = getAppDb();
 	const service = createUserService(db);
 	const result = await service.readUserPageCount(query);

--- a/src/modules/users/presentation/actions/update-user.action.ts
+++ b/src/modules/users/presentation/actions/update-user.action.ts
@@ -1,5 +1,6 @@
 "use server";
 import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import type { UserDto } from "@/modules/users/application/dtos/user.dto";
 import {
 	USER_ERROR_MESSAGES,
@@ -117,6 +118,10 @@ export async function updateUserAction(
 	_prevState: FormResult<unknown>,
 	formData: FormData,
 ): Promise<FormResult<unknown>> {
+	// Authorization: user management is admin-only. Kept above the try/catch so
+	// the redirect for a non-admin/anonymous caller is not swallowed.
+	await requireAdmin();
+
 	const fields = resolveCanonicalFieldNames<
 		EditUserData,
 		EditUserFormFieldNames


### PR DESCRIPTION
## Summary

Server Actions in this app are independently-invocable `"use server"` endpoints, so the route-level checks in middleware (`src/proxy.ts`) aren't sufficient on their own. Two concrete gaps this closes:

- **Privilege escalation** — a logged-in non-admin could replay a user-management action (e.g. `createUserAction`/`deleteUserAction`) against a route they *can* reach; the route-level admin gate never runs for the action itself.
- **PII read** — the user read actions (`read-user`, `read-filtered-users`, `read-users-page-count`) are `"use server"` endpoints and could be invoked directly to enumerate users.

Each action now enforces its own authorization (defense in depth), reusing the existing session check rather than rebuilding it.

### What changed

New guard module `src/modules/auth/presentation/session/guards/session-access.guard.ts` exposing `requireSession()` and `requireAdmin()`, both built on the existing `verifySessionOptimistic()`. Guards sit **above** each action's `try/catch` so the `NEXT_REDIRECT` propagates instead of being swallowed.

| Action | Guard |
| --- | --- |
| invoice create / update / delete | `requireSession` |
| user create / update / delete | `requireAdmin` |
| user read by-id / filtered / page-count | `requireAdmin` |
| form-delete variants | delegate to the core actions (covered transitively) |

`requireAdmin` redirects authenticated non-admins to the dashboard root and delegates the no-session case to `verifySessionOptimistic` (redirect to login) — matching the existing redirect convention. `forbidden()` is left as a future option (`authInterrupts` is enabled but no `forbidden.tsx` exists yet).

Also adds regression tests that lock the already-working "leave password blank to keep current" edit behaviour at the service layer (`UserService.updateUser`), plus unit tests for the new guards.

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Refactor (no behaviour change)
- [ ] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen) — clean
- [x] `pnpm test` (unit) — 141 pass / 19 files
- [x] `pnpm cy:e2e` (end-to-end) — 30 pass / 2 skip / 0 fail (incl. `server-actions/authorization-actions`, invoice + user CRUD specs)
- [x] Manually verified in the running app — login renders; `/dashboard`, `/dashboard/users`, `/dashboard/invoices` redirect to login when anonymous

Also: `pnpm test:integration` — 18 pass / 5 files.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `.aiassistant/rules/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed — N/A (internal authz hardening, no setup/user-facing change)
- [x] Focused change — preserves existing patterns and user-authored work

### Reviewer notes

- **Blank-password edit** (Phase 2 plan item) was already fixed in earlier refactors — handled end-to-end (schema → form → action → service). No fix needed; this just adds the missing service-layer regression tests.
- **Deliberately not guarded:** customer/invoice *read* actions — low-sensitivity data already behind middleware. Easy follow-up if belt-and-suspenders is wanted.
- **Out of scope (separate):** `deleteUserAction` has a pre-existing latent bug — `redirect()` sits inside its `try/catch`, so `NEXT_REDIRECT` is swallowed (masked today by `revalidatePath` + the form variant ignoring the return). Flagged for a separate change; not touched here beyond adding the guard above the try.
