### PR TITLE
test(forms): Vitest Phase 3 — forms characterization suite (0 → 68 tests)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -17,8 +17,10 @@ this file is the deliberate workaround.)
 - [ ] **Live deploy** — Vercel + Neon account setup: create projects, set env vars,
   run prod migrate + seed, paste the live URL into the README.
 - [ ] **Vitest Phase 3** — remaining breadth (`server`, invoices/customers domain) and
-  consider coverage thresholds once breadth lands. _Do this before the forms/error
-  boundary cleanup below — lock behavior first, refactor behind the tests._
+  consider coverage thresholds once breadth lands. Forms breadth DONE (2026-06-11):
+  68 characterization tests across all 11 testable forms files, pinning the three
+  known quirks (key coupling, sensitive echo, payload-mapper overlap) ahead of the
+  boundary redesign. _Lock behavior first, refactor behind the tests._
 - [ ] **Forms/error boundary cleanup** — friction points surfaced while fixing Server
   Action serialization (PR #41, 2026-06-11). Small independent PRs, in roughly this
   order; full context in memory (`project_forms_error_refactor`):

--- a/src/shared/forms/__tests__/unit/field-error-map.mapper.test.ts
+++ b/src/shared/forms/__tests__/unit/field-error-map.mapper.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+	makeEmptyDenseFieldErrorMap,
+	selectSparseFieldErrors,
+	toDenseFieldErrorMap,
+} from "@/shared/forms/logic/mappers/field-error-map.mapper";
+
+/**
+ * Unit tests for the field error map mapper (field-error-map.mapper.ts).
+ *
+ * Dense maps (every field present) are what the UI consumes; sparse maps are
+ * what Zod produces. These tests pin the conversions: filling, filtering to
+ * allowed fields, dropping empty arrays, and freezing every result.
+ */
+describe("field-error-map mapper", () => {
+	describe("makeEmptyDenseFieldErrorMap", () => {
+		it("maps every field to an empty array", () => {
+			expect(makeEmptyDenseFieldErrorMap(["email", "password"])).toEqual({
+				email: [],
+				password: [],
+			});
+		});
+
+		it("freezes the map and its arrays", () => {
+			const map = makeEmptyDenseFieldErrorMap(["email"]);
+
+			expect(Object.isFrozen(map)).toBe(true);
+			expect(Object.isFrozen(map.email)).toBe(true);
+		});
+	});
+
+	describe("toDenseFieldErrorMap", () => {
+		it("returns an empty dense map when the sparse map is undefined", () => {
+			expect(toDenseFieldErrorMap(undefined, ["email", "password"])).toEqual({
+				email: [],
+				password: [],
+			});
+		});
+
+		it("fills missing fields with empty arrays and copies present ones", () => {
+			const dense = toDenseFieldErrorMap({ email: ["Required"] }, [
+				"email",
+				"password",
+			]);
+
+			expect(dense).toEqual({ email: ["Required"], password: [] });
+		});
+
+		it("drops sparse keys that are not in the allowed fields", () => {
+			const dense = toDenseFieldErrorMap(
+				{ email: ["Required"] } as Record<string, ["Required"]>,
+				["password"],
+			);
+
+			expect(dense).toEqual({ password: [] });
+		});
+
+		it("freezes the map and copies arrays instead of sharing them", () => {
+			const source = ["Required"] as const;
+
+			const dense = toDenseFieldErrorMap({ email: source }, ["email"]);
+
+			expect(Object.isFrozen(dense)).toBe(true);
+			expect(Object.isFrozen(dense.email)).toBe(true);
+			expect(dense.email).not.toBe(source);
+		});
+	});
+
+	describe("selectSparseFieldErrors", () => {
+		it("keeps only allowed fields that have non-empty errors", () => {
+			const sparse = selectSparseFieldErrors(
+				{
+					email: ["Required"],
+					ignored: ["Nope"],
+					password: [],
+				},
+				["email", "password"],
+			);
+
+			expect(sparse).toEqual({ email: ["Required"] });
+		});
+
+		it("returns an empty frozen map when nothing matches", () => {
+			const sparse = selectSparseFieldErrors({}, ["email"]);
+
+			expect(sparse).toEqual({});
+			expect(Object.isFrozen(sparse)).toBe(true);
+		});
+
+		it("ignores undefined entries", () => {
+			const sparse = selectSparseFieldErrors({ email: undefined }, ["email"]);
+
+			expect(sparse).toEqual({});
+		});
+	});
+});

