### PR TITLE
docs(backlog) + fix(ci): queue forms cleanup; unbreak frozen-lockfile install

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -17,7 +17,29 @@ this file is the deliberate workaround.)
 - [ ] **Live deploy** — Vercel + Neon account setup: create projects, set env vars,
   run prod migrate + seed, paste the live URL into the README.
 - [ ] **Vitest Phase 3** — remaining breadth (`server`, invoices/customers domain) and
-  consider coverage thresholds once breadth lands.
+  consider coverage thresholds once breadth lands. _Do this before the forms/error
+  boundary cleanup below — lock behavior first, refactor behind the tests._
+- [ ] **Forms/error boundary cleanup** — friction points surfaced while fixing Server
+  Action serialization (PR #41, 2026-06-11). Small independent PRs, in roughly this
+  order; full context in memory (`project_forms_error_refactor`):
+  - [ ] **Tri-state form state** — `useActionState` initial value is a fake validation
+    `AppError` (`cause: "INITIAL_STATE"`, empty message) because `FormResult` has no
+    idle member. Model `idle | ok | err`, delete the hack in
+    `src/shared/forms/logic/factories/form-state.factory.ts`, simplify form branching.
+  - [ ] **Stop echoing sensitive fields** — failed submits echo submitted values
+    (including login/signup passwords) back to the client in `metadata.formData`
+    (`validateForm`, auth mappers). Same-user only, but allowlist what gets echoed.
+  - [ ] **Decide FormResult vs Result** — `Result`'s `TError extends AppError`
+    constraint forced `FormResult` to fork into its own union (PR #41). Either loosen
+    the generic or formally document FormResult as a boundary DTO type.
+  - [ ] **One validation funnel** — auth/users use `validateForm`; create-invoice does
+    inline `safeParse`; update-invoice hand-flattens Zod errors. Unify on `validateForm`.
+  - [ ] **Fix field-error key coupling** — `makeFormError` stamps form metadata onto any
+    error key, but extractors only honor `validation` | `conflict`; a `database`-keyed
+    form error silently drops its field errors (`form-error.inspector.ts`).
+  - [ ] **Dead-seam sweep** — `AppError.fromDto` (test-only), `_isFormErr`/`_isFormOk`/
+    `_isOk`/`_isErr` guards, parked result combinators decision, `retryable` removal
+    TODO, and the overlap TODO in `form-error-payload.mapper.ts`.
 - [ ] **Skills exploration** — evaluate reputable-source skills (e.g. Vercel's
   `vercel-react-best-practices`) against `docs/standards/` before adopting.
 - [ ] **TSConfig Version 6** - figure out how to use TSConfig Version 6.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   esbuild: ^0.25.0
   vite: ^7.3.5
-  postcss: ^8.5.10
+  postcss: ^8.5.15
 
 importers:
 
@@ -127,7 +127,7 @@ importers:
         version: 6.1.3
       start-server-and-test:
         specifier: ^3.0.9
-        version: 3.0.9
+        version: 3.0.9(supports-color@8.1.1)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -139,7 +139,7 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.1.1(supports-color@8.1.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -3730,7 +3730,7 @@ snapshots:
   acorn@8.16.0:
     optional: true
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -3787,11 +3787,11 @@ snapshots:
 
   axe-core@4.12.0: {}
 
-  axios@1.17.0(debug@4.4.3):
+  axios@1.17.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.5
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -4176,7 +4176,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -4296,9 +4296,9 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -4958,7 +4958,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  start-server-and-test@3.0.9:
+  start-server-and-test@3.0.9(supports-color@8.1.1):
     dependencies:
       arg: 5.0.2
       check-more-types: 2.24.0
@@ -4966,7 +4966,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 2.0.3
       tree-kill: 1.2.2
-      wait-on: 9.0.10(debug@4.4.3)
+      wait-on: 9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5125,7 +5125,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-tsconfig-paths@6.1.1(supports-color@8.1.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       globrex: 0.1.2
@@ -5187,9 +5187,9 @@ snapshots:
       xml-name-validator: 5.0.0
     optional: true
 
-  wait-on@9.0.10(debug@4.4.3):
+  wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      axios: 1.17.0(debug@4.4.3)
+      axios: 1.17.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       joi: 18.2.1
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,6 @@ onlyBuiltDependencies:
 overrides:
   esbuild: ^0.25.0
   vite: ^7.3.5
-  postcss: ^8.5.10
+  postcss: ^8.5.15
 
 sideEffectsCache: false


### PR DESCRIPTION
Two small things:

## fix(ci): frozen-lockfile install (unbreaks CI on main)

CI's `pnpm install --frozen-lockfile` has failed on every push since this morning's dep update (957f0c2b): package.json bumped postcss to `^8.5.15`, but `pnpm-workspace.yaml`'s `overrides` still pinned `^8.5.10`. pnpm applies the override when computing manifest specifiers, so the lockfile no longer matched (`ERR_PNPM_OUTDATED_LOCKFILE`, ~16s fast-fail). Bumped the override to `^8.5.15` and regenerated the lockfile — installed versions unchanged (postcss was already 8.5.15), the rest of the lockfile diff is pnpm 11.5.3 peer-annotation normalization. Verified locally with the exact CI command.

(The earlier June 9 CI failure was a different, self-healing issue: the `minimumReleaseAge` supply-chain policy rejected `start-server-and-test@3.0.9` while it was <24h old.)

## docs(backlog): queue forms/error boundary cleanup

Adds the six-item forms/error boundary cleanup to `BACKLOG.md`, surfaced while fixing Server Action serialization in #41: tri-state form state, sensitive-field echo allowlist, FormResult-vs-Result decision, validation funnel unification, field-error key coupling, dead-seam sweep. Sequenced after Vitest Phase 3 breadth (lock behavior first, refactor behind tests).
