### PR TITLE
fix(forms): allowlist metadata.formData echo (reshape slice 2)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,20 +26,22 @@ this file is the deliberate workaround.)
   decide → reshape. Small independent PRs, in roughly this order; full context in
   memory (`project_forms_error_refactor`):
   - [x] **Decide boundary state type** _(2026-06-11)_ — ADR 001 in
-    `src/shared/forms/notes/adr/` (status: Proposed, awaiting review) merges the old
+    `src/shared/forms/notes/adr/` (status: Accepted) merges the old
     "tri-state form state" and "FormResult vs Result" items into one decision:
     `FormResult` stays a boundary DTO union (core `Result` keeps its
     `TError extends AppError` constraint), and idle is modeled as `null` via
     `FormState<T> = FormResult<T> | null` — no fake `INITIAL_STATE` error.
-  - [ ] **Implement FormState (reshape, slice 1)** — per ADR 001: `null` initial state
-    in the 7 `useActionState` forms, widen `FormAction`/action `prevState` types,
-    early-return on `null` in feedback components, delete `form-state.factory.ts` +
-    its tests (deliberate lock-protocol edit), update
-    `docs/standards/error-handling-and-result-pattern.md` + forms notes README in the
-    same PR.
-  - [ ] **Stop echoing sensitive fields** — failed submits echo submitted values
-    (including login/signup passwords) back to the client in `metadata.formData`
-    (`validateForm`, auth mappers). Same-user only, but allowlist what gets echoed.
+  - [x] **Implement FormState (reshape, slice 1)** _(2026-06-11, PR #50)_ — per
+    ADR 001: `null` initial state in the 7 `useActionState` forms, widened
+    `FormAction`/action `prevState` types, early-return on `null` in feedback
+    components, deleted `form-state.factory.ts` + its tests, updated
+    `docs/standards/error-handling-and-result-pattern.md` + forms notes README;
+    ADR status flipped to Accepted in the same PR.
+  - [x] **Stop echoing sensitive fields** _(2026-06-11)_ — `metadata.formData` is
+    now allowlist-only: `validateForm` echoes just `options.echoFields` (default
+    none), auth mappers filter through `selectEchoedFieldValues` (login echoes
+    email; signup echoes email+username; passwords never round-trip), and the
+    invoice actions stopped echoing raw input (incl. `sensitiveData`).
   - [ ] **One validation funnel** — auth/users use `validateForm`; create-invoice does
     inline `safeParse`; update-invoice hand-flattens Zod errors. Unify on `validateForm`.
   - [ ] **Fix field-error key coupling** — `makeFormError` stamps form metadata onto any

--- a/src/modules/auth/__tests__/unit/presentation/authn/to-login-form-result.mapper.test.ts
+++ b/src/modules/auth/__tests__/unit/presentation/authn/to-login-form-result.mapper.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { toLoginFormResult } from "@/modules/auth/presentation/authn/mappers/to-login-form-result.mapper";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
+
+/**
+ * Unit tests for toLoginFormResult.
+ *
+ * Security boundary: this mapper builds the client-visible FormResult for
+ * failed logins. Only `LOGIN_ECHO_FIELDS_LIST` values may appear in
+ * `metadata.formData`; the submitted password must never cross the
+ * Server Action boundary (BACKLOG: "Stop echoing sensitive fields").
+ */
+describe("toLoginFormResult", () => {
+	const submitted = {
+		email: "user@example.com",
+		password: "hunter2-secret",
+	} as const;
+
+	it("maps invalid_credentials to a unified response without echoing the password", () => {
+		const error = makeAppError(APP_ERROR_KEYS.invalid_credentials, {
+			cause: "",
+			message: "Invalid credentials.",
+			metadata: {},
+		});
+
+		const result = toLoginFormResult(error, submitted);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({
+					formData: { email: "user@example.com" },
+				}),
+			);
+
+			// JSON serialization safety: the DTO crossing the boundary carries
+			// no trace of the password.
+			expect(JSON.stringify(result)).not.toContain("hunter2-secret");
+		}
+	});
+
+	it("redacts the echo on the generic error path too", () => {
+		const error = makeAppError(APP_ERROR_KEYS.unexpected, {
+			cause: "",
+			message: "Something broke.",
+			metadata: {},
+		});
+
+		const result = toLoginFormResult(error, submitted);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({
+					formData: { email: "user@example.com" },
+				}),
+			);
+			expect(JSON.stringify(result)).not.toContain("hunter2-secret");
+		}
+	});
+});