--- a/src/shared/forms/__tests__/unit/form-data.utils.test.ts
+++ b/src/shared/forms/__tests__/unit/form-data.utils.test.ts
@@ -1,0 +1,62 @@
+import { buildFormData } from "@test-support/forms/form-data";
+import { describe, expect, it } from "vitest";
+import { resolveRawFieldPayload } from "@/shared/forms/server/utils/form-data.utils";
+
+/**
+ * Unit tests for the FormData utils (form-data.utils.ts).
+ *
+ * `resolveRawFieldPayload` builds the raw payload validation sees: an explicit
+ * raw map wins when non-empty, otherwise the allowed fields are picked out of
+ * the FormData. Missing fields stay absent (sparse), values are stringified.
+ */
+describe("resolveRawFieldPayload", () => {
+	it("extracts only the allowed fields from FormData", () => {
+		const formData = buildFormData({
+			email: "a@b.c",
+			ignored: "nope",
+			password: "secret",
+		});
+
+		const raw = resolveRawFieldPayload(formData, ["email", "password"]);
+
+		expect(raw).toEqual({ email: "a@b.c", password: "secret" });
+	});
+
+	it("omits fields missing from the FormData instead of filling them", () => {
+		const formData = buildFormData({ email: "a@b.c" });
+
+		const raw = resolveRawFieldPayload(formData, ["email", "password"]);
+
+		expect(raw).toEqual({ email: "a@b.c" });
+		expect(Object.isFrozen(raw)).toBe(true);
+	});
+
+	it("prefers a non-empty explicit raw map and stringifies its values", () => {
+		const formData = buildFormData({ amount: "ignored" });
+
+		const raw = resolveRawFieldPayload(formData, ["amount", "memo"], {
+			amount: 42,
+		});
+
+		expect(raw).toEqual({ amount: "42" });
+	});
+
+	it("skips null and undefined values in the explicit raw map", () => {
+		const formData = buildFormData({});
+
+		const raw = resolveRawFieldPayload(formData, ["amount", "memo"], {
+			amount: null as unknown as string,
+			memo: "note",
+		});
+
+		expect(raw).toEqual({ memo: "note" });
+	});
+
+	it("falls back to FormData when the explicit raw map is empty", () => {
+		const formData = buildFormData({ email: "a@b.c" });
+
+		const raw = resolveRawFieldPayload(formData, ["email"], {});
+
+		expect(raw).toEqual({ email: "a@b.c" });
+	});
+});

--- a/src/shared/forms/__tests__/unit/form-error-payload.mapper.test.ts
+++ b/src/shared/forms/__tests__/unit/form-error-payload.mapper.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
+import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
+import {
+	formErrorPayloadMapper,
+	toFormErrorPayload,
+} from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
+
+/**
+ * Unit tests for the form error payload mapper (form-error-payload.mapper.ts).
+ *
+ * Two overlapping exports adapt an AppError for the form UI. Production code
+ * uses only `toFormErrorPayload`; `formErrorPayloadMapper` differs in its
+ * form-error fallback (`[error.message]`). Both behaviors are pinned so the
+ * planned consolidation (BACKLOG: "Form error payload overlap") is a
+ * deliberate change, not an accident.
+ */
+describe("form-error payload mapper", () => {
+	const validationError = makeAppError("validation", {
+		cause: "test",
+		message: "There were errors.",
+		metadata: {
+			fieldErrors: { email: ["Required"] },
+			formData: { email: "a@b.c" },
+			formErrors: ["Fix the fields below."],
+		},
+	});
+
+	const nonFormError: AppErrorLike = {
+		key: "not_found",
+		message: "Nothing here.",
+		metadata: {},
+	};
+
+	describe("toFormErrorPayload", () => {
+		it("maps a validation error onto message, field errors, form errors, and echoed data", () => {
+			expect(toFormErrorPayload(validationError)).toEqual({
+				fieldErrors: { email: ["Required"] },
+				formData: { email: "a@b.c" },
+				formErrors: ["Fix the fields below."],
+				message: "There were errors.",
+			});
+		});
+
+		it("builds an empty dense map from the fields list for a non-form error", () => {
+			const payload = toFormErrorPayload(nonFormError, ["email", "password"]);
+
+			expect(payload.fieldErrors).toEqual({ email: [], password: [] });
+			expect(payload.formErrors).toEqual([]);
+			expect(payload.message).toBe("Nothing here.");
+		});
+
+		it("falls back to a frozen empty map when no fields are provided", () => {
+			const payload = toFormErrorPayload(nonFormError);
+
+			expect(payload.fieldErrors).toEqual({});
+			expect(Object.isFrozen(payload.fieldErrors)).toBe(true);
+			expect(payload.formData).toEqual({});
+		});
+	});
+
+	describe("formErrorPayloadMapper", () => {
+		it("matches toFormErrorPayload for a validation error with form errors", () => {
+			expect(formErrorPayloadMapper(validationError)).toEqual(
+				toFormErrorPayload(validationError),
+			);
+		});
+
+		it("falls back to [error.message] when there are no form errors (divergence)", () => {
+			// toFormErrorPayload returns [] here; the mapper substitutes the
+			// message — the behavioral difference behind the overlap TODO.
+			const payload = formErrorPayloadMapper(nonFormError);
+
+			expect(payload.formErrors).toEqual(["Nothing here."]);
+			expect(toFormErrorPayload(nonFormError).formErrors).toEqual([]);
+		});
+
+		it("never builds a dense map — non-form errors get an empty fieldErrors object", () => {
+			expect(formErrorPayloadMapper(nonFormError).fieldErrors).toEqual({});
+		});
+	});
+});

