### PR TITLE
fix(users): stop deleteUserAction from swallowing its success redirect

### DIFF
--- a/src/modules/users/__tests__/unit/presentation/actions/delete-user.action.test.ts
+++ b/src/modules/users/__tests__/unit/presentation/actions/delete-user.action.test.ts
@@ -1,0 +1,98 @@
+import {
+	makeUserEntity,
+	TEST_USER_ID,
+} from "@test-support/fixtures/user.fixtures";
+import { runAndCaptureRedirectPath } from "@test-support/next-redirect";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { requireAdmin } from "@/modules/auth/presentation/session/guards/session-access.guard";
+import { USER_ERROR_MESSAGES } from "@/modules/users/domain/constants/user.constants";
+import { createUserService } from "@/modules/users/infrastructure/factories/user-service.factory";
+import { deleteUserAction } from "@/modules/users/presentation/actions/delete-user.action";
+import { getAppDb } from "@/server/db/db.connection";
+import type { AppError } from "@/shared/core/errors/core/app-error.entity";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+import { Err, Ok } from "@/shared/core/result/result";
+import { ROUTES } from "@/shared/routing/routes";
+
+vi.mock("@/modules/users/infrastructure/factories/user-service.factory");
+vi.mock("@/server/db/db.connection");
+vi.mock(
+	"@/modules/auth/presentation/session/guards/session-access.guard",
+	() => ({
+		requireAdmin: vi.fn().mockResolvedValue({
+			isAuthorized: true,
+			role: "ADMIN",
+			userId: "admin-1",
+		}),
+	}),
+);
+
+describe("deleteUserAction", () => {
+	// deleteUserAction calls the real `toUserId` mapper, which throws on
+	// non-UUID input, so the id under test must be a valid UserId string.
+	const validId = String(TEST_USER_ID);
+
+	const mockService = {
+		deleteUser: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(createUserService as Mock).mockReturnValue(mockService);
+		(getAppDb as Mock).mockReturnValue({});
+	});
+
+	it("redirects to the users list on success instead of returning a result", async () => {
+		mockService.deleteUser.mockResolvedValue(Ok(makeUserEntity()));
+
+		// Regression guard: redirect() now lives outside the try/catch, so its
+		// NEXT_REDIRECT control-flow error propagates. Previously the catch
+		// swallowed it and returned an "unexpected" FormResult on the success path.
+		const redirectedTo = await runAndCaptureRedirectPath(
+			deleteUserAction(validId),
+		);
+
+		expect(redirectedTo).toBe(ROUTES.dashboard.users);
+
+		const { revalidatePath } = await import("next/cache");
+		expect(revalidatePath).toHaveBeenCalledWith(ROUTES.dashboard.users);
+	});
+
+	it("returns a not-found error without redirecting when deletion fails", async () => {
+		const serviceError = {
+			key: APP_ERROR_KEYS.not_found,
+			message: "User not found",
+		} as unknown as AppError;
+		mockService.deleteUser.mockResolvedValue(Err(serviceError));
+
+		const result = await deleteUserAction(validId);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.key).toBe(APP_ERROR_KEYS.not_found);
+		}
+
+		const { redirect } = await import("next/navigation");
+		expect(redirect).not.toHaveBeenCalled();
+	});
+
+	it("returns an unexpected error when the service throws", async () => {
+		mockService.deleteUser.mockRejectedValue(new Error("boom"));
+
+		const result = await deleteUserAction(validId);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.key).toBe(APP_ERROR_KEYS.unexpected);
+			expect(result.error.message).toBe(USER_ERROR_MESSAGES.unexpected);
+		}
+	});
+
+	it("enforces admin authorization before deleting", async () => {
+		mockService.deleteUser.mockResolvedValue(Ok(makeUserEntity()));
+
+		await runAndCaptureRedirectPath(deleteUserAction(validId));
+
+		expect(requireAdmin).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/modules/users/presentation/actions/delete-user.action.ts
+++ b/src/modules/users/presentation/actions/delete-user.action.ts
@@ -25,22 +25,19 @@ export async function deleteUserAction(id: string): Promise<FormResult<never>> {
 
 		const result = await service.deleteUser(toUserId(id));
 
-		if (result.ok) {
-			revalidatePath(ROUTES.dashboard.users);
-			redirect(ROUTES.dashboard.users);
+		if (!result.ok) {
+			return makeFormError<"_root">({
+				fieldErrors: {
+					_root: [
+						result.error.message || USER_ERROR_MESSAGES.notFoundOrDeleteFailed,
+					],
+				},
+				formData: {} as Readonly<Partial<Record<"_root", string>>>,
+				formErrors: [],
+				key: APP_ERROR_KEYS.not_found,
+				message: USER_ERROR_MESSAGES.notFoundOrDeleteFailed,
+			});
 		}
-
-		return makeFormError<"_root">({
-			fieldErrors: {
-				_root: [
-					result.error.message || USER_ERROR_MESSAGES.notFoundOrDeleteFailed,
-				],
-			},
-			formData: {} as Readonly<Partial<Record<"_root", string>>>,
-			formErrors: [],
-			key: APP_ERROR_KEYS.not_found,
-			message: USER_ERROR_MESSAGES.notFoundOrDeleteFailed,
-		});
 	} catch (_error: unknown) {
 		return makeFormError<"_root">({
 			fieldErrors: { _root: [USER_ERROR_MESSAGES.unexpected] },
@@ -50,4 +47,11 @@ export async function deleteUserAction(id: string): Promise<FormResult<never>> {
 			message: USER_ERROR_MESSAGES.unexpected,
 		});
 	}
+
+	// Success path: revalidate + redirect OUTSIDE the try/catch. Next's
+	// redirect() signals by throwing a NEXT_REDIRECT control-flow error; keeping
+	// it out of the try prevents the catch above from swallowing that signal and
+	// returning an "unexpected" FormResult on what is actually the success path.
+	revalidatePath(ROUTES.dashboard.users);
+	redirect(ROUTES.dashboard.users);
 }


### PR DESCRIPTION
## Summary

`deleteUserAction` called `redirect(ROUTES.dashboard.users)` **inside** its `try` block. Next.js's `redirect()` signals by throwing a `NEXT_REDIRECT` control-flow error, which the action's `catch` caught and converted into an "unexpected error" `FormResult` — so the explicit success redirect was effectively dead code and the action returned an *error* result on its success path.

The bug was masked at runtime: `revalidatePath` refreshed the list before the redirect, and the only caller (`deleteUserFormAction`) ignores the returned `FormResult` — so the list still appeared to update and users saw the right outcome by accident.

**Fix:** invert the `result.ok` check to early-return the not-found error inside the `try`, then move `revalidatePath` + `redirect` to the success path **after** the `try/catch`, so the `NEXT_REDIRECT` throw propagates to Next. The `requireAdmin()` guard is unchanged (still above the try).

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor (no behaviour change)
- [ ] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen)
- [x] `pnpm test` (unit) — full unit suite green (145 tests across 20 files)
- [ ] `pnpm cy:e2e` (end-to-end)
- [ ] Manually verified in the running app

New `delete-user.action.test.ts` covers four cases: the success redirect (asserted via the project's `runAndCaptureRedirectPath` helper), the not-found path, the unexpected-error path, and admin enforcement. The success-redirect test was confirmed to **fail against the pre-fix code** (it threw `Expected NEXT_REDIRECT to be thrown`), proving it's a genuine regression guard rather than a tautology.

## Notes for the reviewer

- `delete-invoice-form.action.ts` has a similar shape, but its `redirect()` is already outside any `try`, so it's correct as-is — confirmed, no change needed. A sweep of all `*.action.ts` found `delete-user` was the **only** action with a `redirect()` inside a `catch`.
- The fix relies on Next's `redirect()` being typed `never`, so the function still satisfies its `Promise<FormResult<never>>` return type with the redirect as the final statement (no trailing `return` needed).
- The test passes a valid UUID (`TEST_USER_ID` fixture) because the action calls the real `toUserId` mapper, which throws on non-UUID input.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `.aiassistant/rules/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (n/a — internal control-flow fix; no API, behaviour-contract, or setup change)
- [x] Focused change — preserves existing patterns and user-authored work (dev-server `launch.json` and a scratch `TODO.md` were deliberately left out of this PR)
