### PR TITLE
feat(deploy): standalone Docker stack, health endpoint, and deployment guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Keep the build context small and free of secrets / build artifacts.
+
+# Dependencies and build output (reinstalled/rebuilt inside the image)
+node_modules
+.next
+out
+build
+coverage
+
+# Secrets and local env (env is injected at runtime, never baked in)
+.env
+.env.*
+!.env.example.local
+
+# VCS and tooling
+.git
+.gitignore
+.github
+.claude
+.aiassistant
+.idea
+.vscode
+
+# Tests and e2e (not needed to build the production server)
+cypress
+**/*.test.ts
+**/*.spec.ts
+vitest.config.ts
+vitest.workspace.ts
+
+# Docs and misc
+docs
+diagrams
+*.md
+!README.md
+Dockerfile
+.dockerignore
+docker-compose.yml
+npm-debug.log*
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,84 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build that produces a small, self-contained image for the
+# Next.js app using `output: "standalone"` (set in next.config.ts).
+#
+# Why standalone: Next traces exactly the files the server needs and emits a
+# minimal `server.js`, so the runtime image carries no pnpm, no dev deps, and
+# only the production node_modules it actually uses.
+#
+# This image is host-agnostic: it talks to any Postgres over DATABASE_URL.
+# See docker-compose.yml for a one-command local stack (app + Postgres).
+
+##############################
+# base: Node + pnpm (corepack)
+##############################
+FROM node:26-alpine AS base
+# `libc6-compat` covers the glibc shims some Node binaries expect on Alpine.
+RUN apk add --no-cache libc6-compat
+# Node 25+ no longer bundles corepack, so install it, then let it provide the
+# exact pnpm pinned in package.json "packageManager". Never prompt to download.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN npm install -g corepack@latest && corepack enable
+WORKDIR /app
+
+##############################
+# deps: install node_modules
+##############################
+FROM base AS deps
+# Skip Cypress's large binary download — it's an e2e tool, never needed to
+# build or run the production server.
+ENV CYPRESS_INSTALL_BINARY=0
+# pnpm-workspace.yaml carries overrides + onlyBuiltDependencies, so it must be
+# present or --frozen-lockfile rejects the install as out of sync.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+##############################
+# builder: compile the app
+##############################
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+# Build-time env. The env layer (src/shared/core/config) validates these when
+# server modules are imported during `next build`, so they must be present and
+# well-formed. The secret-shaped ones are PLACEHOLDERS — real values are
+# injected at runtime by docker-compose / your host. NEXT_PUBLIC_* values are
+# inlined into the client bundle at build time, so set their real values here.
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV DATABASE_ENV=production
+ENV LOG_LEVEL=info
+ENV NEXT_PUBLIC_NODE_ENV=production
+ENV NEXT_PUBLIC_LOG_LEVEL=info
+ENV SESSION_ISSUER=my-app
+ENV SESSION_AUDIENCE=web
+ENV AUTH_BCRYPT_SALT_ROUNDS=12
+ENV SESSION_SECRET=build-time-placeholder-overridden-at-runtime
+ENV DATABASE_URL=postgresql://build:build@localhost:5432/build
+RUN pnpm next:build
+
+##############################
+# runner: minimal runtime image
+##############################
+FROM base AS runner
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+# Bind to all interfaces so the container is reachable from the host/network.
+ENV HOSTNAME=0.0.0.0
+
+# Run as an unprivileged user.
+RUN addgroup --system --gid 1001 nodejs \
+	&& adduser --system --uid 1001 nextjs
+
+# Standalone output, plus the static assets it expects to find beside it.
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+
+# Entry point emitted by Next's standalone output.
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Next.js Dashboard
 