--- a/src/shared/forms/__tests__/unit/form-error.inspector.test.ts
+++ b/src/shared/forms/__tests__/unit/form-error.inspector.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
+import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
+import {
+	extractFieldErrors,
+	extractFieldValues,
+	extractFormErrors,
+} from "@/shared/forms/logic/inspectors/form-error.inspector";
+
+/**
+ * Unit tests for the form error inspector (form-error.inspector.ts).
+ *
+ * The inspectors read form metadata back out of an AppError (entity or
+ * serialized DTO). They are key-coupled: `extractFieldErrors` honors
+ * `validation | conflict`, while `extractFieldValues` / `extractFormErrors`
+ * honor only `validation`. A form error under any other key silently drops
+ * its metadata — pinned below; see the "Fix field-error key coupling"
+ * BACKLOG item before changing this.
+ */
+describe("form-error inspector", () => {
+	const formMetadata = {
+		fieldErrors: { email: ["Required"] },
+		formData: { email: "a@b.c" },
+		formErrors: ["Fix the fields below."],
+	} as const;
+
+	const validationError = makeAppError("validation", {
+		cause: "test",
+		message: "There were errors.",
+		metadata: formMetadata,
+	});
+
+	// Mirrors production (to-signup-form-result.mapper): a conflict form error
+	// carries the pg metadata plus the form fields.
+	const conflictError = makeAppError("conflict", {
+		cause: "test",
+		message: "Email already exists.",
+		metadata: { ...formMetadata, pgCode: "23505" },
+	});
+
+	// Built structurally: a database-keyed form error never survives entity
+	// metadata validation in tests, but the boundary type (AppErrorLike) admits
+	// it — and that is exactly the shape the extractors mishandle.
+	const databaseFormError: AppErrorLike = {
+		key: "database",
+		message: "insert failed",
+		metadata: formMetadata,
+	};
+
+	describe("extractFieldErrors", () => {
+		it("returns field errors for a validation-keyed entity", () => {
+			expect(extractFieldErrors(validationError)).toEqual({
+				email: ["Required"],
+			});
+		});
+
+		it("returns field errors for the serialized DTO of the same error", () => {
+			expect(extractFieldErrors(validationError.toDto())).toEqual({
+				email: ["Required"],
+			});
+		});
+
+		it("returns field errors for a conflict-keyed form error", () => {
+			expect(extractFieldErrors(conflictError)).toEqual({
+				email: ["Required"],
+			});
+		});
+
+		it("silently drops field errors for a database-keyed form error (known coupling bug)", () => {
+			// The metadata carries fieldErrors, but the inspector only looks at
+			// the key — BACKLOG: "Fix field-error key coupling".
+			expect(extractFieldErrors(databaseFormError)).toBeUndefined();
+		});
+
+		it("returns undefined for a conflict error without form metadata", () => {
+			const pgConflict = makeAppError("conflict", {
+				cause: "test",
+				message: "duplicate key",
+				metadata: { pgCode: "23505" },
+			});
+
+			expect(extractFieldErrors(pgConflict)).toBeUndefined();
+		});
+	});
+
+	describe("extractFieldValues", () => {
+		it("returns echoed form data for a validation-keyed error", () => {
+			expect(extractFieldValues(validationError)).toEqual({
+				email: "a@b.c",
+			});
+		});
+
+		it("returns undefined for a conflict-keyed form error (asymmetric with extractFieldErrors)", () => {
+			expect(extractFieldValues(conflictError)).toBeUndefined();
+		});
+
+		it("returns undefined when validation metadata has no fieldErrors shape", () => {
+			const bare: AppErrorLike = {
+				key: "validation",
+				message: "m",
+				metadata: { reason: "x" },
+			};
+
+			expect(extractFieldValues(bare)).toBeUndefined();
+		});
+	});
+
+	describe("extractFormErrors", () => {
+		it("returns form-level errors for a validation-keyed error", () => {
+			expect(extractFormErrors(validationError)).toEqual([
+				"Fix the fields below.",
+			]);
+		});
+
+		it("returns a frozen empty array for a conflict-keyed form error (asymmetric)", () => {
+			const formErrors = extractFormErrors(conflictError);
+
+			expect(formErrors).toEqual([]);
+			expect(Object.isFrozen(formErrors)).toBe(true);
+		});
+
+		it("returns an empty array for a database-keyed form error", () => {
+			expect(extractFormErrors(databaseFormError)).toEqual([]);
+		});
+	});
+});

