### PR TITLE
refactor(invoices): one validation funnel via validateForm (reshape slice 3)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -42,8 +42,13 @@ this file is the deliberate workaround.)
     none), auth mappers filter through `selectEchoedFieldValues` (login echoes
     email; signup echoes email+username; passwords never round-trip), and the
     invoice actions stopped echoing raw input (incl. `sensitiveData`).
-  - [ ] **One validation funnel** — auth/users use `validateForm`; create-invoice does
-    inline `safeParse`; update-invoice hand-flattens Zod errors. Unify on `validateForm`.
+  - [x] **One validation funnel** _(2026-06-11)_ — create/update-invoice now go
+    through `validateForm` like auth/users (create dropped its inline `safeParse`;
+    update dropped per-field `formData.get` + hand-flattened Zod errors). The edit
+    form's messages are translated text instead of raw `INVOICE.*` ids (update's
+    AppError branch now says `updateFailed`, not `invalidInput`'s "create" copy),
+    and the stale-skipped update-form Cypress error test is re-enabled — its
+    serialization blocker was fixed back in PR #41.
   - [ ] **Fix field-error key coupling** — `makeFormError` stamps form metadata onto any
     error key, but extractors only honor `validation` | `conflict`; a `database`-keyed
     form error silently drops its field errors (`form-error.inspector.ts`).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -86,6 +86,15 @@ this file is the deliberate workaround.)
   Triage each: knip config fix vs. un-export vs. delete.
 - [ ] **Skills exploration** — evaluate reputable-source skills (e.g. Vercel's
   `vercel-react-best-practices`) against `docs/standards/` before adopting.
+- [ ] **e2e port-reuse guard** — `cy:e2e` inherits the session's `PORT` (the
+  `env:test*` scripts run dotenv without `-o`, so an exported `PORT` wins over
+  `.env.test.local`), and start-server-and-test reuses ANY server already
+  answering on that port. With a dev preview running on 3001, two full suite
+  runs (2026-06-11) silently executed against the dev server — `/api/db/reset`
+  404s there, so 7 specs "failed" with no hint of the real cause. Fix ideas:
+  add `-o` to the `env:test*` scripts, pin the cypress PORT, or have
+  `cypress-with-server.cli.ts` verify the responding server's `DATABASE_ENV`
+  (the `smoke/log-env` spec already proves the concept).
 - [ ] **TSConfig Version 6** - figure out how to use TSConfig Version 6.
 - [ ]  The allowCypressEnv configuration option is enabled. This allows any browser code to read values from
   Cypress.env(). This is insecure and will be removed in a future major version.

--- a/cypress/e2e/invoices/update-form.cy.ts
+++ b/cypress/e2e/invoices/update-form.cy.ts
@@ -41,11 +41,7 @@ describe("Invoices - Update via Server Action Form", () => {
 		cy.location("pathname").should("include", EDIT_PATH_FRAGMENT);
 	});
 
