### PR TITLE
fix(api): hide test-only DB reset route outside the test env

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -13,6 +13,23 @@
 			"runtimeExecutable": "pnpm"
 		},
 		{
+			"name": "Next.js Dev (Dev env, pinned)",
+			"port": 3001,
+			"runtimeArgs": [
+				"exec",
+				"dotenv",
+				"-e",
+				".env.development.local",
+				"-o",
+				"--",
+				"pnpm",
+				"next:dev",
+				"--port",
+				"3001"
+			],
+			"runtimeExecutable": "pnpm"
+		},
+		{
 			"name": "Drizzle Studio (Dev)",
 			"port": 4983,
 			"runtimeArgs": ["db:studio:dev"],

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -40,6 +40,20 @@ this file is the deliberate workaround.)
   - [ ] **Dead-seam sweep** — `AppError.fromDto` (test-only), `_isFormErr`/`_isFormOk`/
     `_isOk`/`_isErr` guards, parked result combinators decision, `retryable` removal
     TODO, and the overlap TODO in `form-error-payload.mapper.ts`.
+- [ ] **Env hygiene** — surfaced during deploy prep (2026-06-11):
+  - [ ] Remove dead `LOG_LEVEL` plumbing — only the unused `_getLogLevel` in
+    `env-shared.ts` reads it; the real runtime level comes from
+    `NEXT_PUBLIC_LOG_LEVEL` (with an `info` fallback in `logging.levels.ts`).
+    Drop the tuple entry and the template line together.
+  - [ ] Drop the per-lookup `console.log` in `env-access.utils.ts`
+    (`Retrieving env var: …`) — it spams production function logs on every request.
+  - [ ] Decide `SESSION_ISSUER`/`SESSION_AUDIENCE` shape — single-literal zod enums
+    make them constants-as-env-vars. Either widen to `z.string().min(1)` so the env
+    actually configures them (renaming later invalidates live sessions), or hardcode
+    them as code constants and drop the env vars.
+  - [ ] Remove `AUTH_SECRET`/`AUTH_GITHUB_ID`/`AUTH_GITHUB_SECRET` from
+    `.env.example.local` and any real env files — auth.js holdovers, zero references
+    in code since the custom jose/bcrypt auth replaced it.
 - [ ] **Skills exploration** — evaluate reputable-source skills (e.g. Vercel's
   `vercel-react-best-practices`) against `docs/standards/` before adopting.
 - [ ] **TSConfig Version 6** - figure out how to use TSConfig Version 6.

--- a/src/app/api/db/reset/route.ts
+++ b/src/app/api/db/reset/route.ts
@@ -3,9 +3,23 @@ import { schema } from "@database/schema/schema.aggregate";
 import { reset } from "drizzle-seed";
 import { NextResponse } from "next/server";
 import { getAppDb } from "@/server/db/db.connection";
+import { isTestDatabaseEnvironment } from "@/shared/core/config/shared/env-shared";
 
-// biome-ignore lint/nursery/useExplicitType: <fix later>
-export async function GET() {
+/**
+ * Test-only route that truncates every table (drizzle-seed `reset`).
+ *
+ * Cypress e2e calls this between specs against a server started with
+ * `.env.test.local`. Outside the test database environment the route
+ * answers 404 so a deployed instance never exposes a destructive endpoint.
+ */
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(): Promise<NextResponse> {
+	if (!isTestDatabaseEnvironment()) {
+		return new NextResponse(null, { status: 404 });
+	}
+
 	try {
 		await reset(getAppDb(), schema);
 		return NextResponse.json({ action: "reset", ok: true });

--- a/src/shared/core/config/shared/env-shared.ts
+++ b/src/shared/core/config/shared/env-shared.ts
@@ -163,3 +163,14 @@ function _isProdDb(): boolean {
 function _isEnv(...envs: NodeEnvironment[]): boolean {
 	return envs.includes(getNodeEnv());
 }
+
+/**
+ * True only when DATABASE_ENV is explicitly "test".
+ *
+ * Non-throwing by design (unlike {@link getDatabaseEnv}): a missing or
+ * invalid value answers `false`, so callers can use it as a hard gate for
+ * test-only functionality such as the `/api/db/reset` route.
+ */
+export function isTestDatabaseEnvironment(): boolean {
+	return process.env.DATABASE_ENV === "test";
+}


### PR DESCRIPTION
## Summary
Deploy blocker found while prepping the Vercel launch: **`/api/db/reset` was an unauthenticated GET that truncates every table** (it exists for Cypress, which resets the DB between specs). Deployed as-is, anyone could wipe production with one request.

- The route now returns **404 unless `DATABASE_ENV=test`**, short-circuiting before any DB access.
- The check lives in the config layer as a non-throwing `isTestDatabaseEnvironment()` (`env-shared.ts`) — `biome.json` reserves `process` access for `src/shared/core/config/**` / `src/server/**`, and a *missing* `DATABASE_ENV` must mean "blocked", not a thrown 500.
- `force-dynamic` + `nodejs` runtime exports (matching `/api/health`) guarantee per-request evaluation, never build-time prerender.
- `launch.json`: adds a dotenv-pinned dev config — Claude desktop sessions export the test env, so a plain `next dev` preview in a worktree silently runs against `.env.test.local`.
- `BACKLOG.md`: queues env-hygiene follow-ups surfaced during deploy prep (dead `LOG_LEVEL` plumbing, per-request `console.log` in `env-access.utils.ts`, `SESSION_ISSUER`/`SESSION_AUDIENCE` single-literal decision, auth.js env holdovers in the template).

## Test plan
- [x] `pnpm check:fast` — Biome, tsc, typegen all clean
- [x] `pnpm test` — 149/149 unit tests pass
- [x] Live (dev-env server): `GET /api/db/reset` → **404**, empty body, no DB touch
- [x] Live (test-env server): `GET /api/db/reset` → **200** `{"action":"reset","ok":true}` — Cypress path intact
- [ ] `pnpm cy:e2e` before deploy (`reset.cy.ts` exercises the allowed path end-to-end)