--- a/src/shared/forms/__tests__/unit/form-result.factory.test.ts
+++ b/src/shared/forms/__tests__/unit/form-result.factory.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
+import {
+	makeFormError,
+	makeFormOk,
+	toFormErrResult,
+} from "@/shared/forms/logic/factories/form-result.factory";
+
+/**
+ * Unit tests for the form result factory (form-result.factory.ts).
+ *
+ * Form results cross the Server Action boundary via `useActionState`, so the
+ * error side must be a plain serialized DTO — never an `AppError` instance
+ * (PR #41). These tests pin the serialization, the frozen shapes, and the fact
+ * that `makeFormError` stamps form metadata onto whatever key it is given.
+ */
+describe("form-result factory", () => {
+	describe("makeFormOk", () => {
+		it("wraps data and message as a success payload", () => {
+			const result = makeFormOk({ id: 1 }, "Saved.");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toEqual({ data: { id: 1 }, message: "Saved." });
+			}
+		});
+
+		it("freezes the payload", () => {
+			const result = makeFormOk("data", "ok");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(Object.isFrozen(result.value)).toBe(true);
+			}
+		});
+	});
+
+	describe("toFormErrResult", () => {
+		it("serializes the AppError into a plain DTO, not the class instance", () => {
+			const error = makeAppError("validation", {
+				cause: "test",
+				message: "bad input",
+				metadata: {
+					fieldErrors: { email: ["Required"] },
+					formData: {},
+					formErrors: [],
+				},
+			});
+
+			const result = toFormErrResult(error);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error).not.toBeInstanceOf(Error);
+				expect(result.error._isAppError).toBe(true);
+				expect(result.error.key).toBe("validation");
+				expect(result.error.message).toBe("bad input");
+			}
+		});
+
+		it("returns a frozen result", () => {
+			const error = makeAppError("validation", {
+				cause: "test",
+				message: "m",
+				metadata: { fieldErrors: {}, formData: {}, formErrors: [] },
+			});
+
+			expect(Object.isFrozen(toFormErrResult(error))).toBe(true);
+		});
+	});
+
+	describe("makeFormError", () => {
+		it("carries field errors, echoed form data, and form errors in metadata", () => {
+			const result = makeFormError({
+				fieldErrors: { email: ["Required"], password: [] },
+				formData: { email: "a@b.c" },
+				formErrors: ["Fix the fields below."],
+				key: "validation",
+				message: "There were errors.",
+			});
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.key).toBe("validation");
+				expect(result.error.message).toBe("There were errors.");
+				expect(result.error.metadata).toEqual({
+					fieldErrors: { email: ["Required"], password: [] },
+					formData: { email: "a@b.c" },
+					formErrors: ["Fix the fields below."],
+				});
+			}
+		});
+
+		it("stamps form metadata onto a conflict key too (e.g. duplicate email)", () => {
+			const result = makeFormError({
+				fieldErrors: { email: ["Email already exists."] },
+				formData: { email: "taken@b.c" },
+				formErrors: [],
+				key: "conflict",
+				message: "Email already exists.",
+			});
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.key).toBe("conflict");
+				expect(result.error.metadata).toEqual(
+					expect.objectContaining({
+						fieldErrors: { email: ["Email already exists."] },
+					}),
+				);
+			}
+		});
+	});
+});

