### PR TITLE
docs(auth): document action-level authorization (PR #31)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ command / query split — that the rest of the codebase follows too.
 | [004 — Strip passwords at the application boundary](../src/modules/auth/notes/adr/004-strip-passwords-at-application-boundary.md) | "Where do password hashes get dropped as data moves up the layers?" |
 | [005 — JWT for session tokens](../src/modules/auth/notes/adr/005-use-jwt-for-session-tokens.md) | "Why stateless JWT-in-cookie sessions instead of a server-side store?" |
 | [006 — Prevent credential enumeration](../src/modules/auth/notes/adr/006-prevent-credential-enumeration.md) | "How does login avoid leaking whether an email is registered?" |
+| [007 — Enforce action-level authorization](../src/modules/auth/notes/adr/007-enforce-action-level-authorization.md) | "Why do server actions check auth themselves when the middleware already gates routes?" |
 
 ## Keeping them honest
 

--- a/docs/diagrams/route-authorization.md
+++ b/docs/diagrams/route-authorization.md
@@ -106,3 +106,28 @@ layer **before** that: the edge gate that runs on every navigation and decides
 whether the request is even allowed through. Same JWT, different moment — the gate
 is the bouncer at the door; the optimistic check is the host double-checking your
 wristband once you're inside.
+
+## A second layer: server actions guard themselves
+
+The gate above protects **navigations** — it decides whether a *page* may render.
+But Next.js Server Actions are independently invocable RPC endpoints: a crafted
+request can call an action without ever loading the page that hosts it, so the
+gate alone doesn't protect them. Each sensitive action therefore enforces its own
+authorization as a second layer (defense in depth), via two guards in
+[`session-access.guard.ts`](../../src/modules/auth/presentation/session/guards/session-access.guard.ts):
+
+- **`requireSession()`** — any valid session; used by the invoice mutations.
+- **`requireAdmin()`** — an admin session; used by every user action (the
+  mutations *and* the PII-exposing reads).
+
+Both reuse the same `verifySessionOptimistic()` check the gate's optimistic
+sibling uses, so there's one source of truth for the session. The reasoning — why
+actions need their own check, and why a denial `redirect()`s rather than rendering
+`forbidden()` — is in
+[ADR-007](../../src/modules/auth/notes/adr/007-enforce-action-level-authorization.md);
+the auth module's
+[presentation README](../../src/modules/auth/presentation/README.md#authorization-guards)
+documents the guards in detail.
+
+> So: the **gate** stops you at the door (route), and the **guards** check your
+> wristband again at each ride (action). Same session, two enforcement points.

--- a/src/modules/auth/notes/adr/007-enforce-action-level-authorization.md
+++ b/src/modules/auth/notes/adr/007-enforce-action-level-authorization.md
@@ -1,0 +1,71 @@
+# ADR 007: Enforce Authorization at the Server-Action Level
+
+## Status
+
+Accepted
+
+## Context
+
+Route protection lives in the edge middleware (`src/proxy.ts`): it classifies
+each path as public / protected / admin and redirects unauthorized requests
+before a page renders (see the
+[route-authorization diagram](../../../../../docs/diagrams/route-authorization.md)).
+
+But Next.js Server Actions are **independently invocable RPC endpoints**. A
+crafted request can reach an action without navigating through the page that
+hosts it, so the route-level checks are not sufficient on their own. Without an
+action-level check, a signed-in non-admin could replay a user-management action
+(create / update / delete, or a user read) against a route they can reach and
+escalate privileges — or read user PII directly.
+
+## Decision
+
+Each sensitive server action enforces its own authorization, as a second layer
+beneath the route gate (defense in depth). Two guards live in
+[`session/guards/session-access.guard.ts`](../../presentation/session/guards/session-access.guard.ts):
+
+- **`requireSession()`** — requires any valid session; redirects to login when
+  none exists. Used by the invoice mutations (create / update / delete).
+- **`requireAdmin()`** — requires an admin session; redirects to login when
+  unauthenticated and to the dashboard root when authenticated without the admin
+  role. Used by every user action — create / update / delete **and** the user
+  reads (which expose PII). The `delete-user-form` wrapper inherits the guard by
+  delegating to the guarded core action.
+
+Two supporting choices:
+
+- **Reuse the optimistic check.** Both guards call `verifySessionOptimistic()`,
+  the canonical session check, so there is one source of truth for "is there a
+  session." It is wrapped in React `cache`, so repeated guard calls within a
+  single request collapse to one verification.
+- **Redirect, don't `forbidden()`.** A denied guard `redirect()`s rather than
+  rendering Next's `forbidden()` / `unauthorized()`, matching the existing
+  convention (`verifySessionOptimistic` already redirects to login; there are no
+  `forbidden.tsx` / `unauthorized.tsx` pages). `authInterrupts` is enabled in
+  `next.config.ts`, so switching to a real `403` is a clean future upgrade.
+
+Guards are placed **above** each action's `try/catch`, so the `NEXT_REDIRECT`
+control-flow error a guard throws propagates to Next instead of being swallowed
+by the catch and reported as a generic error.
+
+Customer reads and invoice reads are deliberately **not** guarded at the action
+level: they are lower-sensitivity and remain behind the route middleware.
+
+## Consequences
+
+### Positive
+
+- **Closes a privilege-escalation / PII-read gap** — role-restricted operations
+  are enforced at the action, the real boundary, not just at the page.
+- **Single source of truth** — guards reuse the one optimistic session check, so
+  there is no parallel auth logic to drift out of sync.
+- **Composable** — authorization is a one-line guard call at the top of an
+  action; form wrappers inherit it by delegating to the guarded core action.
+
+### Negative
+
+- **Per-action discipline** — a new sensitive action must remember to add the
+  right guard; nothing yet fails the build if it forgets.
+- **Redirect, not 403** — a denied non-admin is bounced to the dashboard rather
+  than shown an explicit "forbidden" page (acceptable until `forbidden()` is
+  adopted).

--- a/src/modules/auth/presentation/README.md
+++ b/src/modules/auth/presentation/README.md
@@ -132,9 +132,11 @@ presentation/
 │       ├── login.transport.ts
 │       └── signup.transport.ts
 │
-├── session/                        # Session UI
+├── session/                        # Session UI + authorization guards
 │   ├── actions/
 │   │   └── verify-session-optimistic.action.ts
+│   ├── guards/                     # Server-action authorization
+│   │   └── session-access.guard.ts # requireSession() / requireAdmin()
 │   ├── components/                 # (Empty - future session UI)
 │   └── features/
 │       └── session-refresh.tsx
@@ -224,6 +226,33 @@ Terminates current session.
 **Input:** None  
 **Success:** Redirect to login  
 **Errors:** Session termination failed
+
+---
+
+## Authorization Guards
+
+Server Actions are independently invocable RPC endpoints — a crafted request can
+reach an action without going through the page that hosts it — so the route
+checks in `proxy.ts` (middleware) are not sufficient on their own. The guards in
+[`session/guards/session-access.guard.ts`](session/guards/session-access.guard.ts)
+make each sensitive action enforce its own authorization (defense in depth).
+
+| Guard | Requires | Redirects when denied | Used by |
+|---|---|---|---|
+| `requireSession()` | any valid session | login | invoice mutations (create / update / delete) |
+| `requireAdmin()` | an **admin** session | login (anon) · dashboard root (non-admin) | every user action — create / update / delete **and** the user reads (PII) |
+
+Both reuse `verifySessionOptimistic()` (the canonical session check, wrapped in
+React `cache`), so there is one source of truth for "is there a session" and
+repeated guard calls in a request collapse to a single verification.
+
+**Placement matters:** call the guard **above** the action's `try/catch`. A denied
+guard signals by `redirect()`-ing (a thrown `NEXT_REDIRECT`); inside a `try` that
+catches everything, that throw would be swallowed and reported as a generic error.
+See [ADR-007](../notes/adr/007-enforce-action-level-authorization.md) for the
+decision, and the
+[route-authorization diagram](../../../../docs/diagrams/route-authorization.md)
+for how this layers under the route gate.
 
 ---
 
@@ -478,6 +507,7 @@ describe("loginAction", () => {
 ## Related Documentation
 
 - **[Application Layer](../application/README.md)**: Workflows called by Server Actions
+- **[Route authorization](../../../../docs/diagrams/route-authorization.md)**: The edge-middleware route gate; the action guards above are the second layer
 - **[Auth Flows](../../../../docs/diagrams/auth-login-flow.md)**: Login, signup & session-check flows (diagram)
 - **[Error Handling](../../../../docs/diagrams/error-handling-flow.md)**: Error handling flow (diagram)
 
@@ -631,5 +661,5 @@ Changes to Server Action signatures or form field names are breaking changes. Co
 
 ---
 
-**Last Updated**: 2026-02-01  
+**Last Updated**: 2026-06-09  
 **Maintainer**: Auth Module Team

--- a/src/modules/invoices/README.md
+++ b/src/modules/invoices/README.md
@@ -162,6 +162,16 @@ won't type-check where an ID is expected. Convert at the boundary with
   `translator()` (`domain/i18n/`); domain/infra errors are mapped to a message via
   `toInvoiceErrorMessage()`.
 
+### Authorization
+
+The three mutations (create / update / delete) call `requireSession()` at the top
+of their action, above the `try/catch` — Server Actions are invocable on their
+own, so the route middleware isn't enough. The **reads** (filtered list, page
+count, latest, totals) are deliberately left unguarded at the action level: they
+sit behind the dashboard route gate and are lower-sensitivity. See the auth
+module's [authorization guards](../auth/presentation/README.md#authorization-guards)
+and [ADR-007](../auth/notes/adr/007-enforce-action-level-authorization.md).
+
 ---
 
 ## Layer responsibilities
@@ -246,4 +256,4 @@ Kept honest on purpose — a doc that hides the warts isn't worth much.
 
 ---
 
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-09

--- a/src/modules/users/README.md
+++ b/src/modules/users/README.md
@@ -147,6 +147,17 @@ They share the same user records and the same shared primitives
 `@/shared/policies/{email,password,username}`), but neither imports the other's
 use-cases.
 
+### Authorization: admin-only, enforced per action
+
+Every server action in this module — the create / update / delete commands **and**
+the three reads (which expose user PII) — calls `requireAdmin()` at the top, above
+its `try/catch`. The `/dashboard/users` route is already admin-gated by the
+middleware, but actions are independently invocable, so each one re-checks. The
+`delete-user-form` wrapper inherits the guard by delegating to the guarded delete
+action. See the auth module's
+[authorization guards](../auth/presentation/README.md#authorization-guards) and
+[ADR-007](../auth/notes/adr/007-enforce-action-level-authorization.md).
+
 ### Ports and adapters (dependency inversion)
 
 The service depends only on `UserRepositoryContract`, never on a concrete class.
@@ -278,4 +289,4 @@ in the service, the DAL functions, and the update/delete actions are not yet uni
 
 ---
 
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-09


### PR DESCRIPTION
## Summary

The action-level authorization feature merged in #31 (`requireSession` / `requireAdmin` guards on the invoice/user server actions) shipped with **no documentation** — no markdown file mentioned the guards, even though this repo documents authorization heavily (a dedicated route-authorization diagram, six auth ADRs). This PR closes that gap.

What changed:

- **New ADR-007** (`src/modules/auth/notes/adr/007-enforce-action-level-authorization.md`) — records the decision: enforce authz in each sensitive action (defense in depth beneath the route gate), reuse `verifySessionOptimistic()` as the single source of truth, and `redirect()` rather than Next's `forbidden()` (with `authInterrupts` noted as the future-upgrade path).
- **`auth/presentation/README.md`** — was factually stale: its `session/` directory tree omitted the new `session/guards/` folder. Added the folder, a new **Authorization Guards** section (`requireSession` vs `requireAdmin`, and the "guard must sit above the `try/catch`" rule so the `NEXT_REDIRECT` isn't swallowed), a route-authorization cross-link, and refreshed the date.
- **`docs/diagrams/route-authorization.md`** — added a "second layer: server actions guard themselves" section so the doc no longer implies authorization is middleware-only.
- **`users/README.md` & `invoices/README.md`** — noted that user actions are admin-only and invoice mutations require a session (and that invoice/customer reads are *deliberately* unguarded at the action level).
- **`docs/README.md`** — indexed ADR-007 alongside 001–006.

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor (no behaviour change)
- [x] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen) — clean
- [ ] `pnpm test`
- [ ] `pnpm cy:e2e`
- [ ] Manually verified in the running app

Docs-only — no behaviour change. I verified the guard facts against the source (`session-access.guard.ts` and every call site: all 6 user core actions use `requireAdmin`; the 3 invoice mutations use `requireSession`; reads are unguarded) and ran a link checker over the six files — **71 relative links, 0 broken**.

## Notes for the reviewer

- This was found while auditing why recent sessions left docs untouched; the feature was the one real gap. No code is touched here.
- All cross-links between the new ADR, the diagram, and the module READMEs were path-checked (the ADR sits one directory deeper than the presentation README, so its `docs/` links use one extra `../`).

## Checklist

- [x] Follows the rules in `AGENTS.md` and `.aiassistant/rules/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (this PR *is* the doc update)
- [x] Focused change — preserves existing patterns and user-authored work