-	// SKIPPED: blocked by an app bug — form error results are AppError class
-	// instances (makeFormError → Err(makeAppError)), which can't be serialized
-	// across the server-action boundary, so the error banner never renders.
-	// biome-ignore lint/suspicious/noSkippedTests: re-enable once form errors are plain serializable objects (tracked)
-	it.skip("shows an error message when the amount is invalid", () => {
+	it("shows an error message when the amount is invalid", () => {
 		openFirstInvoiceForEdit();
 
 		// Amount must be positive, so 0 fails server-side validation.

--- a/cypress/e2e/server-actions/auth-actions.cy.ts
+++ b/cypress/e2e/server-actions/auth-actions.cy.ts
@@ -5,6 +5,7 @@ import {
 } from "@cypress/e2e/shared/auth-forms";
 import { DASHBOARD_PATH, LOGIN_PATH } from "@cypress/e2e/shared/paths";
 import { AUTH_SEL } from "@cypress/e2e/shared/selectors";
+import { DEFAULT_TIMEOUT } from "@cypress/e2e/shared/times";
 import { createTestUser } from "@cypress/e2e/shared/users";
 
 describe("Authentication Server Actions", () => {
@@ -22,20 +23,20 @@ describe("Authentication Server Actions", () => {
 		cy.url().should("include", DASHBOARD_PATH);
 	});
 
-	// SKIPPED: same app bug as the invoice update error test — auth form error
-	// results are AppError class instances that can't serialize across the
-	// server-action boundary, so the "Failed to validate form data" banner never
-	// renders.
-	// biome-ignore lint/suspicious/noSkippedTests: re-enable once form errors are plain serializable objects (tracked)
-	it.skip("should handle login with invalid credentials", () => {
+	it("should handle login with invalid credentials", () => {
 		cy.visit(LOGIN_PATH);
 		cy.get(AUTH_SEL.loginEmail).type(INVALID_EMAIL);
 		cy.get(AUTH_SEL.loginPassword).type(INVALID_PASSWORD);
 
 		cy.get(AUTH_SEL.loginSubmit).click();
 
-		// Assert error UI is shown, and we remain on login
-		cy.findByText(ERROR_MESSAGES_REGEX.failedAuthForm).should("be.visible");
+		// The unified invalid-credentials message renders in the AuthFormFeedback
+		// banner AND as both field errors (no username enumeration), so target
+		// the banner selector rather than findByText (which requires a unique match).
+		cy.get(AUTH_SEL.authServerMessageError, { timeout: DEFAULT_TIMEOUT })
+			.should("be.visible")
+			.invoke("text")
+			.should("match", ERROR_MESSAGES_REGEX.invalidCredentials);
 		cy.url().should("include", LOGIN_PATH);
 	});
 });

--- a/cypress/e2e/shared/auth-forms.ts
+++ b/cypress/e2e/shared/auth-forms.ts
@@ -2,12 +2,18 @@ import type { UserRole } from "@database/schema/schema.constants";
 
 export const E2E_ID_MODULUS = 99_999_999 as const;
 
+// Credentials for the invalid-credentials login test. Both must PASS schema
+// validation (PasswordSchema requires a letter, number, and special char) so
+// the submission reaches authentication and fails THERE — otherwise the form
+// short-circuits with a validation error instead of the unified
+// invalid-credentials response.
 export const INVALID_EMAIL: string = "invalid@example.com";
-export const INVALID_PASSWORD: string = "wrongpassword";
+export const INVALID_PASSWORD: string = "Wr0ngPassword!";
 
 export const ERROR_MESSAGES_REGEX = {
-	failedAuthForm: /Failed to validate form data/i,
-	invalidCredentials: /Invalid email or password/i,
+	// Must match LOGIN_CREDENTIALS_ERROR_MESSAGE in to-login-form-result.mapper.ts
+	// ("Invalid credentials. Please try again.").
+	invalidCredentials: /invalid credentials/i,
 } as const satisfies Readonly<Record<string, RegExp>>;
 
 export type SignupCreds = {

--- a/cypress/e2e/shared/selectors.ts
+++ b/cypress/e2e/shared/selectors.ts
@@ -13,6 +13,8 @@ export const COMMON_SEL = {
 
 // Auth-related selectors (login/signup)
 export const AUTH_SEL = {
+	// Server-action feedback rendered by AuthFormFeedback (FormAlertMolecule).
+	authServerMessageError: '[data-cy="auth-server-message-error"]',
 	loginEmail: '[data-cy="login-email-input"]',
 	//  For a "pure" fundamental level, lean more heavily on Testing Library queries (which you already have installed).
 	//  Instead of cy.get('#email'), use cy.findByLabelText(/email/i). This makes tests less dependent on code structure

--- a/src/modules/invoices/domain/schema/invoice.schema.ts
+++ b/src/modules/invoices/domain/schema/invoice.schema.ts
@@ -57,3 +57,5 @@ export type EditInvoiceViewModel = z.output<typeof CreateInvoiceSchema> & {
 };
 
 export const CREATE_INVOICE_FIELDS_LIST = toSchemaKeys(CreateInvoiceSchema);
+
+export const UPDATE_INVOICE_FIELDS_LIST = toSchemaKeys(UpdateInvoiceSchema);

--- a/src/modules/invoices/presentation/actions/create-invoice.action.ts
+++ b/src/modules/invoices/presentation/actions/create-invoice.action.ts
@@ -23,7 +23,7 @@ import {
 	makeFormOk,
 } from "@/shared/forms/logic/factories/form-result.factory";
 import { toDenseFieldErrorMapFromZod } from "@/shared/forms/server/mappers/zod-error.mapper";
-import { resolveRawFieldPayload } from "@/shared/forms/server/utils/form-data.utils";
+import { validateForm } from "@/shared/forms/server/validate-form";
 import { isZodErrorInstance } from "@/shared/policies/zod/zod.guard";
 import { ROUTES } from "@/shared/routing/routes";
 import { logger } from "@/shared/telemetry/logging/infrastructure/logging.client";
@@ -40,30 +40,30 @@ export async function createInvoiceAction(
 	// try/catch below so a no-session redirect propagates instead of being caught.
 	await requireSession();
 
-	// 1. Parse Input: Leverage infrastructure for consistent extraction
-	const rawInput = resolveRawFieldPayload(formData, CREATE_INVOICE_FIELDS_LIST);
-	const parsed = CreateInvoiceSchema.safeParse(rawInput);
+	// 1. Validate input through the shared funnel. Echo stays off (the default):
+	// nothing repopulates from invoice error metadata, and the raw payload
+	// includes sensitiveData.
+	const validated = await validateForm(
+		formData,
+		CreateInvoiceSchema,
+		CREATE_INVOICE_FIELDS_LIST,
+		{
+			loggerContext: "createInvoiceAction",
+			messages: { failureMessage: translator(INVOICE_MSG.validationFailed) },
+		},
+	);
 
-	if (!parsed.success) {
-		return makeFormError<CreateInvoiceFieldNames>({
-			fieldErrors: toDenseFieldErrorMapFromZod(
-				parsed.error,
-				CREATE_INVOICE_FIELDS_LIST,
-			),
-			// No echo: nothing repopulates from invoice error metadata, and the
-			// raw payload includes sensitiveData.
-			formData: {},
-			formErrors: [],
-			key: "validation",
-			message: translator(INVOICE_MSG.validationFailed),
-		});
+	if (!validated.ok) {
+		return validated;
 	}
+
+	const payload = validated.value.data;
 
 	// 2. Perform Async Operation
 	try {
 		const repo = new InvoiceRepository(getAppDb());
 		const service = new InvoiceService(repo);
-		const result = await service.createInvoice(parsed.data);
+		const result = await service.createInvoice(payload);
 
 		if (!result.ok) {
 			return makeFormError<CreateInvoiceFieldNames>({
@@ -83,7 +83,7 @@ export async function createInvoiceAction(
 
 		// 3. Success: Revalidate but do NOT redirect so the form can show the success message
 		revalidatePath(ROUTES.dashboard.invoices);
-		return makeFormOk(parsed.data, translator(INVOICE_MSG.createSuccess));
+		return makeFormOk(payload, translator(INVOICE_MSG.createSuccess));
 	} catch (error) {
 		// Decide the top-level user-facing message based on error type
 		const baseMessage = isZodErrorInstance(error)

--- a/src/modules/invoices/presentation/actions/update-invoice.action.ts
+++ b/src/modules/invoices/presentation/actions/update-invoice.action.ts
@@ -4,7 +4,9 @@ import { revalidatePath } from "next/cache";
 import { requireSession } from "@/modules/auth/presentation/session/guards/session-access.guard";
 import { InvoiceService } from "@/modules/invoices/application/services/invoice.service";
 import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
+import { translator } from "@/modules/invoices/domain/i18n/translator";
 import {
+	UPDATE_INVOICE_FIELDS_LIST,
 	type UpdateInvoiceFieldNames,
 	type UpdateInvoicePayload,
 	UpdateInvoiceSchema,
@@ -20,10 +22,8 @@ import {
 	makeFormError,
 	makeFormOk,
 } from "@/shared/forms/logic/factories/form-result.factory";
-import {
-	selectSparseFieldErrors,
-	toDenseFieldErrorMap,
-} from "@/shared/forms/logic/mappers/field-error-map.mapper";
+import { toDenseFieldErrorMap } from "@/shared/forms/logic/mappers/field-error-map.mapper";
+import { validateForm } from "@/shared/forms/server/validate-form";
 import { ROUTES } from "@/shared/routing/routes";
 import { logger } from "@/shared/telemetry/logging/infrastructure/logging.client";
 
@@ -35,12 +35,11 @@ function handleActionError(id: string, error: unknown): FormResult<never> {
 		message: INVOICE_MSG.serviceError,
 	});
 
-	const schemaFields = Object.keys(
-		UpdateInvoiceSchema.shape,
-	) as readonly UpdateInvoiceFieldNames[];
-
 	return makeFormError<UpdateInvoiceFieldNames>({
-		fieldErrors: toDenseFieldErrorMap({}, schemaFields),
+		fieldErrors: toDenseFieldErrorMap<UpdateInvoiceFieldNames, string>(
+			{},
+			UPDATE_INVOICE_FIELDS_LIST,
+		),
 		formData: {},
 		formErrors: [],
 		key: error instanceof AppError ? error.key : "unknown",
@@ -59,8 +58,6 @@ function handleActionError(id: string, error: unknown): FormResult<never> {
  * @param formData - FormData from the client
  * @returns FormResult with data, errors, message, and success
  */
-
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: <ignore for now>
 export async function updateInvoiceAction(
 	_prevState: FormState<UpdateInvoicePayload>,
 	id: string,
@@ -70,50 +67,27 @@ export async function updateInvoiceAction(
 	// try/catch so a no-session redirect propagates instead of being caught.
 	await requireSession();
 
+	// Validate input through the shared funnel. Echo stays off (the default):
+	// nothing repopulates from invoice error metadata, and the raw payload
+	// includes sensitiveData.
+	const validated = await validateForm(
+		formData,
+		UpdateInvoiceSchema,
+		UPDATE_INVOICE_FIELDS_LIST,
+		{
+			loggerContext: "updateInvoiceAction",
+			messages: { failureMessage: translator(INVOICE_MSG.validationFailed) },
+		},
+	);
+
+	if (!validated.ok) {
+		return validated;
+	}
+
 	try {
-		const input = {
-			amount: formData.get("amount"),
-			customerId: formData.get("customerId"),
-			date: formData.get("date"),
-			sensitiveData: formData.get("sensitiveData"),
-			status: formData.get("status"),
-		};
-		const parsed = UpdateInvoiceSchema.safeParse(input);
-
-		if (!parsed.success) {
-			// Build dense error map aligned with the schema's fields
-			const schemaFields = Object.keys(
-				UpdateInvoiceSchema.shape,
-			) as readonly UpdateInvoiceFieldNames[];
-
-			const zFieldErrors = parsed.error.flatten().fieldErrors as Record<
-				string,
-				readonly string[] | undefined
-			>;
-
-			const sparse = selectSparseFieldErrors<UpdateInvoiceFieldNames, string>(
-				zFieldErrors,
-				schemaFields,
-			);
-			const dense = toDenseFieldErrorMap<UpdateInvoiceFieldNames, string>(
-				sparse,
-				schemaFields,
-			);
-
-			return makeFormError<UpdateInvoiceFieldNames>({
-				fieldErrors: dense,
-				// No echo: nothing repopulates from invoice error metadata, and the
-				// raw payload includes sensitiveData.
-				formData: {},
-				formErrors: [],
-				key: "validation",
-				message: INVOICE_MSG.validationFailed,
-			});
-		}
-
 		const service = new InvoiceService(new InvoiceRepository(getAppDb()));
 
-		const updateResult = await service.updateInvoice(id, parsed.data);
+		const updateResult = await service.updateInvoice(id, validated.value.data);
 		if (!updateResult.ok) {
 			return handleActionError(id, updateResult.error);
 		}

--- a/src/modules/invoices/presentation/actions/update-invoice.action.ts
+++ b/src/modules/invoices/presentation/actions/update-invoice.action.ts
@@ -43,10 +43,11 @@ function handleActionError(id: string, error: unknown): FormResult<never> {
 		formData: {},
 		formErrors: [],
 		key: error instanceof AppError ? error.key : "unknown",
-		message:
+		message: translator(
 			error instanceof AppError
-				? INVOICE_MSG.invalidInput
+				? INVOICE_MSG.updateFailed
 				: INVOICE_MSG.serviceError,
+		),
 	});
 }
 
@@ -103,7 +104,7 @@ export async function updateInvoiceAction(
 				sensitiveData: updatedInvoice.sensitiveData,
 				status: updatedInvoice.status,
 			},
-			INVOICE_MSG.updateSuccess,
+			translator(INVOICE_MSG.updateSuccess),
 		);
 	} catch (error) {
 		return handleActionError(id, error);


### PR DESCRIPTION
## Summary

Reshape slice 3 of the forms/error cleanup (BACKLOG: "One validation funnel"). The three validation styles collapse into one: create-invoice's inline `safeParse` and update-invoice's hand-rolled `formData.get()` + manual Zod-error flattening are gone — both invoice actions now go through the same `validateForm` funnel auth/users already use. Bonus: both of the suite's stale-skipped e2e tests are re-enabled — the suite runs with **zero skips** for the first time.

## Changes

**Commit 1 — the funnel** (net −28 lines)
- `create-invoice.action.ts`: inline parse + hand-built `makeFormError` → one `validateForm` call (`toDenseFieldErrorMapFromZod` stays for the service-error catch path).
- `update-invoice.action.ts`: per-field extraction + flatten/select/dense chain → one `validateForm` call, hoisted above the try/catch (it never throws). `handleActionError` uses the new `UPDATE_INVOICE_FIELDS_LIST` export instead of an `Object.keys` cast.
- `invoice.schema.ts`: adds `UPDATE_INVOICE_FIELDS_LIST` (mirrors create).
- Re-enables the skipped update-form Cypress error test — its skip reason (AppError instances not serializable across the action boundary) was fixed by the FormResult DTO work (PR #41/#50).

**Commit 2 — translated messages on the edit form**
The edit form renders `state` messages directly, so users saw raw ids (`INVOICE.UPDATE_SUCCESS`, `INVOICE.VALIDATION_FAILED`, …). All update-action messages now go through `translator(...)`, and the AppError branch uses `updateFailed` instead of `invalidInput` (whose copy reads "Failed to **create** invoice.").

**Commit 3 — BACKLOG note** on the `cy:e2e` port-reuse trap discovered while verifying (suite silently ran against a dev preview squatting on `$PORT`).

**Commit 4 — re-enable the auth invalid-credentials e2e test** (the suite's last skip, same stale reason). A bare unskip would fail — the spec had three layers of drift: `INVALID_PASSWORD` failed `PasswordSchema` (so the flow short-circuited at validation instead of reaching authentication; now schema-valid but wrong), both shared message regexes predated the actual unified message ("Invalid credentials. Please try again."), and `findByText` can't work because the anti-enumeration response renders the same text in the banner and both field errors (assertion now targets the banner via a new `AUTH_SEL.authServerMessageError` selector).

## Deliberate behavior changes

- Edit-form validation failures show translated text instead of the raw message id.
- Missing fields reach the `.partial()` update schema as absent (`undefined`), not `null` — optional-field semantics now work as intended (the real form always submits all five fields, so no user-visible change).
- Validation failures now log via `formValidationErrorFactory` with the action name as logger context (previously unlogged).

## Verification

- `pnpm check:fast` green (lint, typecheck, typegen) and 221/221 unit tests — the PR #48 lock tests hold unmodified.
- In-browser (dev preview): both forms return `key:"validation"`, a dense 5-key `fieldErrors` map, **`formData:{}`** (no `sensitiveData` echo), and translated messages; valid edit shows "Invoice updated successfully."
- Full Cypress e2e: **all specs passed — 32 passing / 0 pending / 0 skipped** (first zero-skip run). The re-enabled auth test demonstrably exercises the authentication-failure path (`login.authentication.failed` in the server log), and a nonexistent email yields the same unified message — no username enumeration.