--- a/src/shared/forms/__tests__/unit/form-result.guard.test.ts
+++ b/src/shared/forms/__tests__/unit/form-result.guard.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
+import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
+import { isFormValidationError } from "@/shared/forms/core/guards/form-result.guard";
+
+/**
+ * Unit tests for the form result guard (form-result.guard.ts).
+ *
+ * `isFormValidationError` is the single live guard: validation key AND a
+ * `fieldErrors` property in metadata. Both conditions are pinned — a
+ * conflict-keyed form error fails the guard even with identical metadata.
+ */
+describe("isFormValidationError", () => {
+	const formMetadata = {
+		fieldErrors: { email: ["Required"] },
+		formData: {},
+		formErrors: [],
+	} as const;
+
+	it("accepts a validation-keyed entity carrying fieldErrors", () => {
+		const error = makeAppError("validation", {
+			cause: "test",
+			message: "m",
+			metadata: formMetadata,
+		});
+
+		expect(isFormValidationError(error)).toBe(true);
+	});
+
+	it("accepts the serialized DTO of the same error", () => {
+		const error = makeAppError("validation", {
+			cause: "test",
+			message: "m",
+			metadata: formMetadata,
+		});
+
+		expect(isFormValidationError(error.toDto())).toBe(true);
+	});
+
+	it("rejects a validation-keyed error without a fieldErrors property", () => {
+		const error = makeAppError("validation", {
+			cause: "test",
+			message: "m",
+			metadata: { reason: "x" },
+		});
+
+		expect(isFormValidationError(error)).toBe(false);
+	});
+
+	it("rejects a conflict-keyed error even when it carries form metadata", () => {
+		const error: AppErrorLike = {
+			key: "conflict",
+			message: "Email already exists.",
+			metadata: formMetadata,
+		};
+
+		expect(isFormValidationError(error)).toBe(false);
+	});
+});

--- a/src/shared/forms/__tests__/unit/form-state.factory.test.ts
+++ b/src/shared/forms/__tests__/unit/form-state.factory.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+	makeInitialFormState,
+	makeInitialFormStateFromSchema,
+} from "@/shared/forms/logic/factories/form-state.factory";
+
+/**
+ * Unit tests for the initial form state factory (form-state.factory.ts).
+ *
+ * `useActionState` needs a state value before the first submission, and
+ * `FormResult` has no idle member — so the initial state is a fake
+ * validation-keyed Err with an empty message and empty dense field errors.
+ * These tests pin that hack exactly as it is today; the "Tri-state form
+ * state" BACKLOG item replaces it with an explicit `idle | ok | err` union.
+ */
+describe("form-state factory", () => {
+	describe("makeInitialFormState", () => {
+		it("is an Err with an empty message and a validation key", () => {
+			const state = makeInitialFormState(["email", "password"]);
+
+			expect(state.ok).toBe(false);
+			if (!state.ok) {
+				expect(state.error.key).toBe("validation");
+				expect(state.error.message).toBe("");
+			}
+		});
+
+		it("carries an empty dense field-error map for every field", () => {
+			const state = makeInitialFormState(["email", "password"]);
+
+			expect(state.ok).toBe(false);
+			if (!state.ok) {
+				expect(state.error.metadata).toEqual({
+					fieldErrors: { email: [], password: [] },
+					formData: {},
+					formErrors: [],
+				});
+			}
+		});
+
+		it("serializes as a plain DTO so Next.js can encode it into the form", () => {
+			const state = makeInitialFormState(["email"]);
+
+			expect(state.ok).toBe(false);
+			if (!state.ok) {
+				expect(state.error).not.toBeInstanceOf(Error);
+				expect(state.error._isAppError).toBe(true);
+			}
+		});
+	});
+
+	describe("makeInitialFormStateFromSchema", () => {
+		it("derives the field set from the Zod object schema", () => {
+			const schema = z.object({
+				email: z.string(),
+				password: z.string(),
+			});
+
+			const state = makeInitialFormStateFromSchema(schema);
+
+			expect(state.ok).toBe(false);
+			if (!state.ok) {
+				expect(state.error.metadata).toEqual(
+					expect.objectContaining({
+						fieldErrors: { email: [], password: [] },
+					}),
+				);
+			}
+		});
+	});
+});