--- a/src/modules/auth/__tests__/unit/presentation/authn/to-signup-form-result.mapper.test.ts
+++ b/src/modules/auth/__tests__/unit/presentation/authn/to-signup-form-result.mapper.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { toSignupFormResult } from "@/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
+import { PG_CODES } from "@/shared/core/errors/server/adapters/postgres/pg-error.constants";
+
+/**
+ * Unit tests for toSignupFormResult.
+ *
+ * Security boundary: this mapper builds the client-visible FormResult for
+ * failed signups. Only `SIGNUP_ECHO_FIELDS_LIST` values may appear in
+ * `metadata.formData`; the submitted password must never cross the
+ * Server Action boundary (BACKLOG: "Stop echoing sensitive fields").
+ */
+describe("toSignupFormResult", () => {
+	const submitted = {
+		email: "user@example.com",
+		password: "hunter2-secret",
+		username: "andrew",
+	} as const;
+
+	it("maps a unique violation to conflict field errors without echoing the password", () => {
+		const error = makeAppError(APP_ERROR_KEYS.conflict, {
+			cause: "",
+			message: "duplicate key",
+			metadata: {
+				constraint: "users_email_unique",
+				pgCode: PG_CODES.UNIQUE_VIOLATION,
+			},
+		});
+
+		const result = toSignupFormResult(error, submitted);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.key).toBe(APP_ERROR_KEYS.conflict);
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({
+					fieldErrors: expect.objectContaining({
+						email: ["alreadyInUse"],
+					}),
+					formData: { email: "user@example.com", username: "andrew" },
+				}),
+			);
+
+			// JSON serialization safety: the DTO crossing the boundary carries
+			// no trace of the password.
+			expect(JSON.stringify(result)).not.toContain("hunter2-secret");
+		}
+	});
+
+	it("redacts the echo on the generic error path too", () => {
+		const error = makeAppError(APP_ERROR_KEYS.unexpected, {
+			cause: "",
+			message: "Something broke.",
+			metadata: {},
+		});
+
+		const result = toSignupFormResult(error, submitted);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({
+					formData: { email: "user@example.com", username: "andrew" },
+				}),
+			);
+			expect(JSON.stringify(result)).not.toContain("hunter2-secret");
+		}
+	});
+});

