### PR TITLE
fix(forms): serialize action state as plain DTO for progressive enhancement

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,12 +7,6 @@ this file is the deliberate workaround.)
 
 ## Open
 
-- [ ] **Server Action serialization** — the initial `useActionState` state in the auth
-  and invoice server actions carries an `Error` instance, so Next.js logs *"Failed to
-  serialize an action for progressive enhancement."* Forms work with JS, but no-JS
-  progressive enhancement is degraded. Fix: make the initial/error state a plain
-  serializable shape (not an `Error` class). Files: `src/modules/auth/presentation/**`,
-  `src/modules/invoices/presentation/**`. _(Recovered 2026-06-09 from a dismissed task chip.)_
 - [ ] **Weekly codemod routine** — scheduled Claude agent that checks Next.js/Biome
   releases, runs the codemods, verifies with `pnpm check:fast`, and opens a PR.
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
@@ -29,8 +23,12 @@ this file is the deliberate workaround.)
 - [ ] **TSConfig Version 6** - figure out how to use TSConfig Version 6.
 - [ ]  The allowCypressEnv configuration option is enabled. This allows any browser code to read values from
   Cypress.env(). This is insecure and will be removed in a future major version.
--
 
 ## Done
 
 <!-- Move finished items here with a date, or delete them. -->
+
+- [x] **Server Action serialization** _(2026-06-11)_ — `FormResult` now carries a plain
+  `AppErrorJsonDto` instead of an `AppError` instance across the `useActionState`
+  boundary, so Next.js can serialize form state for progressive enhancement. The
+  *"Failed to serialize an action for progressive enhancement"* warning is gone.

--- a/src/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper.ts
+++ b/src/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper.ts
@@ -9,12 +9,12 @@ import { isPgMetadata } from "@/shared/core/errors/core/metadata/error-metadata.
 
 import { PG_CODES } from "@/shared/core/errors/server/adapters/postgres/pg-error.constants";
 import { getPgConstraintFromAppError } from "@/shared/core/errors/server/adapters/postgres/pg-error.utils";
-import { Err } from "@/shared/core/result/result";
 import type {
 	FieldError,
 	SparseFieldErrorMap,
 } from "@/shared/forms/core/types/field-error.types";
 import type { FormResult } from "@/shared/forms/core/types/form-result.dto";
+import { toFormErrResult } from "@/shared/forms/logic/factories/form-result.factory";
 import { toDenseFieldErrorMap } from "@/shared/forms/logic/mappers/field-error-map.mapper";
 
 type SignupFormData = Readonly<Partial<Record<SignupField, string>>>;
@@ -76,7 +76,7 @@ export function toSignupFormResult(
 			SIGNUP_FIELDS_LIST,
 		);
 
-		return Err(
+		return toFormErrResult(
 			makeAppError(APP_ERROR_KEYS.conflict, {
 				cause: error,
 				message: "Value already in use",

--- a/src/shared/core/errors/__tests__/unit/app-error.entity.test.ts
+++ b/src/shared/core/errors/__tests__/unit/app-error.entity.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
-	_isAppErrorDto,
 	AppError,
 	isAppError,
+	isAppErrorDto,
 } from "@/shared/core/errors/core/app-error.entity";
 import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
 
@@ -93,11 +93,11 @@ describe("AppError entity", () => {
 		});
 	});
 
-	describe("_isAppErrorDto", () => {
+	describe("isAppErrorDto", () => {
 		it("accepts a real DTO and the minimal valid shape", () => {
-			expect(_isAppErrorDto(makeConflict().toDto())).toBe(true);
+			expect(isAppErrorDto(makeConflict().toDto())).toBe(true);
 			expect(
-				_isAppErrorDto({ _isAppError: true, key: "conflict", message: "m" }),
+				isAppErrorDto({ _isAppError: true, key: "conflict", message: "m" }),
 			).toBe(true);
 		});
 
@@ -108,7 +108,7 @@ describe("AppError entity", () => {
 			null,
 			"x",
 		])("rejects invalid DTO shape %p", (value) => {
-			expect(_isAppErrorDto(value)).toBe(false);
+			expect(isAppErrorDto(value)).toBe(false);
 		});
 	});
 });

--- a/src/shared/core/errors/core/app-error.dto.ts
+++ b/src/shared/core/errors/core/app-error.dto.ts
@@ -58,3 +58,14 @@ export type AppErrorJsonDto<T extends AppErrorMetadata = AppErrorMetadata> =
 			readonly metadata: T;
 		}
 	>;
+
+/**
+ * Structural supertype satisfied by both the `AppError` entity and its
+ * serialized {@link AppErrorJsonDto}. Use for code that inspects errors on
+ * either side of a Server Action boundary.
+ */
+export type AppErrorLike = Readonly<{
+	readonly key: AppErrorKey;
+	readonly message: string;
+	readonly metadata: AppErrorMetadata;
+}>;

