### PR TITLE
fix(auth): stop leaking raw pg metadata in signup conflict results

### DIFF
--- a/src/modules/auth/__tests__/integration/signup-flow.test.ts
+++ b/src/modules/auth/__tests__/integration/signup-flow.test.ts
@@ -96,6 +96,17 @@ describe("Signup Flow Integration", () => {
 				expect(payload.fieldErrors.email[0]?.toLowerCase()).toMatch(
 					/already|use|exists|unique|conflict/,
 				);
+
+				// Boundary hygiene: the conflict DTO must not leak Postgres
+				// internals (raw detail string, table/schema/constraint names).
+				// The metadata carries exactly the form-relevant fields.
+				expect(Object.keys(result.error.metadata).sort()).toEqual([
+					"fieldErrors",
+					"formData",
+					"formErrors",
+					"pgCode",
+				]);
+				expect(JSON.stringify(result.error)).not.toContain("already exists.");
 			}
 		});
 

--- a/src/modules/auth/__tests__/unit/presentation/authn/to-signup-form-result.mapper.test.ts
+++ b/src/modules/auth/__tests__/unit/presentation/authn/to-signup-form-result.mapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { toSignupFormResult } from "@/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper";
+import type { AppError } from "@/shared/core/errors/core/app-error.entity";
 import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
 import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
 import { PG_CODES } from "@/shared/core/errors/server/adapters/postgres/pg-error.constants";
@@ -8,9 +9,16 @@ import { PG_CODES } from "@/shared/core/errors/server/adapters/postgres/pg-error
  * Unit tests for toSignupFormResult.
  *
  * Security boundary: this mapper builds the client-visible FormResult for
- * failed signups. Only `SIGNUP_ECHO_FIELDS_LIST` values may appear in
- * `metadata.formData`; the submitted password must never cross the
- * Server Action boundary (BACKLOG: "Stop echoing sensitive fields").
+ * failed signups, and `AppError.toDto()` serializes metadata verbatim (and
+ * drops `cause`). Two sibling leaks are pinned here:
+ *
+ * - Only `SIGNUP_ECHO_FIELDS_LIST` values may appear in `metadata.formData`;
+ *   the submitted password must never cross the Server Action boundary
+ *   (BACKLOG: "Stop echoing sensitive fields").
+ * - Raw Postgres metadata — `detail` (which embeds the duplicate value),
+ *   `table`, `schema`, `constraint`, `severity`, `where` — stays server-side
+ *   on the cause chain; conflict metadata carries only form-relevant fields
+ *   plus the bare pg code.
  */
 describe("toSignupFormResult", () => {
 	const submitted = {
@@ -18,6 +26,24 @@ describe("toSignupFormResult", () => {
 		password: "hunter2-secret",
 		username: "andrew",
 	} as const;
+
+	const PG_DETAIL = "Key (email)=(user@example.com) already exists.";
+
+	/** Conflict error as `normalizePgError` produces it: raw pg metadata. */
+	const rawPgConflictError = (constraint: string): AppError =>
+		makeAppError(APP_ERROR_KEYS.conflict, {
+			cause: "pg unique violation",
+			message: "pg_unique_violation",
+			metadata: {
+				constraint,
+				detail: PG_DETAIL,
+				pgCode: PG_CODES.UNIQUE_VIOLATION,
+				schema: "public",
+				severity: "ERROR",
+				table: "users",
+				where: "SQL statement",
+			},
+		});
 
 	it("maps a unique violation to conflict field errors without echoing the password", () => {
 		const error = makeAppError(APP_ERROR_KEYS.conflict, {
@@ -67,5 +93,142 @@ describe("toSignupFormResult", () => {
 			);
 			expect(JSON.stringify(result)).not.toContain("hunter2-secret");
 		}
+	});
+
+	describe("unique-violation field routing", () => {
+		it("flags username for a username-constraint conflict", () => {
+			const result = toSignupFormResult(
+				rawPgConflictError("users_username_unique"),
+				submitted,
+			);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.metadata).toEqual(
+					expect.objectContaining({
+						fieldErrors: {
+							email: [],
+							password: [],
+							username: ["alreadyInUse"],
+						},
+					}),
+				);
+			}
+		});
+
+		it("flags both email and username when the constraint matches neither", () => {
+			const result = toSignupFormResult(
+				rawPgConflictError("users_pkey"),
+				submitted,
+			);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.metadata).toEqual(
+					expect.objectContaining({
+						fieldErrors: {
+							email: ["alreadyInUse"],
+							password: [],
+							username: ["alreadyInUse"],
+						},
+					}),
+				);
+			}
+		});
+
+		it("finds the constraint on the cause chain (infra-mapped conflict shape)", () => {
+			const integrity = makeAppError(APP_ERROR_KEYS.integrity, {
+				cause: "pg unique violation",
+				message: "pg_unique_violation",
+				metadata: {
+					constraint: "users_email_unique",
+					detail: PG_DETAIL,
+					pgCode: PG_CODES.UNIQUE_VIOLATION,
+					table: "users",
+				},
+			});
+			const conflict = makeAppError(APP_ERROR_KEYS.conflict, {
+				cause: integrity,
+				message: "Signup failed: value already in use",
+				metadata: { pgCode: PG_CODES.UNIQUE_VIOLATION },
+			});
+
+			const result = toSignupFormResult(conflict, submitted);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.metadata).toEqual(
+					expect.objectContaining({
+						fieldErrors: {
+							email: ["alreadyInUse"],
+							password: [],
+							username: [],
+						},
+					}),
+				);
+			}
+		});
+	});
+
+	describe("pg metadata must not cross the Server Action boundary", () => {
+		it("builds the conflict metadata only from form-relevant fields", () => {
+			const result = toSignupFormResult(
+				rawPgConflictError("users_email_unique"),
+				submitted,
+			);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				// Exact metadata shape: any extra key (e.g. a forwarded pg field)
+				// fails this assertion.
+				expect(result.error.metadata).toEqual({
+					fieldErrors: {
+						email: ["alreadyInUse"],
+						password: [],
+						username: [],
+					},
+					formData: { email: "user@example.com", username: "andrew" },
+					formErrors: [],
+					pgCode: PG_CODES.UNIQUE_VIOLATION,
+				});
+			}
+		});
+
+		it("forwards none of the raw pg fields", () => {
+			const result = toSignupFormResult(
+				rawPgConflictError("users_email_unique"),
+				submitted,
+			);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				for (const pgField of [
+					"column",
+					"constraint",
+					"datatype",
+					"detail",
+					"hint",
+					"position",
+					"schema",
+					"severity",
+					"table",
+					"where",
+				]) {
+					expect(result.error.metadata).not.toHaveProperty(pgField);
+				}
+
+				// Nothing pg-shaped survives anywhere in the serialized DTO.
+				const serialized = JSON.stringify(result.error);
+				expect(serialized).not.toContain(PG_DETAIL);
+				expect(serialized).not.toContain("already exists.");
+				expect(serialized).not.toContain("users_email_unique");
+				expect(serialized).not.toContain('"table"');
+				expect(serialized).not.toContain('"schema"');
+
+				// The server error is kept as cause on the entity, and toDto
+				// drops cause — so it must not appear on the DTO either.
+				expect(result.error).not.toHaveProperty("cause");
+			}
+		});
 	});
 });