--- a/src/modules/auth/presentation/authn/actions/login.action.ts
+++ b/src/modules/auth/presentation/authn/actions/login.action.ts
@@ -5,6 +5,7 @@ import { makeAuthComposition } from "@/modules/auth/infrastructure/composition/a
 import { toLoginCommand } from "@/modules/auth/presentation/authn/adapters/to-login-command.adapter";
 import { toLoginFormResult } from "@/modules/auth/presentation/authn/mappers/to-login-form-result.mapper";
 import {
+	LOGIN_ECHO_FIELDS_LIST,
 	LOGIN_FIELDS_LIST,
 	LoginFormSchema,
 	type LoginRequestDto,
@@ -56,7 +57,9 @@ export async function loginAction(
 	});
 
 	const validated = await tracker.measure("validation", () =>
-		validateForm(formData, LoginFormSchema, LOGIN_FIELDS_LIST),
+		validateForm(formData, LoginFormSchema, LOGIN_FIELDS_LIST, {
+			echoFields: LOGIN_ECHO_FIELDS_LIST,
+		}),
 	);
 
 	if (!validated.ok) {

--- a/src/modules/auth/presentation/authn/actions/signup.action.ts
+++ b/src/modules/auth/presentation/authn/actions/signup.action.ts
@@ -5,6 +5,7 @@ import { makeAuthComposition } from "@/modules/auth/infrastructure/composition/a
 import { toSignupCommand } from "@/modules/auth/presentation/authn/adapters/to-signup-command.adapter";
 import { toSignupFormResult } from "@/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper";
 import {
+	SIGNUP_ECHO_FIELDS_LIST,
 	SIGNUP_FIELDS_LIST,
 	SignupFormSchema,
 	type SignupRequestDto,
@@ -59,7 +60,9 @@ export async function signupAction(
 	});
 
 	const validated = await tracker.measure("validation", () =>
-		validateForm(formData, SignupFormSchema, fields),
+		validateForm(formData, SignupFormSchema, fields, {
+			echoFields: SIGNUP_ECHO_FIELDS_LIST,
+		}),
 	);
 
 	if (!validated.ok) {

--- a/src/modules/auth/presentation/authn/mappers/to-login-form-result.mapper.ts
+++ b/src/modules/auth/presentation/authn/mappers/to-login-form-result.mapper.ts
@@ -1,9 +1,13 @@
 import { mapGenericAuthError } from "@/modules/auth/presentation/authn/mappers/map-generic-auth.error";
-import { LOGIN_FIELDS_LIST } from "@/modules/auth/presentation/authn/transports/login.form.schema";
+import {
+	LOGIN_ECHO_FIELDS_LIST,
+	LOGIN_FIELDS_LIST,
+} from "@/modules/auth/presentation/authn/transports/login.form.schema";
 import type { LoginField } from "@/modules/auth/presentation/authn/transports/login.transport";
 import type { AppError } from "@/shared/core/errors/core/app-error.entity";
 import type { FormResult } from "@/shared/forms/core/types/form-result.dto";
 import { makeFormError } from "@/shared/forms/logic/factories/form-result.factory";
+import { selectEchoedFieldValues } from "@/shared/forms/logic/mappers/field-value-map.mapper";
 import { toFormErrorPayload } from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
 
 const LOGIN_CREDENTIALS_ERROR_MESSAGE =
@@ -52,6 +56,9 @@ function mapLoginInvalidCredentialsError(
  * Returns `FormResult<never>` because this mapper is intended for error scenarios
  * only (it never returns a success state).
  *
+ * Only fields in `LOGIN_ECHO_FIELDS_LIST` are echoed back in error metadata;
+ * the submitted password never leaves the server.
+ *
  * @param error - The application error encountered during login.
  * @param formData - The data submitted with the login form.
  * @returns A {@link FormResult} containing the mapped errors.
@@ -60,9 +67,14 @@ export function toLoginFormResult(
 	error: AppError,
 	formData: LoginFormData,
 ): FormResult<never> {
+	const echoed = selectEchoedFieldValues<LoginField>(
+		formData,
+		LOGIN_ECHO_FIELDS_LIST,
+	);
+
 	if (error.key === "invalid_credentials") {
-		return mapLoginInvalidCredentialsError(error, formData);
+		return mapLoginInvalidCredentialsError(error, echoed);
 	}
 
-	return mapGenericAuthError(error, formData, LOGIN_FIELDS_LIST);
+	return mapGenericAuthError(error, echoed, LOGIN_FIELDS_LIST);
 }

--- a/src/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper.ts
+++ b/src/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper.ts
@@ -1,6 +1,9 @@
 import "server-only";
 import { mapGenericAuthError } from "@/modules/auth/presentation/authn/mappers/map-generic-auth.error";
-import { SIGNUP_FIELDS_LIST } from "@/modules/auth/presentation/authn/transports/signup.form.schema";
+import {
+	SIGNUP_ECHO_FIELDS_LIST,
+	SIGNUP_FIELDS_LIST,
+} from "@/modules/auth/presentation/authn/transports/signup.form.schema";
 import type { SignupField } from "@/modules/auth/presentation/authn/transports/signup.transport";
 import type { AppError } from "@/shared/core/errors/core/app-error.entity";
 import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
@@ -16,6 +19,7 @@ import type {
 import type { FormResult } from "@/shared/forms/core/types/form-result.dto";
 import { toFormErrResult } from "@/shared/forms/logic/factories/form-result.factory";
 import { toDenseFieldErrorMap } from "@/shared/forms/logic/mappers/field-error-map.mapper";
+import { selectEchoedFieldValues } from "@/shared/forms/logic/mappers/field-value-map.mapper";
 
 type SignupFormData = Readonly<Partial<Record<SignupField, string>>>;
 
@@ -34,6 +38,9 @@ const ALREADY_IN_USE_FIELD_ERRORS: FieldError<string> = Object.freeze([
  * Returns `FormResult<never>` because this mapper is intended for error scenarios
  * only (it never returns a success state).
  *
+ * Only fields in `SIGNUP_ECHO_FIELDS_LIST` are echoed back in error metadata;
+ * the submitted password never leaves the server.
+ *
  * @param error - The application error encountered during signup.
  * @param formData - The data submitted with the signup form.
  * @returns A {@link FormResult} containing the mapped errors.
@@ -42,6 +49,11 @@ export function toSignupFormResult(
 	error: AppError,
 	formData: SignupFormData,
 ): FormResult<never> {
+	const echoed = selectEchoedFieldValues<SignupField>(
+		formData,
+		SIGNUP_ECHO_FIELDS_LIST,
+	);
+
 	if (
 		isPgMetadata(error.metadata) &&
 		error.metadata.pgCode === PG_CODES.UNIQUE_VIOLATION
@@ -84,7 +96,7 @@ export function toSignupFormResult(
 					...error.metadata,
 					constraint,
 					fieldErrors,
-					formData,
+					formData: echoed,
 					formErrors: Object.freeze([]),
 					pgCode: PG_CODES.UNIQUE_VIOLATION,
 				}),
@@ -92,5 +104,5 @@ export function toSignupFormResult(
 		);
 	}
 
-	return mapGenericAuthError(error, formData, SIGNUP_FIELDS_LIST);
+	return mapGenericAuthError(error, echoed, SIGNUP_FIELDS_LIST);
 }

--- a/src/modules/auth/presentation/authn/transports/login.form.schema.ts
+++ b/src/modules/auth/presentation/authn/transports/login.form.schema.ts
@@ -24,3 +24,10 @@ export type LoginRequestDto = z.output<typeof LoginFormSchema>;
 
 export const LOGIN_FIELDS_LIST: readonly (keyof LoginRequestDto & string)[] =
 	toSchemaKeys(LoginFormSchema);
+
+/**
+ * Fields safe to echo back in error metadata for repopulation after a
+ * failed submit. Deliberately excludes `password`.
+ */
+export const LOGIN_ECHO_FIELDS_LIST: readonly (keyof LoginRequestDto &
+	string)[] = ["email"];

--- a/src/modules/auth/presentation/authn/transports/signup.form.schema.ts
+++ b/src/modules/auth/presentation/authn/transports/signup.form.schema.ts
@@ -16,3 +16,10 @@ export const SignupFormSchema = LoginFormSchema.safeExtend({
 export type SignupRequestDto = z.output<typeof SignupFormSchema>;
 
 export const SIGNUP_FIELDS_LIST = toSchemaKeys(SignupFormSchema);
+
+/**
+ * Fields safe to echo back in error metadata for repopulation after a
+ * failed submit. Deliberately excludes `password`.
+ */
+export const SIGNUP_ECHO_FIELDS_LIST: readonly (keyof SignupRequestDto &
+	string)[] = ["email", "username"];

--- a/src/modules/invoices/presentation/actions/create-invoice.action.ts
+++ b/src/modules/invoices/presentation/actions/create-invoice.action.ts
@@ -50,7 +50,9 @@ export async function createInvoiceAction(
 				parsed.error,
 				CREATE_INVOICE_FIELDS_LIST,
 			),
-			formData: rawInput,
+			// No echo: nothing repopulates from invoice error metadata, and the
+			// raw payload includes sensitiveData.
+			formData: {},
 			formErrors: [],
 			key: "validation",
 			message: translator(INVOICE_MSG.validationFailed),
@@ -72,7 +74,7 @@ export async function createInvoiceAction(
 					sensitiveData: [],
 					status: [],
 				},
-				formData: rawInput,
+				formData: {},
 				formErrors: [],
 				key: isAppError(result.error) ? result.error.key : "unknown",
 				message: toInvoiceErrorMessage(result.error),

--- a/src/modules/invoices/presentation/actions/update-invoice.action.ts
+++ b/src/modules/invoices/presentation/actions/update-invoice.action.ts
@@ -102,7 +102,9 @@ export async function updateInvoiceAction(
 
 			return makeFormError<UpdateInvoiceFieldNames>({
 				fieldErrors: dense,
-				formData: input as Partial<Record<UpdateInvoiceFieldNames, string>>,
+				// No echo: nothing repopulates from invoice error metadata, and the
+				// raw payload includes sensitiveData.
+				formData: {},
 				formErrors: [],
 				key: "validation",
 				message: INVOICE_MSG.validationFailed,

--- a/src/shared/forms/__tests__/unit/field-value-map.mapper.test.ts
+++ b/src/shared/forms/__tests__/unit/field-value-map.mapper.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { selectEchoedFieldValues } from "@/shared/forms/logic/mappers/field-value-map.mapper";
+
+/**
+ * Unit tests for the echo allowlist filter (field-value-map.mapper.ts).
+ *
+ * `selectEchoedFieldValues` is the single primitive deciding which submitted
+ * values may cross back to the client in error metadata (BACKLOG: "Stop
+ * echoing sensitive fields"). Pinned: allowlist-only picking, omission of
+ * absent fields, and the frozen empty result for an empty allowlist.
+ */
+describe("selectEchoedFieldValues", () => {
+	type Field = "email" | "password" | "username";
+
+	const values: Readonly<Partial<Record<Field, string>>> = {
+		email: "a@b.c",
+		password: "hunter2",
+		username: "andrew",
+	};
+
+	it("picks only allowlisted fields", () => {
+		const result = selectEchoedFieldValues<Field>(values, [
+			"email",
+			"username",
+		]);
+
+		expect(result).toEqual({ email: "a@b.c", username: "andrew" });
+		expect(result).not.toHaveProperty("password");
+	});
+
+	it("returns a frozen empty map for an empty allowlist", () => {
+		const result = selectEchoedFieldValues<Field>(values, []);
+
+		expect(result).toEqual({});
+		expect(Object.isFrozen(result)).toBe(true);
+	});
+
+	it("omits allowlisted fields that have no submitted value", () => {
+		const result = selectEchoedFieldValues<Field>({ email: "a@b.c" }, [
+			"email",
+			"username",
+		]);
+
+		expect(result).toEqual({ email: "a@b.c" });
+	});
+});

--- a/src/shared/forms/__tests__/unit/validate-form.test.ts
+++ b/src/shared/forms/__tests__/unit/validate-form.test.ts
@@ -16,10 +16,9 @@ vi.mock(
  *
  * `validateForm` is the intended single entry point from FormData to a
  * FormResult (BACKLOG: "One validation funnel"). Pinned: the ok path with
- * default and custom messages, dense field errors on failure, the verbatim
- * echo of submitted values — including passwords — into error metadata
- * (BACKLOG: "Stop echoing sensitive fields"), and the unknown-error path for
- * throwing refinements.
+ * default and custom messages, dense field errors on failure, the echo
+ * allowlist contract — nothing is echoed into error metadata unless listed
+ * in `echoFields` — and the unknown-error path for throwing refinements.
  */
 describe("validateForm", () => {
 	const schema = z.object({
@@ -64,9 +63,7 @@ describe("validateForm", () => {
 		}
 	});
 
-	it("echoes every submitted value into metadata — including the password", async () => {
-		// Same-user echo, but still hygiene: BACKLOG "Stop echoing sensitive
-		// fields" wants an allowlist here. Pinned as-is until then.
+	it("echoes nothing into metadata by default — submitted values stay server-side", async () => {
 		const formData = buildFormData({
 			email: "a@b.c",
 			password: "hunter2",
@@ -77,9 +74,46 @@ describe("validateForm", () => {
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
 			expect(result.error.metadata).toEqual(
-				expect.objectContaining({
-					formData: { email: "a@b.c", password: "hunter2" },
-				}),
+				expect.objectContaining({ formData: {} }),
+			);
+			expect(JSON.stringify(result)).not.toContain("hunter2");
+		}
+	});
+
+	it("echoes only the fields allowlisted via echoFields", async () => {
+		const formData = buildFormData({
+			email: "a@b.c",
+			password: "hunter2",
+		});
+
+		const result = await validateForm(formData, schema, undefined, {
+			echoFields: ["email"],
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({ formData: { email: "a@b.c" } }),
+			);
+			expect(JSON.stringify(result)).not.toContain("hunter2");
+		}
+	});
+
+	it("applies the echo allowlist to an explicit raw payload too", async () => {
+		const result = await validateForm(
+			buildFormData({}),
+			schema,
+			["email", "password"],
+			{
+				echoFields: ["email"],
+				raw: { email: "a@b.c", password: "x" },
+			},
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.metadata).toEqual(
+				expect.objectContaining({ formData: { email: "a@b.c" } }),
 			);
 		}
 	});

--- a/src/shared/forms/core/types/form-validation.dto.ts
+++ b/src/shared/forms/core/types/form-validation.dto.ts
@@ -7,6 +7,12 @@ import type { SparseFieldValueMap } from "@/shared/forms/core/types/field-value.
  * @typeParam K - A string literal union of keys from `T` representing field names.
  */
 export interface FormValidationOptions<T, K extends keyof T & string> {
+	/**
+	 * Fields safe to echo back to the client in error metadata (`formData`)
+	 * for repopulation after a failed submit. Anything not listed — passwords
+	 * in particular — never leaves the server. Defaults to echoing nothing.
+	 */
+	readonly echoFields?: readonly K[];
 	readonly fields?: readonly K[];
 	readonly loggerContext?: string;
 	readonly messages?: {

--- a/src/shared/forms/logic/mappers/field-value-map.mapper.ts
+++ b/src/shared/forms/logic/mappers/field-value-map.mapper.ts
@@ -1,0 +1,29 @@
+import type { SparseFieldValueMap } from "@/shared/forms/core/types/field-value.types";
+
+/**
+ * Filters submitted field values down to the fields allowlisted for echo.
+ *
+ * Echoed values become client-visible `metadata.formData` on failed submits,
+ * so anything sensitive (passwords above all) must stay off the allowlist.
+ *
+ * @typeParam T - Allowed field name union.
+ * @param values - Submitted values (raw or validated), possibly sensitive.
+ * @param allowedFields - Fields safe to echo back to the client.
+ * @returns A frozen {@link SparseFieldValueMap} containing only allowlisted fields with defined values.
+ */
+export function selectEchoedFieldValues<T extends string>(
+	values: SparseFieldValueMap<T, string>,
+	allowedFields: readonly T[],
+): SparseFieldValueMap<T, string> {
+	const result = {} as Record<T, string>;
+
+	for (const field of allowedFields) {
+		const value = values[field];
+
+		if (value !== undefined) {
+			result[field] = value;
+		}
+	}
+
+	return Object.freeze(result);
+}

--- a/src/shared/forms/notes/README.md
+++ b/src/shared/forms/notes/README.md
@@ -31,10 +31,14 @@ environment, bridging the gap between Server Actions and client-side UI.
   empty) and "sparse" maps (where only fields with errors are present).
 - **Metadata**: Validation errors carry `FormValidationMetadata`, which includes the dense error map and the echoed form
   data (for re-populating fields).
+- **Echo allowlist**: `metadata.formData` is client-visible, so nothing is echoed unless explicitly allowlisted —
+  `validateForm` echoes only `options.echoFields` (default: none), and mappers building results by hand filter through
+  `selectEchoedFieldValues`. Sensitive values (passwords above all) never round-trip to the client.
 
 #### Best Practices
 
 - Use `validateForm` in Server Actions to ensure consistent error handling and logging.
+- Opt into field echo deliberately: list only safe-to-display fields in `echoFields` (never passwords or secrets).
 - Pass `null` as the `useActionState` initial state; let feedback components (e.g. `useFormMessage` in
   `src/ui/forms/hooks/`) early-return on `null` rather than inventing a fake initial error.
 - Prefer `FieldError` (non-empty array) when representing specific validation failures.

--- a/src/shared/forms/server/factories/form-validation-error.factory.ts
+++ b/src/shared/forms/server/factories/form-validation-error.factory.ts
@@ -31,6 +31,10 @@ function mapToValidationErrors<T extends string>(
 
 /**
  * Internal helper to log and wrap validation errors.
+ *
+ * @remarks
+ * `formData` becomes client-visible `metadata.formData`; callers must pass
+ * only values already allowlisted for echo (see `FormValidationOptions.echoFields`).
  */
 export function formValidationErrorFactory<Tfieldnames extends string>(
 	error: unknown,

--- a/src/shared/forms/server/validate-form.ts
+++ b/src/shared/forms/server/validate-form.ts
@@ -24,6 +24,9 @@ import { resolveRawFieldPayload } from "@/shared/forms/server/utils/form-data.ut
  * - Resolves validation options and canonical field names.
  * - Extracts raw payload from `FormData`.
  * - Calls `schema.safeParseAsync` and maps Zod errors to form field errors when validation fails.
+ * - On failure, echoes only `options.echoFields` back in `metadata.formData`
+ *   (default: none), so submitted values never round-trip to the client
+ *   unless explicitly allowlisted.
  */
 export async function validateForm<Tin, Tfieldnames extends keyof Tin & string>(
 	formData: FormData,
@@ -32,6 +35,7 @@ export async function validateForm<Tin, Tfieldnames extends keyof Tin & string>(
 	options: FormValidationOptions<Tin, Tfieldnames> = {},
 ): Promise<FormResult<Tin>> {
 	const {
+		echoFields,
 		fields: explicitFields,
 		loggerContext = "FormValidation",
 		messages: {
@@ -49,6 +53,14 @@ export async function validateForm<Tin, Tfieldnames extends keyof Tin & string>(
 
 	const raw = resolveRawFieldPayload(formData, fields, explicitRaw);
 
+	// Only allowlisted fields are echoed into error metadata; the full raw
+	// payload stays server-side.
+	const echoed = resolveRawFieldPayload(
+		formData,
+		echoFields ?? [],
+		explicitRaw,
+	);
+
 	let parsed: Awaited<ReturnType<typeof schema.safeParseAsync>>;
 	try {
 		parsed = await schema.safeParseAsync(raw);
@@ -57,7 +69,7 @@ export async function validateForm<Tin, Tfieldnames extends keyof Tin & string>(
 		return formValidationErrorFactory<Tfieldnames>(e, loggerContext, {
 			failureMessage,
 			fields,
-			formData: raw,
+			formData: echoed,
 		});
 	}
 
@@ -69,7 +81,7 @@ export async function validateForm<Tin, Tfieldnames extends keyof Tin & string>(
 			{
 				failureMessage,
 				fields,
-				formData: raw,
+				formData: echoed,
 			},
 		);
 	}


### PR DESCRIPTION
## Summary

Reshape slice 2 of the forms/error cleanup (follows ADR 001 / #50): stop echoing sensitive fields. Failed submits previously echoed every submitted value — including login/signup passwords — back to the client in `metadata.formData`. The echo is now **allowlist-only**:

- `validateForm` gains `FormValidationOptions.echoFields` and echoes **nothing by default**; a form must opt in to repopulation.
- The auth workflow-failure path redacts inside `toLoginFormResult` / `toSignupFormResult` via a new `selectEchoedFieldValues` mapper, so every caller and branch is covered. Per-form allowlists (`LOGIN_ECHO_FIELDS_LIST` = email, `SIGNUP_ECHO_FIELDS_LIST` = email+username) live next to the existing field lists in the transport schemas.
- The invoice actions echo `{}` — their raw-input echo included the `sensitiveData` demo field, and no invoice UI ever consumed the echo.

UX is unchanged where it mattered: login/signup still repopulate email (and username) after a failed submit; password fields clear.

## Type of change

- [x] Fix

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen)
- [x] `pnpm test` (unit) — 221/221; lane grew 212 → 221
- [ ] `pnpm cy:e2e` (end-to-end)
- [x] Manually verified in the running app — submitted failing logins on both paths (validation failure and real `invalid_credentials`) with probe passwords and inspected the server action responses: `formData` carries only `{"email": …}`, probe passwords absent from the entire payload; email repopulates in the UI.

## Reviewer notes

- **Deliberate lock-protocol edit**: the PR #48 characterization pin *"echoes every submitted value into metadata — including the password"* is flipped to *"echoes nothing into metadata by default"*, with new allowlist-contract tests beside it. New unit tests cover `selectEchoedFieldValues` and both auth mappers (password never serializes, JSON-stringify probe included).
- Adjacent issue spotted but **out of scope**: the signup conflict branch spreads `...error.metadata`, forwarding raw PG fields (`detail`, `table`, `schema`) to the client. Tracked separately.
- Next slice per BACKLOG: single validation funnel (`validateForm` everywhere), which will shrink the hand-built error paths this PR had to touch.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (forms notes README + BACKLOG)
- [x] Focused change — preserves existing patterns and user-authored work