--- a/src/shared/forms/__tests__/unit/form-validation-error.factory.test.ts
+++ b/src/shared/forms/__tests__/unit/form-validation-error.factory.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { formValidationErrorFactory } from "@/shared/forms/server/factories/form-validation-error.factory";
+import { logger } from "@/shared/telemetry/logging/infrastructure/logging.client";
+
+vi.mock(
+	"@/shared/telemetry/logging/infrastructure/logging.client",
+	async () => {
+		const { makeMockLogger } = await import("@test-support/mocks/logger.mock");
+		return { logger: makeMockLogger() };
+	},
+);
+
+/**
+ * Unit tests for the validation error factory (form-validation-error.factory.ts).
+ *
+ * The factory is the single funnel from "validation failed somehow" to a
+ * validation-keyed FormResult: ZodErrors map to dense field errors, anything
+ * else maps to an empty dense map, and every failure is logged. The submitted
+ * form data is echoed into metadata verbatim (BACKLOG: "Stop echoing
+ * sensitive fields").
+ */
+describe("formValidationErrorFactory", () => {
+	beforeEach(() => {
+		vi.mocked(logger.error).mockClear();
+	});
+
+	function makeZodError(): z.ZodError {
+		const parsed = z
+			.object({ email: z.string().min(3, "Email is too short.") })
+			.safeParse({ email: "x" });
+		if (parsed.success) {
+			throw new Error("expected parse to fail");
+		}
+		return parsed.error;
+	}
+
+	it("maps a ZodError to dense field errors under the validation key", () => {
+		const result = formValidationErrorFactory(makeZodError(), "TestContext", {
+			failureMessage: "Failed.",
+			fields: ["email", "password"],
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.key).toBe("validation");
+			expect(result.error.message).toBe("Failed.");
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({
+					fieldErrors: { email: ["Email is too short."], password: [] },
+				}),
+			);
+		}
+	});
+
+	it("maps a non-Zod error to an empty dense map", () => {
+		const result = formValidationErrorFactory(
+			new Error("boom"),
+			"TestContext",
+			{
+				failureMessage: "Failed.",
+				fields: ["email"],
+			},
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({ fieldErrors: { email: [] }, formErrors: [] }),
+			);
+		}
+	});
+
+	it("echoes the provided form data into metadata verbatim", () => {
+		const result = formValidationErrorFactory(makeZodError(), "TestContext", {
+			failureMessage: "Failed.",
+			fields: ["email"],
+			formData: { email: "typed-by-user" },
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({ formData: { email: "typed-by-user" } }),
+			);
+		}
+	});
+
+	it("defaults the echoed form data to a frozen empty map", () => {
+		const result = formValidationErrorFactory(makeZodError(), "TestContext", {
+			failureMessage: "Failed.",
+			fields: ["email"],
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({ formData: {} }),
+			);
+		}
+	});
+
+	it("logs every failure with the logger context", () => {
+		formValidationErrorFactory(makeZodError(), "TestContext", {
+			failureMessage: "Failed.",
+			fields: ["email"],
+		});
+
+		expect(logger.error).toHaveBeenCalledTimes(1);
+		expect(logger.error).toHaveBeenCalledWith(
+			"Failed.",
+			expect.objectContaining({ context: "TestContext" }),
+		);
+	});
+
+	it("labels non-Zod errors as UnknownValidationError in the log", () => {
+		formValidationErrorFactory({ weird: true }, "TestContext", {
+			failureMessage: "Failed.",
+			fields: ["email"],
+		});
+
+		expect(logger.error).toHaveBeenCalledWith(
+			"Failed.",
+			expect.objectContaining({ name: "UnknownValidationError" }),
+		);
+	});
+});