+[![CI](https://github.com/andrewpetersondev/nextjs-dashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/andrewpetersondev/nextjs-dashboard/actions/workflows/ci.yml)
+
 A modern dashboard application built with Next.js (App Router), TypeScript, Drizzle ORM, and Tailwind CSS. It includes
 authentication, middleware-based route protection, database migrations/seeding, and end-to-end tests with Cypress.
 
-Last updated: 2026-04-02
+> **Live demo:** _add your Vercel URL here_ &nbsp;·&nbsp; **Demo login:** `admin@admin.com` / `AdminPassword123!`
+>
+> Run it yourself in one command: `docker compose up --build` → http://localhost:3000. See [Deployment](#deployment).
 
 ## Tech Stack
 
@@ -93,6 +97,31 @@ nextjs-dashboard/
       # or, if already built
       pnpm next:start:standalone
       ```
+
+## Deployment
+
+This app runs two ways from the same codebase — a managed deploy (Vercel + Neon)
+and a fully self-hosted Docker stack — with no platform lock-in. Full walkthrough,
+including the environment-variable contract, is in the
+**[deployment guide](docs/deployment.md)**.
+
+Self-host the whole thing (Postgres + schema + seed + app) in one command:
+
+```sh
+docker compose up --build
+# open http://localhost:3000/auth/login — sign in as admin@admin.com / AdminPassword123!
+```
+
+Seeded demo logins:
+
+| Role  | Email             | Password           |
+|-------|-------------------|--------------------|
+| Admin | admin@admin.com   | `AdminPassword123!` |
+| User  | user@user.com     | `UserPassword123!`  |
+| Guest | guest@guest.com   | `GuestPassword123!` |
+
+A `/api/health` endpoint returns `{ "status": "ok", "db": "up" }` for uptime
+checks and container health probes.
 
 ## Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,78 @@
+# One-command local stack: Postgres + schema/seed + the app.
+#
+#   docker compose up --build
+#   open http://localhost:3000/auth/login   (admin@admin.com / AdminPassword123!)
+#
+# Everything has sensible defaults so it runs with zero configuration. Override
+# any value via the shell or a .env file next to this compose file. This proves
+# the app is fully standalone — no Vercel, no Neon, just containers.
+
+# Shared runtime environment for the app and the migrate/seed job.
+x-app-env: &app-env
+  NODE_ENV: production
+  DATABASE_ENV: production
+  DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-app_password}@db:5432/${POSTGRES_DB:-nextjs_dashboard}
+  SESSION_SECRET: ${SESSION_SECRET:-local-demo-insecure-secret-change-me-0123456789abcdef}
+  AUTH_BCRYPT_SALT_ROUNDS: "12"
+  SESSION_ISSUER: my-app
+  SESSION_AUDIENCE: web
+  LOG_LEVEL: info
+  NEXT_PUBLIC_NODE_ENV: production
+  NEXT_PUBLIC_LOG_LEVEL: info
+
+services:
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-app}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-app_password}
+      POSTGRES_DB: ${POSTGRES_DB:-nextjs_dashboard}
+    ports:
+      # Host 5433 by default so it never collides with a local Postgres on 5432.
+      # The app reaches the DB over the compose network (db:5432); this mapping
+      # is only for connecting your own client from the host.
+      - "${DB_PORT:-5433}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-app} -d ${POSTGRES_DB:-nextjs_dashboard}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  # One-shot job: sync the schema to the fresh DB and seed demo data, then exit.
+  # Uses the `builder` stage because it carries drizzle-kit + tsx + source.
+  # `db:seed` only runs on an empty database (guarded), so re-ups are safe.
+  migrate:
+    build:
+      context: .
+      target: builder
+    depends_on:
+      db:
+        condition: service_healthy
+    environment: *app-env
+    command: sh -c "pnpm exec drizzle-kit push && pnpm db:seed"
+    restart: "no"
+
+  app:
+    build:
+      context: .
+      target: runner
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    environment: *app-env
+    ports:
+      - "${APP_PORT:-3000}:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/api/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+volumes:
+  pgdata:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,124 @@
+# Deployment
+
+This app runs two ways, from the same codebase:
+
+| | **A. Managed (Vercel + Neon)** | **B. Self-hosted (Docker)** |
+|---|---|---|
+| Best for | the always-on live demo | proving it runs anywhere, local dev parity |
+| Cost | $0 on free tiers | free locally; ~$4–6/mo on a VPS |
+| Ops | none | yours (host, TLS, backups) |
+| Database | Neon Postgres | Postgres container (or any Postgres) |
+
+The app is host-agnostic by design: it uses the standard `pg` driver and talks
+to any Postgres over `DATABASE_URL`, has no Vercel-specific APIs, and builds to
+a standalone Node server (`output: "standalone"`). Nothing below is locked in.
+
+---
+
+## Environment variables (the contract)
+
+All environments need these. Validation lives in
+`src/shared/core/config/` — the server **fails fast at startup** if any are
+missing or malformed, so set them all.
+
+| Variable | Example | Notes |
+|---|---|---|
+| `DATABASE_URL` | `postgresql://user:pass@host:5432/db` | Neon: append `?sslmode=require` |
+| `SESSION_SECRET` | (long random string) | generate with `openssl rand -base64 48` |
+| `AUTH_BCRYPT_SALT_ROUNDS` | `12` | positive integer |
+| `SESSION_ISSUER` | `my-app` | fixed value |
+| `SESSION_AUDIENCE` | `web` | fixed value |
+| `NODE_ENV` | `production` | |
+| `DATABASE_ENV` | `production` | selects the migration scope |
+| `LOG_LEVEL` | `info` | `trace`\|`debug`\|`info`\|`warn`\|`error` |
+| `NEXT_PUBLIC_NODE_ENV` | `production` | inlined into the client bundle at build |
+| `NEXT_PUBLIC_LOG_LEVEL` | `info` | inlined into the client bundle at build |
+
+**Demo logins** (created by the seed):
+
+| Role | Email | Password |
+|---|---|---|
+| Admin | `admin@admin.com` | `AdminPassword123!` |
+| User | `user@user.com` | `UserPassword123!` |
+| Guest | `guest@guest.com` | `GuestPassword123!` |
+
+---
+
+## A. Vercel + Neon (managed)
+
+The fastest path to a live URL. Steps marked 🔑 need your accounts.
+
+1. **🔑 Neon** — create a project, copy its pooled `DATABASE_URL`, and append
+   `?sslmode=require`.
+2. **Migrate + seed Neon from your machine** — put the Neon URL in
+   `.env.production.local`, then:
+   ```bash
+   pnpm db:migrate:prod   # apply schema
+   pnpm db:seed:prod      # demo data + logins (only seeds an empty DB)
+   ```
+3. **🔑 Vercel** — import the GitHub repo (Next.js is auto-detected). Add every
+   variable from the table above under Project → Settings → Environment
+   Variables.
+4. **Deploy** — Vercel builds on push to `main` and gives you a URL. Preview
+   deploys per PR are on by default.
+5. **Smoke test** — visit `/api/health` (expect `{"status":"ok","db":"up"}`),
+   then sign in with the demo admin login.
+6. **README** — add the live URL and CI badge.
+
+Good to know:
+- **Neon free tier scales to zero** when idle, so the *first* request after a
+  quiet period waits ~1s while the DB wakes. Fine for a demo.
+- **Vercel Hobby is non-commercial / personal use only** — a portfolio project
+  qualifies. Monetizing it would require Pro.
+
+---
+
+## B. Docker (self-hosted / standalone)
+
+### One command, locally
+
+```bash
+docker compose up --build
+# then open http://localhost:3000/auth/login  →  admin@admin.com / AdminPassword123!
+```
+
+This brings up three things: a **Postgres** container, a one-shot **migrate**
+job that syncs the schema and seeds the demo data, then the **app** on
+`:3000`. The seed only runs against an empty database, so re-running
+`docker compose up` is safe.
+
+```bash
+curl localhost:3000/api/health     # {"status":"ok","db":"up",...}
+docker compose down                # stop (keeps the DB volume)
+docker compose down -v             # stop and wipe the DB
+```
+
+Override any default via the shell or a `.env` file beside `docker-compose.yml`
+(`POSTGRES_PASSWORD`, `SESSION_SECRET`, `APP_PORT`, …).
+
+### Just the image (bring your own Postgres)
+
+```bash
+docker build -t nextjs-dashboard .
+docker run -p 3000:3000 --env-file .env.production.local nextjs-dashboard
+```
+
+Point `DATABASE_URL` at any reachable Postgres (managed or self-run).
+
+### Putting it on a server
+
+1. Build and push the image to a registry (or build on the host).
+2. Run Postgres (a managed instance or its own container with a backed-up
+   volume) and set `DATABASE_URL` to it.
+3. Apply schema with the migration workflow — **not** the demo `push`:
+   ```bash
+   pnpm db:migrate:prod
+   ```
+4. Put a TLS-terminating reverse proxy in front (Caddy is the least effort —
+   automatic HTTPS; Traefik or nginx + certbot also work).
+5. Point your domain at the host.
+
+> The compose `migrate` service uses `drizzle-kit push` because it targets a
+> throwaway demo database — it syncs the current schema directly without
+> depending on the migration history. A persistent production database should
+> use `pnpm db:migrate:prod` (ordered, reviewable migration files) instead.

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,29 @@
+import { sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { getAppDb } from "@/server/db/db.connection";
+
+/**
+ * Liveness/readiness probe.
+ *
+ * Pings the database with a trivial query so the endpoint reflects real
+ * connectivity, not just that the Node process is up. Returns 200 when the DB
+ * answers and 503 when it does not — suitable for a load balancer, container
+ * orchestrator (Docker `healthcheck`), or uptime monitor.
+ */
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(): Promise<NextResponse> {
+	try {
+		await getAppDb().execute(sql`select 1`);
+		return NextResponse.json(
+			{ db: "up", status: "ok", timestamp: new Date().toISOString() },
+			{ status: 200 },
+		);
+	} catch {
+		return NextResponse.json(
+			{ db: "down", status: "error", timestamp: new Date().toISOString() },
+			{ status: 503 },
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Makes the app deployable two ways from one codebase — managed (Vercel + Neon) and fully self-hosted via Docker — with **no changes to the app's own code**. The project was already host-agnostic (standard `pg` driver, no Vercel/edge APIs, `output: "standalone"` already set), so this wires up the packaging and docs around it.

- **Dockerfile** — multi-stage standalone build (`node:26-alpine`, non-root runtime). Installs corepack explicitly (Node 26 no longer bundles it), copies `pnpm-workspace.yaml` so `--frozen-lockfile` matches the lockfile, and skips the Cypress binary. Build-time placeholder env satisfies the startup env validation; real values are injected at runtime.
- **docker-compose.yml** — Postgres + a one-shot migrate/seed job + the app, so `docker compose up --build` is zero-config. DB is published on host **5433** to avoid colliding with a local Postgres on 5432.
- **.dockerignore** — keeps the build context lean and free of secrets.
- **src/app/api/health/route.ts** — GET pings the DB (`select 1`) and returns 200/503. Doubles as the container healthcheck and a deploy smoke test.
- **docs/deployment.md** — env-var contract, Vercel/Neon checklist, and Docker guide.
- **README** — CI badge, live-demo line, Deployment section, seeded demo logins.

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Refactor (no behaviour change)
- [x] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen) — green (Biome 589 files, tsc, typegen)
- [ ] `pnpm test` (unit)
- [ ] `pnpm cy:e2e` (end-to-end)
- [x] Manually verified in the running app — `docker compose up` → db/migrate/app all healthy; schema push + seed succeed; `/api/health` → 200; `/`=200, `/auth/login`=200, `/auth/signup`=200, `/dashboard`=307→`/auth/login` when anonymous

## Checklist

- [x] Follows the rules in `AGENTS.md` and `.aiassistant/rules/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed
- [x] Focused change — preserves existing patterns and user-authored work

## Notes for the reviewer

- Scope is the deploy **artifacts**, not a live URL (that needs Neon/Vercel accounts — step-by-step in `docs/deployment.md`) and not the CI Cypress e2e job (plan Phase 4; the fast lane is already green).
- The compose `migrate` job uses `drizzle-kit push` because it targets an ephemeral demo DB; a persistent production DB should use `pnpm db:migrate:prod` (noted in the deploy doc).