--- a/src/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper.ts
+++ b/src/modules/auth/presentation/authn/mappers/to-signup-form-result.mapper.ts
@@ -35,6 +35,11 @@ const ALREADY_IN_USE_FIELD_ERRORS: FieldError<string> = Object.freeze([
  * the same unified error message strategy for security against enumeration,
  * as the existence of an account is typically revealed during the process.
  *
+ * The unique-violation branch builds the client-visible metadata explicitly
+ * (field errors, echoed form data, pg code) instead of forwarding the server
+ * error's metadata, so raw Postgres fields never reach the client. The full
+ * server error is preserved as `cause` for server-side logging.
+ *
  * Returns `FormResult<never>` because this mapper is intended for error scenarios
  * only (it never returns a success state).
  *
@@ -88,13 +93,16 @@ export function toSignupFormResult(
 			SIGNUP_FIELDS_LIST,
 		);
 
+		// The result crosses the Server Action boundary (toDto keeps metadata
+		// verbatim but drops cause), so metadata carries only form-relevant
+		// fields. Postgres internals — detail, table, schema, constraint —
+		// stay server-side on the cause chain. pgCode is kept because
+		// ConflictErrorMetadataSchema requires it.
 		return toFormErrResult(
 			makeAppError(APP_ERROR_KEYS.conflict, {
 				cause: error,
 				message: "Value already in use",
 				metadata: Object.freeze({
-					...error.metadata,
-					constraint,
 					fieldErrors,
 					formData: echoed,
 					formErrors: Object.freeze([]),

--- a/src/shared/forms/__tests__/unit/form-error.inspector.test.ts
+++ b/src/shared/forms/__tests__/unit/form-error.inspector.test.ts
@@ -31,7 +31,8 @@ describe("form-error inspector", () => {
 	});
 
 	// Mirrors production (to-signup-form-result.mapper): a conflict form error
-	// carries the pg metadata plus the form fields.
+	// carries the form fields plus the bare pg code — never raw pg metadata
+	// (detail/table/schema/constraint stay server-side on the cause chain).
 	const conflictError = makeAppError("conflict", {
 		cause: "test",
 		message: "Email already exists.",


### PR DESCRIPTION
The unique-violation branch of toSignupFormResult spread the server error's metadata into the client-visible conflict DTO, forwarding raw Postgres fields (detail with the duplicate value, table, schema, constraint, severity, where) across the Server Action boundary — AppError.toDto() keeps metadata verbatim and the metadata schemas are passthrough.

Build the metadata explicitly from the form-relevant fields instead (fieldErrors, formData, formErrors, plus pgCode, which the conflict schema requires). The full server error stays on the cause chain, which toDto drops.

- pin the boundary in a new to-signup-form-result.mapper unit test
- assert the exact conflict metadata key set in the signup-flow integration test
- refresh the stale mirror comment in form-error.inspector.test

https://claude.ai/code/session_01FX3anaguE31K2FFJftL8i9

<!-- Thanks for the PR! Fill in the sections below and delete anything that doesn't apply. -->

## Summary

<!-- What does this PR change, and why? Link any related issue (e.g. "Closes #12"). -->

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor (no behaviour change)
- [ ] Chore / tooling / docs

## How it was tested

- [ ] `pnpm check:fast` (lint + typecheck + typegen)
- [ ] `pnpm test` (unit)
- [ ] `pnpm cy:e2e` (end-to-end)
- [ ] Manually verified in the running app

<!-- For UI changes, add before/after screenshots here. -->

## Checklist

- [ ] Follows the rules in `AGENTS.md` and `docs/standards/`
- [ ] No secrets, `.env*` files, or generated artifacts committed
- [ ] Docs / README updated if behaviour or setup changed
- [ ] Focused change — preserves existing patterns and user-authored work
