### PR TITLE
fix(invoices): show empty results instead of erroring on no-match search

### DIFF
--- a/src/modules/invoices/__tests__/unit/infrastructure/repository/dal/fetch-filtered-invoices.dal.test.ts
+++ b/src/modules/invoices/__tests__/unit/infrastructure/repository/dal/fetch-filtered-invoices.dal.test.ts
@@ -1,0 +1,25 @@
+import { makeReadQueryDb } from "@test-support/mocks/drizzle-db.mock";
+import { describe, expect, it } from "vitest";
+import { fetchFilteredInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-filtered-invoices.dal";
+
+describe("fetchFilteredInvoicesDal", () => {
+	it("returns an empty array when no invoices match the query (does not throw)", async () => {
+		// Regression guard: searching a term with no matches (e.g. "potato") used
+		// to throw, which surfaced as the "Invoice Error" boundary. An empty
+		// result is a valid outcome, not an error.
+		const db = makeReadQueryDb([]);
+
+		const result = await fetchFilteredInvoicesDal(db, "potato", 1);
+
+		expect(result).toEqual([]);
+	});
+
+	it("returns the matched rows when the query has results", async () => {
+		const rows = [{ id: "11111111-1111-4111-8111-111111111111", name: "Acme" }];
+		const db = makeReadQueryDb(rows);
+
+		const result = await fetchFilteredInvoicesDal(db, "Acme", 1);
+
+		expect(result).toEqual(rows);
+	});
+});

--- a/src/modules/invoices/__tests__/unit/infrastructure/repository/dal/fetch-invoices-pages.dal.test.ts
+++ b/src/modules/invoices/__tests__/unit/infrastructure/repository/dal/fetch-invoices-pages.dal.test.ts
@@ -1,0 +1,25 @@
+import { makeReadQueryDb } from "@test-support/mocks/drizzle-db.mock";
+import { describe, expect, it } from "vitest";
+import { fetchInvoicesPagesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-invoices-pages.dal";
+import { ITEMS_PER_PAGE } from "@/ui/navigation/pagination/pagination.constants";
+
+describe("fetchInvoicesPagesDal", () => {
+	it("returns 1 page when no invoices match the query (does not throw)", async () => {
+		// Regression guard: count() returns 0 for a no-match search, and the old
+		// `if (!total ...)` guard threw on that 0. The 1-page floor is correct.
+		const db = makeReadQueryDb([{ count: 0 }]);
+
+		const result = await fetchInvoicesPagesDal(db, "potato");
+
+		expect(result).toBe(1);
+	});
+
+	it("computes the page count from the number of matches", async () => {
+		const matches = ITEMS_PER_PAGE * 3 + 1;
+		const db = makeReadQueryDb([{ count: matches }]);
+
+		const result = await fetchInvoicesPagesDal(db, "Acme");
+
+		expect(result).toBe(4);
+	});
+});

--- a/src/modules/invoices/infrastructure/repository/dal/fetch-filtered-invoices.dal.ts
+++ b/src/modules/invoices/infrastructure/repository/dal/fetch-filtered-invoices.dal.ts
@@ -2,10 +2,8 @@ import "server-only";
 import { customers } from "@database/schema/customers";
 import { invoices } from "@database/schema/invoices";
 import { desc, eq, ilike, or, sql } from "drizzle-orm";
-import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
 import type { InvoiceListFilter } from "@/modules/invoices/domain/invoice.types";
 import type { AppDatabase } from "@/server/db/db.connection";
-import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
 import { ITEMS_PER_PAGE } from "@/ui/navigation/pagination/pagination.constants";
 
 /**
@@ -63,14 +61,8 @@ export async function fetchFilteredInvoicesDal(
 		.limit(ITEMS_PER_PAGE)
 		.offset(offset);
 
-	// TODO: Refactor. Empty result does not mean that an error occurred.
-	if (!data || data.length === 0) {
-		throw makeAppError("database", {
-			cause: "",
-			message: INVOICE_MSG.fetchFilteredFailed,
-			metadata: {},
-		});
-	}
-
+	// An empty result is a valid "no matches" outcome, not an error. Drizzle's
+	// .select() always returns an array, so returning it directly lets the
+	// caller render an empty table instead of an error boundary.
 	return data;
 }

--- a/src/modules/invoices/infrastructure/repository/dal/fetch-invoices-pages.dal.ts
+++ b/src/modules/invoices/infrastructure/repository/dal/fetch-invoices-pages.dal.ts
@@ -2,9 +2,7 @@ import "server-only";
 import { customers } from "@database/schema/customers";
 import { invoices } from "@database/schema/invoices";
 import { count, eq, ilike, or, sql } from "drizzle-orm";
-import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
 import type { AppDatabase } from "@/server/db/db.connection";
-import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
 import { ITEMS_PER_PAGE } from "@/ui/navigation/pagination/pagination.constants";
 
 /**
@@ -47,15 +45,8 @@ export async function fetchInvoicesPagesDal(
 			),
 		);
 
-	// TODO: Refactor. Empty result does not mean that an error occurred.
-	if (!total || total < 0) {
-		throw makeAppError("database", {
-			cause: "",
-			message: INVOICE_MSG.fetchPagesFailed,
-			metadata: {},
-		});
-	}
-
+	// A zero count means "no matches", not a failure — count() never returns a
+	// negative or null. Math.max below already yields the 1-page floor.
 	// Always return at least 1 page for UX consistency
 	const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
 

--- a/test-support/mocks/drizzle-db.mock.ts
+++ b/test-support/mocks/drizzle-db.mock.ts
@@ -1,0 +1,41 @@
+import type { AppDatabase } from "@/server/db/db.connection";
+
+/** A chainable, awaitable stand-in for a Drizzle select query builder. */
+type QueryChain = Promise<readonly unknown[]> & Record<string, unknown>;
+
+/**
+ * Minimal chainable stand-in for a Drizzle select query builder.
+ *
+ * The returned object is a real Promise that resolves to `rows`, with every
+ * builder method (`select`, `from`, `where`, joins, `orderBy`, `limit`,
+ * `offset`, …) attached as a no-op that returns the same object. So
+ * `await db.select(...).from(...)....offset(...)` resolves to `rows` no matter
+ * which builder methods a DAL calls — letting unit tests exercise the JS logic
+ * around a single read query (guards, mapping, pagination math) with no live
+ * database.
+ *
+ * Single-query reads only: the whole chain resolves to the same `rows`.
+ */
+export function makeReadQueryDb(rows: readonly unknown[]): AppDatabase {
+	const chain = Promise.resolve(rows) as QueryChain;
+
+	const methods = [
+		"select",
+		"from",
+		"where",
+		"innerJoin",
+		"leftJoin",
+		"rightJoin",
+		"orderBy",
+		"groupBy",
+		"having",
+		"limit",
+		"offset",
+	] as const;
+
+	for (const method of methods) {
+		chain[method] = (): QueryChain => chain;
+	}
+
+	return chain as unknown as AppDatabase;
+}


### PR DESCRIPTION
## Summary

Searching the invoices list for any term with **no matches** — e.g. `potato`, or a value whose invoice was just deleted — rendered the *"Something went wrong! / Invoice Error"* boundary instead of an empty table.

Both data-access functions treated an empty query result as a database failure and threw an `AppError` (each even carried a `// TODO: Refactor. Empty result does not mean that an error occurred.` comment):

- `fetchFilteredInvoicesDal` — threw on `data.length === 0`.
- `fetchInvoicesPagesDal` — threw on `!total`, which is `true` when `count()` returns `0` for a no-match search (so even the pagination count blew up independently).

**Fix:** remove both throws. An empty result is a valid outcome — Drizzle's `.select()` always returns an array, and `count()` never returns null/negative. The filtered DAL returns the empty array (→ empty table); the pages DAL's existing `Math.max(totalPages, 1)` already yields the 1-page floor. Dropped the now-unused `makeAppError` / `INVOICE_MSG` imports from both files.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor (no behaviour change)
- [ ] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen)
- [x] `pnpm test` (unit) — full suite green (149 tests across 22 files)
- [ ] `pnpm cy:e2e` (end-to-end)
- [ ] Manually verified in the running app

Added unit tests for both DALs covering the no-match case (`fetchFilteredInvoicesDal` returns `[]`; `fetchInvoicesPagesDal` returns `1`) plus the happy path. These reproduce the exact scenario from the bug report and fail against the pre-fix throwing code.

## Notes for the reviewer

- The invoices module previously had **no DAL tests** — this adds the first, along with a small reusable `@test-support/mocks/drizzle-db.mock` (`makeReadQueryDb`) chainable query-builder double that future invoice/customer/user DAL tests can use.
- Browser verification wasn't driven because `/dashboard/invoices` is auth-gated, but the unit tests exercise the precise empty-result path that was throwing. Happy to do a demo-login walkthrough if you'd like it in the PR.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `.aiassistant/rules/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (n/a — bugfix; no API or setup change)
- [x] Focused change — preserves existing patterns and user-authored work