--- a/src/shared/core/errors/core/app-error.entity.ts
+++ b/src/shared/core/errors/core/app-error.entity.ts
@@ -112,7 +112,7 @@ export function isAppError(val: unknown): val is AppError {
  * @param val - The value to check.
  * @returns `true` if `val` matches the shape of an `AppErrorJsonDto`, otherwise `false`.
  */
-export function _isAppErrorDto(val: unknown): val is AppErrorJsonDto {
+export function isAppErrorDto(val: unknown): val is AppErrorJsonDto {
 	if (typeof val !== "object" || val === null) {
 		return false;
 	}

--- a/src/shared/forms/core/guards/form-result.guard.ts
+++ b/src/shared/forms/core/guards/form-result.guard.ts
@@ -1,4 +1,4 @@
-import type { AppError } from "@/shared/core/errors/core/app-error.entity";
+import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
 import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
 import type { FormResult } from "@/shared/forms/core/types/form-result.dto";
 import type { FormValidationMetadata } from "@/shared/forms/core/types/validation.types";
@@ -22,11 +22,14 @@ const _isFormOk = <TData>(
 };
 
 /**
- * Type guard: checks if an AppError contains form validation details.
+ * Type guard: checks if an AppError (entity or serialized DTO) contains form
+ * validation details.
  */
 export function isFormValidationError<TFields extends string>(
-	error: AppError,
-): error is AppError & { readonly metadata: FormValidationMetadata<TFields> } {
+	error: AppErrorLike,
+): error is AppErrorLike & {
+	readonly metadata: FormValidationMetadata<TFields>;
+} {
 	return (
 		error.key === APP_ERROR_KEYS.validation &&
 		error.metadata !== undefined &&

--- a/src/shared/forms/core/types/form-result.dto.ts
+++ b/src/shared/forms/core/types/form-result.dto.ts
@@ -1,5 +1,5 @@
-import type { AppError } from "@/shared/core/errors/core/app-error.entity";
-import type { Result } from "@/shared/core/result/result.dto";
+import type { AppErrorJsonDto } from "@/shared/core/errors/core/app-error.dto";
+import type { OkResult } from "@/shared/core/result/result.dto";
 import type {
 	DenseFieldErrorMap,
 	FormErrors,
@@ -45,6 +45,19 @@ export type FormErrorPayload<T extends string> = {
 };
 
 /**
+ * Failed form submission carrying a serialized error.
+ *
+ * The error side holds an {@link AppErrorJsonDto} (plain object), not an
+ * `AppError` instance: form results cross the Server Action boundary via
+ * `useActionState`, and Next.js must be able to serialize them (e.g. for
+ * progressive enhancement of no-JS form posts). Class instances break that.
+ */
+export type FormErrResult = {
+	readonly error: AppErrorJsonDto;
+	readonly ok: false;
+};
+
+/**
  * Result type for form submissions, using standard Result.
  *
  * @typeParam T - The type of the data returned on success.
@@ -55,4 +68,4 @@ export type FormErrorPayload<T extends string> = {
  *   message: "User created successfully."
  * });
  */
-export type FormResult<T> = Result<FormSuccessPayload<T>, AppError>;
+export type FormResult<T> = OkResult<FormSuccessPayload<T>> | FormErrResult;

--- a/src/shared/forms/logic/factories/form-result.factory.ts
+++ b/src/shared/forms/logic/factories/form-result.factory.ts
@@ -1,6 +1,7 @@
+import type { AppError } from "@/shared/core/errors/core/app-error.entity";
 import type { AppErrorKey } from "@/shared/core/errors/core/catalog/app-error.registry";
 import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
-import { Err, Ok } from "@/shared/core/result/result";
+import { Ok } from "@/shared/core/result/result";
 import type {
 	DenseFieldErrorMap,
 	FormErrors,
@@ -24,10 +25,24 @@ interface FormErrorParams<TFields extends string> {
 }
 
 /**
+ * Wraps an AppError as a failed form result, serializing it to a plain DTO.
+ *
+ * Form results cross the Server Action boundary (`useActionState`), so the
+ * error must be a plain object — an `AppError` instance would break Next.js
+ * serialization for progressive enhancement.
+ *
+ * @param error - The AppError to serialize into the result.
+ * @returns A frozen failed FormResult carrying the error as a DTO.
+ */
+export const toFormErrResult = (error: AppError): FormResult<never> => {
+	return Object.freeze({ error: error.toDto(), ok: false as const });
+};
+
+/**
  * Create a form validation error result.
  *
  * @param params - Error construction parameters including fields and form-level errors.
- * @returns A Result containing an AppError with validation metadata.
+ * @returns A Result containing a serialized AppError with validation metadata.
  */
 export const makeFormError = <TFields extends string>(
 	params: FormErrorParams<TFields>,
@@ -38,7 +53,7 @@ export const makeFormError = <TFields extends string>(
 		formErrors: params.formErrors,
 	});
 
-	return Err(
+	return toFormErrResult(
 		makeAppError(params.key, {
 			cause: "",
 			message: params.message,

--- a/src/shared/forms/logic/factories/form-state.factory.ts
+++ b/src/shared/forms/logic/factories/form-state.factory.ts
@@ -1,9 +1,9 @@
 import type { ZodObject, ZodRawShape } from "zod";
 import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
-import { Err } from "@/shared/core/result/result";
 import { EMPTY_FORM_ERRORS } from "@/shared/forms/core/constants";
 import type { DenseFieldErrorMap } from "@/shared/forms/core/types/field-error.types";
 import type { FormResult } from "@/shared/forms/core/types/form-result.dto";
+import { toFormErrResult } from "@/shared/forms/logic/factories/form-result.factory";
 import { toSchemaKeys } from "@/shared/forms/logic/inspectors/zod-schema.inspector";
 import { makeEmptyDenseFieldErrorMap } from "@/shared/forms/logic/mappers/field-error-map.mapper";
 
@@ -11,6 +11,10 @@ import { makeEmptyDenseFieldErrorMap } from "@/shared/forms/logic/mappers/field-
  * Creates the initial form state with empty field errors.
  * This is technically a "failed" result (Err) to satisfy useActionState requirements
  * before the first submission, but with empty messages.
+ *
+ * The state is a plain serializable object (error as DTO): Next.js encodes the
+ * initial state into the rendered form for progressive enhancement, which fails
+ * on class instances.
  */
 export function makeInitialFormState<T extends string>(
 	fieldNames: readonly T[],
@@ -28,7 +32,7 @@ export function makeInitialFormState<T extends string>(
 		}),
 	});
 
-	return Err(error);
+	return toFormErrResult(error);
 }
 
 /**

--- a/src/shared/forms/logic/inspectors/form-error.inspector.ts
+++ b/src/shared/forms/logic/inspectors/form-error.inspector.ts
@@ -1,4 +1,4 @@
-import type { AppError } from "@/shared/core/errors/core/app-error.entity";
+import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
 import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
 import { isFormValidationError } from "@/shared/forms/core/guards/form-result.guard";
 import type {
@@ -8,10 +8,11 @@ import type {
 import type { SparseFieldValueMap } from "@/shared/forms/core/types/field-value.types";
 import type { FormValidationMetadata } from "@/shared/forms/core/types/validation.types";
 
-// Helper internal to the inspector
+// Helper internal to the inspector. Accepts AppError entities and their
+// serialized DTOs alike, since form results carry DTOs across the boundary.
 function hasFormMetadata<T extends string>(
-	error: AppError,
-): error is AppError & { readonly metadata: FormValidationMetadata<T> } {
+	error: AppErrorLike,
+): error is AppErrorLike & { readonly metadata: FormValidationMetadata<T> } {
 	return (
 		error.key === APP_ERROR_KEYS.validation ||
 		error.key === APP_ERROR_KEYS.conflict
@@ -19,7 +20,7 @@ function hasFormMetadata<T extends string>(
 }
 
 /**
- * Extracts dense field errors from an AppError.
+ * Extracts dense field errors from an AppError or its serialized DTO.
  * Returns undefined if not a form validation error.
  *
  * @example
@@ -29,7 +30,7 @@ function hasFormMetadata<T extends string>(
  * }
  */
 export const extractFieldErrors = <T extends string>(
-	error: AppError,
+	error: AppErrorLike,
 ): DenseFieldErrorMap<T, string> | undefined => {
 	if (hasFormMetadata<T>(error)) {
 		return error.metadata.fieldErrors;
@@ -39,11 +40,11 @@ export const extractFieldErrors = <T extends string>(
 };
 
 /**
- * Extracts echoed field values from an AppError.
+ * Extracts echoed field values from an AppError or its serialized DTO.
  * Returns undefined if not present.
  */
 export const extractFieldValues = <T extends string>(
-	error: AppError,
+	error: AppErrorLike,
 ): SparseFieldValueMap<T, string> | undefined => {
 	if (isFormValidationError<T>(error)) {
 		return error.metadata.formData;
@@ -53,10 +54,10 @@ export const extractFieldValues = <T extends string>(
 };
 
 /**
- * Extracts form-level errors from an AppError.
+ * Extracts form-level errors from an AppError or its serialized DTO.
  * Returns empty array if not present.
  */
-export const extractFormErrors = (error: AppError): FormErrors => {
+export const extractFormErrors = (error: AppErrorLike): FormErrors => {
 	if (isFormValidationError(error)) {
 		return error.metadata.formErrors;
 	}

--- a/src/shared/forms/presentation/mappers/form-error-payload.mapper.ts
+++ b/src/shared/forms/presentation/mappers/form-error-payload.mapper.ts
@@ -1,4 +1,4 @@
-import type { AppError } from "@/shared/core/errors/core/app-error.entity";
+import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
 import type { DenseFieldErrorMap } from "@/shared/forms/core/types/field-error.types";
 import type { FormErrorPayload } from "@/shared/forms/core/types/form-result.dto";
 import {
@@ -11,14 +11,15 @@ import { makeEmptyDenseFieldErrorMap } from "@/shared/forms/logic/mappers/field-
 // TODO: THESE FUNCTIONS OVERLAP AND INDICATE A REFACTOR IS NEEDED
 
 /**
- * Adapts a canonical AppError into a shape the Form UI can consume.
+ * Adapts a canonical AppError (entity or serialized DTO) into a shape the
+ * Form UI can consume.
  *
  * @param error - The AppError from the service/action.
  * @param fields - Optional list of field names to ensure a dense error map.
  * @returns An object containing the top-level message and a map of field errors.
  */
 export function toFormErrorPayload<T extends string>(
-	error: AppError,
+	error: AppErrorLike,
 	fields?: readonly T[],
 ): FormErrorPayload<T> {
 	const fieldErrors = extractFieldErrors<T>(error);
@@ -42,7 +43,7 @@ export function toFormErrorPayload<T extends string>(
  * Essential for UI components to display fieldErrors and formErrors.
  */
 export function formErrorPayloadMapper<F extends string>(
-	error: AppError,
+	error: AppErrorLike,
 ): FormErrorPayload<F> {
 	const formErrors = extractFormErrors(error);
 

--- a/src/ui/molecules/server-message.molecule.tsx
+++ b/src/ui/molecules/server-message.molecule.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "react";
-import { isAppError } from "@/shared/core/errors/core/app-error.entity";
+import { isAppErrorDto } from "@/shared/core/errors/core/app-error.entity";
 import type {
 	FormResult,
 	FormSuccessPayload,
@@ -65,10 +65,10 @@ function extractMessageAndSuccess<Tdata>(
 		});
 	}
 
-	// Error branch: state.error is AppError
+	// Error branch: state.error is a serialized AppError DTO
 	const error = state.error;
 
-	if (isAppError(error)) {
+	if (isAppErrorDto(error)) {
 		return Object.freeze({
 			message: error.message,
 			success: false,


### PR DESCRIPTION
## Problem

Every form using `useActionState` passed an initial state of `Err(new AppError(...))` — and `AppError extends Error`. Class instances can't cross the React Server Action serialization boundary, so Next.js logged

```
Failed to serialize an action for progressive enhancement:
Error: Only plain objects, and a few built-ins, can be passed to Server Functions.
  {error: Error, ok: false}
```

three times per auth page render (signup/login + two demo forms), and no-JS form posts were degraded. (Backlog item, recovered 2026-06-09.)

## Fix

The standards doc already prescribed the answer — *"Interface Adapters (Actions): translate into … `AppErrorJsonDto`"* — and `AppError.toDto()` existed but was never wired up. This PR wires it up at the one place form errors are built:

- `FormResult<T>`'s error branch is now `{ error: AppErrorJsonDto, ok: false }` (plain, serializable)
- New `toFormErrResult(appError)` in the form-result factory does the `toDto()` conversion; `makeFormError` and `makeInitialFormState` route through it, so **actions are unchanged** — `AppError` construction and its Zod metadata validation stay exactly as before
- Form inspectors/guards/payload-mappers now accept `AppErrorLike` (structural supertype of entity + DTO), so server code passing real `AppError`s and client code reading DTOs both work
- `_isAppErrorDto` promoted to `isAppErrorDto`; `server-message.molecule.tsx` uses it instead of `isAppError`, which would otherwise stop matching and silently drop error messages
- Signup conflict mapper wraps its `AppError` with `toFormErrResult` (pg constraint metadata preserved)
- Internal layers keep `Err(AppError)` — only the `useActionState` boundary serializes, per `docs/standards/error-handling-and-result-pattern.md`

## Verification

- A/B on the dev server: stashed the fix → warning fires 3× on `/auth/signup` load; restored → zero new warnings across page loads **and** a failed-submit round trip
- Submitted invalid signup data: field errors ("Username must be at least 3 characters long."), form-level message, and echoed field values all render from the DTO; no browser console errors
- `pnpm check:fast` (Biome + tsc + Next typegen) ✅ — `pnpm test` 149/149 ✅

Also moves the backlog item to Done.