--- a/src/shared/forms/__tests__/unit/validate-form.test.ts
+++ b/src/shared/forms/__tests__/unit/validate-form.test.ts
@@ -1,0 +1,139 @@
+import { buildFormData } from "@test-support/forms/form-data";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { validateForm } from "@/shared/forms/server/validate-form";
+
+vi.mock(
+	"@/shared/telemetry/logging/infrastructure/logging.client",
+	async () => {
+		const { makeMockLogger } = await import("@test-support/mocks/logger.mock");
+		return { logger: makeMockLogger() };
+	},
+);
+
+/**
+ * Unit tests for the validation funnel (validate-form.ts).
+ *
+ * `validateForm` is the intended single entry point from FormData to a
+ * FormResult (BACKLOG: "One validation funnel"). Pinned: the ok path with
+ * default and custom messages, dense field errors on failure, the verbatim
+ * echo of submitted values — including passwords — into error metadata
+ * (BACKLOG: "Stop echoing sensitive fields"), and the unknown-error path for
+ * throwing refinements.
+ */
+describe("validateForm", () => {
+	const schema = z.object({
+		email: z.string().min(3, "Email is too short."),
+		password: z.string().min(8, "Password is too short."),
+	});
+
+	it("returns ok with parsed data and the default success message", async () => {
+		const formData = buildFormData({
+			email: "a@b.c",
+			password: "longenough",
+		});
+
+		const result = await validateForm(formData, schema);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.data).toEqual({
+				email: "a@b.c",
+				password: "longenough",
+			});
+			expect(result.value.message).toBe("Action completed successfully.");
+		}
+	});
+
+	it("returns dense field errors and the default failure message", async () => {
+		const formData = buildFormData({ email: "a@b.c", password: "short" });
+
+		const result = await validateForm(formData, schema);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.key).toBe("validation");
+			expect(result.error.message).toBe(
+				"There were errors with your submission.",
+			);
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({
+					fieldErrors: { email: [], password: ["Password is too short."] },
+				}),
+			);
+		}
+	});
+
+	it("echoes every submitted value into metadata — including the password", async () => {
+		// Same-user echo, but still hygiene: BACKLOG "Stop echoing sensitive
+		// fields" wants an allowlist here. Pinned as-is until then.
+		const formData = buildFormData({
+			email: "a@b.c",
+			password: "hunter2",
+		});
+
+		const result = await validateForm(formData, schema);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({
+					formData: { email: "a@b.c", password: "hunter2" },
+				}),
+			);
+		}
+	});
+
+	it("uses custom messages when provided", async () => {
+		const ok = await validateForm(
+			buildFormData({ email: "a@b.c", password: "longenough" }),
+			schema,
+			undefined,
+			{ messages: { successMessage: "Welcome!" } },
+		);
+		const err = await validateForm(
+			buildFormData({ email: "a@b.c", password: "x" }),
+			schema,
+			undefined,
+			{ messages: { failureMessage: "Check the form." } },
+		);
+
+		expect(ok.ok).toBe(true);
+		if (ok.ok) {
+			expect(ok.value.message).toBe("Welcome!");
+		}
+		expect(err.ok).toBe(false);
+		if (!err.ok) {
+			expect(err.error.message).toBe("Check the form.");
+		}
+	});
+
+	it("validates an explicit raw payload instead of the FormData", async () => {
+		const result = await validateForm(buildFormData({}), schema, undefined, {
+			raw: { email: "a@b.c", password: "longenough" },
+		});
+
+		expect(result.ok).toBe(true);
+	});
+
+	it("maps a throwing refinement to a validation failure with empty field errors", async () => {
+		const throwing = schema.refine(() => {
+			throw new Error("refinement exploded");
+		});
+
+		const result = await validateForm(
+			buildFormData({ email: "a@b.c", password: "longenough" }),
+			throwing,
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.key).toBe("validation");
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({
+					fieldErrors: { email: [], password: [] },
+				}),
+			);
+		}
+	});
+});

--- a/src/shared/forms/__tests__/unit/zod-error.mapper.test.ts
+++ b/src/shared/forms/__tests__/unit/zod-error.mapper.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+	fromZodError,
+	toDenseFieldErrorMapFromZod,
+} from "@/shared/forms/server/mappers/zod-error.mapper";
+
+/**
+ * Unit tests for the Zod error mapper (zod-error.mapper.ts).
+ *
+ * Adapts a foreign ZodError into the canonical dense field-error map plus
+ * form-level errors. Pinned: density over the allowed fields, dropping of
+ * unknown fields, and root issues landing in formErrors.
+ */
+describe("zod-error mapper", () => {
+	const schema = z.object({
+		email: z.string().min(3, "Email is too short."),
+		password: z.string().min(8, "Password is too short."),
+	});
+
+	function failParse(input: Record<string, string>): z.ZodError {
+		const parsed = schema.safeParse(input);
+		if (parsed.success) {
+			throw new Error("expected parse to fail");
+		}
+		return parsed.error;
+	}
+
+	describe("fromZodError", () => {
+		it("produces a dense map over the allowed fields", () => {
+			const error = failParse({ email: "a@b.c", password: "short" });
+
+			const { fieldErrors, formErrors } = fromZodError(error, [
+				"email",
+				"password",
+			]);
+
+			expect(fieldErrors).toEqual({
+				email: [],
+				password: ["Password is too short."],
+			});
+			expect(formErrors).toEqual([]);
+		});
+
+		it("drops issues for fields outside the allowed list", () => {
+			const error = failParse({ email: "x", password: "short" });
+
+			const { fieldErrors } = fromZodError(error, ["email"]);
+
+			expect(fieldErrors).toEqual({ email: ["Email is too short."] });
+		});
+
+		it("routes root-level issues into formErrors", () => {
+			const refined = schema.refine(() => false, "Form is invalid.");
+			const parsed = refined.safeParse({
+				email: "a@b.c",
+				password: "longenough",
+			});
+			if (parsed.success) {
+				throw new Error("expected parse to fail");
+			}
+
+			const { fieldErrors, formErrors } = fromZodError(parsed.error, [
+				"email",
+				"password",
+			]);
+
+			expect(formErrors).toEqual(["Form is invalid."]);
+			expect(fieldErrors).toEqual({ email: [], password: [] });
+		});
+	});
+
+	describe("toDenseFieldErrorMapFromZod", () => {
+		it("returns only the dense field-error map", () => {
+			const error = failParse({ email: "x", password: "short" });
+
+			expect(toDenseFieldErrorMapFromZod(error, ["email", "password"])).toEqual(
+				{
+					email: ["Email is too short."],
+					password: ["Password is too short."],
+				},
+			);
+		});
+	});
+});

--- a/src/shared/forms/__tests__/unit/zod-schema.inspector.test.ts
+++ b/src/shared/forms/__tests__/unit/zod-schema.inspector.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+	resolveCanonicalFieldNames,
+	toSchemaKeys,
+} from "@/shared/forms/logic/inspectors/zod-schema.inspector";
+
+/**
+ * Unit tests for the Zod schema inspector (zod-schema.inspector.ts).
+ *
+ * Field names drive everything downstream (dense maps, echo payloads), so the
+ * resolution priority — explicit list, then allowed subset, then schema keys,
+ * then empty — is pinned, including the quirk that empty arrays are treated
+ * as absent.
+ */
+describe("zod-schema inspector", () => {
+	const schema = z.object({
+		email: z.string(),
+		password: z.string(),
+	});
+
+	describe("toSchemaKeys", () => {
+		it("derives the keys of an object schema", () => {
+			expect(toSchemaKeys(schema)).toEqual(["email", "password"]);
+		});
+
+		it("returns a frozen array", () => {
+			expect(Object.isFrozen(toSchemaKeys(schema))).toBe(true);
+		});
+	});
+
+	describe("resolveCanonicalFieldNames", () => {
+		it("prefers the explicit field list over everything else", () => {
+			const fields = resolveCanonicalFieldNames(
+				schema,
+				["password"],
+				["email"],
+			);
+
+			expect(fields).toEqual(["email"]);
+		});
+
+		it("falls back to the allowed subset when no explicit list is given", () => {
+			expect(resolveCanonicalFieldNames(schema, ["password"])).toEqual([
+				"password",
+			]);
+		});
+
+		it("derives fields from the object schema when no lists are given", () => {
+			expect(resolveCanonicalFieldNames(schema)).toEqual(["email", "password"]);
+		});
+
+		it("treats empty lists as absent and keeps falling through", () => {
+			expect(resolveCanonicalFieldNames(schema, [], [])).toEqual([
+				"email",
+				"password",
+			]);
+		});
+
+		it("returns a frozen empty array for a non-object schema", () => {
+			const fields = resolveCanonicalFieldNames(z.string());
+
+			expect(fields).toEqual([]);
+			expect(Object.isFrozen(fields)).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Step 2 ("Lock") of the forms/error cleanup roadmap: the forms module had **zero unit tests** and is exactly what the upcoming boundary redesign will rewrite. This adds 68 characterization tests across all 11 testable files under `src/shared/forms/__tests__/unit/`, pinning behavior **exactly as it is today** so the redesign refactors behind tests.

The three known quirks are pinned deliberately, each annotated with its BACKLOG item so changing them later is a conscious test edit:

| Pinned quirk | Test | BACKLOG item |
|---|---|---|
| `database`-keyed form errors silently drop their field errors; `extractFieldErrors` honors `validation\|conflict` while `extractFieldValues`/`extractFormErrors` honor only `validation` | `form-error.inspector.test.ts` | Fix field-error key coupling |
| `validateForm` echoes every submitted value — passwords included — into error metadata | `validate-form.test.ts` | Stop echoing sensitive fields |
| `formErrorPayloadMapper` falls back to `[error.message]` where `toFormErrorPayload` returns `[]` | `form-error-payload.mapper.test.ts` | Form error payload overlap |

Also pinned: the `INITIAL_STATE` fake-Err hack (tri-state item), DTO serialization at the `useActionState` boundary, dense/sparse map conversions, field-name resolution priority, the unknown-error path for throwing refinements, and logging in the validation factory (logger mocked via `@test-support`).

## Verification

- `pnpm test`: **216 passed** (was 148; +68, no existing tests touched)
- `pnpm check:fast`: clean (Biome + tsc + typegen)
- No source files changed — tests and a BACKLOG note only

## Remaining Phase 3 scope

`server` and the invoices/customers domain breadth, then consider coverage thresholds — tracked in BACKLOG.md.
