### PR TITLE
chore: env-hygiene cleanup + Claude command guide & maintenance routine

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,11 +7,11 @@ this file is the deliberate workaround.)
 
 ## Open
 
-- [ ] **Weekly codemod routine** — scheduled Claude agent that checks Next.js/Biome
-  releases, runs the codemods, verifies with `pnpm check:fast`, and opens a PR.
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
   override automation + grouped dep updates (Dependabot can't do those). Replaces
-  Dependabot; needs the Mend Renovate GitHub App installed.
+  Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of
+  2026-06-13 by the `weekly-maintenance` routine, which reports/bumps the
+  pnpm/node/override gap; Renovate would still automate grouped updates.)_
 - [ ] **docs/ consolidation** — reconcile `docs/standards/` overlap with the existing
   `project-structure.md`, `when-to-use-app-error.md`, and `ui-refactor-strategy.md`.
 - [ ] **Live deploy** — Vercel + Neon account setup: create projects, set env vars,
@@ -57,25 +57,33 @@ this file is the deliberate workaround.)
     only uses `toFormErrorPayload`; the mapper variant is imported solely by auth
     integration tests and differs in fallback semantics (`[error.message]`).
 - [ ] **Env hygiene** — surfaced during deploy prep (2026-06-11):
-  - [ ] Remove dead `LOG_LEVEL` plumbing — only the unused `_getLogLevel` in
-    `env-shared.ts` reads it; the real runtime level comes from
-    `NEXT_PUBLIC_LOG_LEVEL` (with an `info` fallback in `logging.levels.ts`).
-    Drop the tuple entry and the template line together.
-  - [ ] Drop the per-lookup `console.log` in `env-access.utils.ts`
-    (`Retrieving env var: …`) — it spams production function logs on every request.
+  - [x] Remove dead `LOG_LEVEL` plumbing _(2026-06-13)_ — deleted `getLogLevelResult` +
+    `_getLogLevel` from `env-shared.ts` (and their orphaned `LogLevel`/`LogLevelSchema`
+    imports), dropped the `"LOG_LEVEL"` entry from the `env-access.utils.ts` accessor
+    tuple, and removed the stale `LOG_LEVEL` bullet from `config/README.md`. Runtime level
+    still comes from `NEXT_PUBLIC_LOG_LEVEL`; `check:fast` green. **Still TODO by hand:**
+    delete `LOG_LEVEL=info` from `.env.example.local` — the deny rule blocks tooling from
+    editing env files.
+  - [x] Drop the per-lookup `console.log` in `env-access.utils.ts` _(2026-06-13)_ —
+    removed the `Retrieving env var: …` line. (A second `console.log` on the missing/empty
+    path remains, but it only fires on error, not on every lookup.)
   - [ ] Decide `SESSION_ISSUER`/`SESSION_AUDIENCE` shape — single-literal zod enums
     make them constants-as-env-vars. Either widen to `z.string().min(1)` so the env
     actually configures them (renaming later invalidates live sessions), or hardcode
     them as code constants and drop the env vars.
-  - [ ] Remove `AUTH_SECRET`/`AUTH_GITHUB_ID`/`AUTH_GITHUB_SECRET` from
+  - [x] Remove `AUTH_SECRET`/`AUTH_GITHUB_ID`/`AUTH_GITHUB_SECRET` from
     `.env.example.local` and any real env files — auth.js holdovers, zero references
-    in code since the custom jose/bcrypt auth replaced it.
-- [ ] **Per-env migration drift guard** — prod's migration set was missing the
-  `revenues` DROP (dev/test had their 0006; prod stopped at 0005), so the first truly
-  fresh production DB (Neon, 2026-06-11) was created with an obsolete FK and
-  `db:seed:prod` failed with 23503. Three independent migration folders make this
-  drift invisible. Either collapse to a single migration set, or add a CI check that
-  the three `meta/_journal.json`/latest snapshots describe the same final schema.
+    in code since the custom jose/bcrypt auth replaced it. _(Verified done 2026-06-13:
+    absent from `.env.example.local`, zero code references. Double-check your own
+    real `.env*.local` files — tooling can't read those.)_
+- [ ] **Per-env migration drift guard** — _symptom resolved (2026-06-13): prod's missing
+  `revenues` DROP was backfilled — prod now has `0006`, matching dev/test — and the
+  `weekly-maintenance` routine now reports journal drift weekly. Remaining work = the
+  systemic guard._ Three independent migration folders (`drizzle/migrations/{dev,test,prod}`)
+  still let schemas drift silently: the 2026-06-11 miss created a fresh Neon prod DB with an
+  obsolete FK and failed `db:seed:prod` with 23503. Either collapse to a single migration
+  set, or add a CI **gate** that the three `meta/_journal.json`/latest snapshots describe the
+  same final schema (the weekly report is detection, not enforcement).
 - [ ] **knip full-report triage** — the earlier "knip residue" list came from a
   truncated report tail; the full report still shows (all pre-existing): 10 unused
   files (incl. `crypto.service.ts`, auth `mapper-chains`/`mapper-registry`, and 6
@@ -96,12 +104,23 @@ this file is the deliberate workaround.)
   `cypress-with-server.cli.ts` verify the responding server's `DATABASE_ENV`
   (the `smoke/log-env` spec already proves the concept).
 - [ ] **TSConfig Version 6** - figure out how to use TSConfig Version 6.
-- [ ]  The allowCypressEnv configuration option is enabled. This allows any browser code to read values from
-  Cypress.env(). This is insecure and will be removed in a future major version.
+- [ ] **Secrets readable via `Cypress.env()`** — `cypress.config.ts` writes `DATABASE_URL`
+  and `SESSION_SECRET` into `config.env` (in `setupNodeEvents`), so any browser-side spec
+  code can read them through `Cypress.env()`. (The original note blamed the `allowCypressEnv`
+  option, but that flag isn't actually set — the exposure is the explicit `config.env.*`
+  assignments.) Pass only what specs truly need to the browser; keep DB/secret values
+  Node-side in tasks, or scope them out of `config.env`.
 
 ## Done
 
 <!-- Move finished items here with a date, or delete them. -->
+
+- [x] **Weekly codemod routine** _(2026-06-13)_ — created as a live `/schedule` cloud
+  agent (`weekly-maintenance`, Mondays ~9am Central). Scope expanded past the original
+  Next.js/Biome codemods to also cover dependency-pin blind spots (pnpm/Node/overrides),
+  a migration-drift guard across the three drizzle migration sets, and a knip+`pnpm audit`
+  report — all in one weekly PR; verifies with `check:fast`+unit, never runs e2e, never
+  pushes to main. Full spec: `docs/weekly-maintenance-routine.md`.
 
 - [x] **knip residue (named seven)** _(2026-06-11)_ — un-exported the five
   internally-used types (`DalIdentifiers`, `PgErrorMetadataBase`, `FormErrResult`,

--- a/docs/claude-code-command-guide.md
+++ b/docs/claude-code-command-guide.md
@@ -1,0 +1,72 @@
+# Claude Code command guide
+
+A personal reference for the `/` command palette in the Claude Code input box —
+curated for *this* project (solo Next.js dashboard), not the full catalog.
+
+> The desktop "Code" app shows both **built-in commands** (session/control verbs
+> that ship with Claude Code) and **skills** (a large plugin catalog plus this
+> repo's own `/check`, `/fix`, …). Plugin skills are namespaced: `/productivity:update`,
+> `/engineering:architecture`. You invoke them exactly like commands. Most of the
+> catalog is noise for a solo project — the dozen below are the ones that earn their keep.
+
+## By cadence (when to reach for each)
+
+| Cadence | When | Commands |
+|---|---|---|
+| **Per change / pre-PR** ⭐ | before you commit or merge | `/code-review` · `/simplify` · `/security-review` · `/verify` |
+| **Session control** | manage the chat itself | `/clear` · `/compact` · `/model` · `/fast` |
+| **Periodic upkeep** | weekly · as memory grows | `/productivity:update` · `/fewer-permission-prompts` · `consolidate-memory` |
+| **On-demand power** | when the task calls for it | `/schedule` · `/loop` · `/deep-research` · `/run` |
+| **Config (terminal-only)** | *not in this app's box* | `/config` · `/permissions` · `/agents` · `/hooks` · `/doctor` |
+
+⭐ = run most often.
+
+## Most important (daily drivers)
+
+The quality loop around every change — fits this project (lots of refactor PRs,
+auth code, tests).
+
+| Command | What it does | When |
+|---|---|---|
+| `/code-review` | Reviews the current diff for **bugs** + cleanups. Effort scales: `low`/`medium` (few, high-confidence) → `high`/`max` (broader) → `ultra` (multi-agent **cloud, billed**). Flags: `--fix` applies findings, `--comment` posts inline on the PR. | before every PR |
+| `/simplify` | Applies reuse / simplification / altitude cleanups. **Quality only — does not hunt bugs.** Pairs with refactor work. | after a feature, before review |
+| `/security-review` | Security pass over the branch's pending changes. | any auth / DB / session-touching diff |
+| `/verify`, `/run` | Launches the app and confirms a change works in-browser (not just green tests). | per feature |
+
+**Key distinction:** `/code-review` finds bugs, `/simplify` improves quality.
+Run review → simplify → verify.
+
+## Run periodically
+
+- **`/productivity:update`** — weekly-ish: syncs tasks + refreshes memory.
+  `--comprehensive` does a deep activity scan.
+- **`consolidate-memory`** (`/anthropic-skills:consolidate-memory`) — when `memory/`
+  grows or drifts: merges duplicates, prunes the index. Worth a pass every few weeks.
+- **`/schedule`** — for recurring cloud agents. See
+  [`weekly-maintenance-routine.md`](weekly-maintenance-routine.md) for the drafted
+  weekly codemod/maintenance agent.
+
+## Must-knows
+
+1. **Some commands aren't in this box.** `/config`, `/permissions`, `/agents`,
+   `/hooks`, `/doctor` open an interactive *terminal* panel — they do nothing in the
+   desktop "Code" app. Use the app's own UI (e.g. the model picker, bottom-right) or
+   a `claude` terminal.
+2. **`/clear` vs `/compact`** — the biggest lever on cost/quality in long sessions.
+   `/clear` wipes context (fresh start, unrelated task); `/compact` summarizes and
+   keeps going. Reach for `/clear` when you switch tasks — a bloated context makes
+   responses slower and worse.
+3. **`/fast`** toggles faster Opus output (no model downgrade) — available on Opus 4.8.
+4. **`ultra` is real money.** `/code-review ultra` (deprecated alias: `/ultrareview`)
+   spins up a multi-agent cloud review. Worth it before a big merge, overkill for a
+   one-liner. It's user-triggered and billed — Claude cannot launch it for you.
+5. **Report-only project skills can't touch files.** `/check`, `/lint`, `/test`,
+   `/coverage`, `/e2e` carry `disallowed-tools: Edit, Write` — safe to fire anytime;
+   they report, Claude acts on the result.
+6. **Namespaced domain skills** that fit this project: `/engineering:architecture`
+   (you already write ADRs), `/engineering:tech-debt` (knip-triage backlog),
+   `/engineering:testing-strategy`, `/deep-research` (the "evaluate reputable-source
+   skills" backlog item).
+
+---
+_Generated 2026-06-13. Companion: [`weekly-maintenance-routine.md`](weekly-maintenance-routine.md)._

--- a/docs/weekly-maintenance-routine.md
+++ b/docs/weekly-maintenance-routine.md
@@ -1,0 +1,100 @@
+# Weekly maintenance routine (drafted)
+
+A scheduled Claude Code cloud agent that keeps the repo current with a single,
+reviewable PR each week. Drafted from the `BACKLOG.md` "Weekly codemod routine"
+item, with extra scope recommended below. **Not yet live** — create it with
+`/schedule` once you're happy with the scope.
+
+## Schedule
+
+- **Cron:** `0 9 * * 1` (Mondays, 09:00) — adjust the hour/day and timezone to taste.
+- **Frequency rationale:** weekly is often enough to stay current without churning a
+  PR every day. Monday morning means the PR is waiting when you start the week.
+
+## Scope
+
+### Core (from the backlog) — the transformative work Dependabot can't do
+
+1. **Next.js codemods** — if `next` is a minor/major behind, bump it and run the
+   official codemod (`npx @next/codemod@latest upgrade`), applying relevant transforms.
+2. **Biome migration** — if `@biomejs/biome` is behind, bump it and run
+   `pnpm biome migrate --write` to update `biome.json` to the new schema.
+3. **Verify** with `pnpm check:fast` (lint + typecheck + typegen) before opening the PR.
+
+### Recommended additions (why each earns its place)
+
+4. **Dependabot's blind spots** _(report, or bump if safe)_ — the pnpm version pin
+   (`packageManager: pnpm@11.5.3`), Node `.nvmrc` (`26`), and any `overrides` /
+   `pnpm-workspace.yaml` overrides. These are exactly what broke CI on 2026-06-11 and
+   what Dependabot/this project's current tooling can't bump. **Lockstep rule:** when a
+   bumped dependency also appears in an `overrides` block, bump both together.
+5. **Migration drift guard** _(report-only)_ — compare the final snapshot/journal across
+   `drizzle/migrations/{dev,test,prod}/meta/_journal.json`. Flag if the three don't
+   describe the same final schema. This is the exact failure that gave a fresh prod DB an
+   obsolete FK and a `23503` seed failure (and it's a standing backlog item).
+6. **knip + audit summary** _(report-only, never auto-fix)_ — run `pnpm knip` and
+   `pnpm audit`; summarize *new* dead code (vs. what the backlog already tracks) and any
+   CVEs in the PR body. Signal without risk.
+
+### Deliberately left out (keep the cron fast & deterministic)
+
+- **Full e2e (`pnpm cy:e2e`)** — slow, and it has the port-reuse trap (silently targets
+  any server already on `$PORT`). Verification stops at `check:fast` + `pnpm test:unit`.
+- **Coverage thresholds** — still a "consider later" item; too noisy as a weekly gate.
+- **Backlog grooming** — fuzzy; that's what the manual `/productivity:update` is for.
+
+## Safeguards (baked into the agent prompt)
+
+- **Release age ≥ 3 days.** Skip anything released in the last ~72h — the pnpm-11
+  fresh-release CI breakage (2026-06-11) is the lesson. Brand-new releases wait a week.
+- **Never push to `main`, never merge, never run `db:*:prod`.** The agent only opens a PR.
+- **No empty PRs.** If there are no code changes *and* no notable report findings, exit
+  quietly — don't open a PR just to say "nothing this week."
+- **Fail loud, not silent.** If `check:fast` or unit tests can't be made green with a
+  minimal fix, open the PR as a **draft** with the failure output captured, so a human decides.
+- **Respect project standards.** Read `AGENTS.md`, `CLAUDE.md`, and `BACKLOG.md` first.
+
+## The agent prompt (ready to paste into `/schedule`)
+
+```text
+You are the weekly maintenance agent for the nextjs-dashboard repo. Run on a fresh
+branch off the latest main: claude/weekly-maintenance-<YYYY-MM-DD>. First read
+AGENTS.md, CLAUDE.md, and BACKLOG.md so you respect the project's standards and
+known gotchas. Never push to main, never merge, never run any db:*:prod script.
+
+1. RELEASE SCAN — check latest STABLE versions, but ignore any release younger than
+   3 days (fresh releases have broken CI here before): next, @biomejs/biome, and
+   report-only: pnpm, Node (.nvmrc=26), react/react-dom, drizzle-kit/drizzle-orm,
+   vitest, cypress, typescript.
+
+2. CODEMODS (the part Dependabot can't do):
+   - If `next` is behind: bump next (and eslint-config-next if present) and run
+     `npx @next/codemod@latest upgrade`, applying the relevant transforms.
+   - If `@biomejs/biome` is behind: bump it and run `pnpm biome migrate --write`.
+   - LOCKSTEP: if any bumped dep also appears in package.json `overrides`/`pnpm.overrides`
+     or pnpm-workspace.yaml, bump it there too in the same change.
+
+3. VERIFY: `pnpm install`, then `pnpm check:fast`. If green, also `pnpm test:unit`.
+   Do NOT run e2e. If something fails, try a minimal fix; if still red, continue but
+   open the PR as a DRAFT with the failing output in the description.
+
+4. REPORT-ONLY (summarize in the PR body; do not change code for these):
+   - `pnpm knip` — list NEW unused files/exports not already tracked in BACKLOG.md.
+   - `pnpm audit` — list any advisories.
+   - MIGRATION DRIFT: compare the latest snapshot + _journal.json across
+     drizzle/migrations/{dev,test,prod}. If they don't describe the same final
+     schema, flag it prominently.
+
+5. PR: if there are code changes OR notable report findings, open a PR against main
+   titled `chore: weekly maintenance <YYYY-MM-DD>` with a body covering what bumped,
+   codemods applied, check:fast/unit results, and the report-only findings. If there
+   is nothing to change and nothing notable to report, do not open a PR — just stop.
+```
+
+## Creating / disabling it
+
+- **Create:** run `/schedule` and paste the prompt above with the cron `0 9 * * 1`.
+- **Adjust or stop later:** `/schedule` can list, update, or delete existing routines.
+
+---
+_Drafted 2026-06-13. Companion: [`claude-code-command-guide.md`](claude-code-command-guide.md)._

--- a/src/shared/core/config/README.md
+++ b/src/shared/core/config/README.md
@@ -17,7 +17,6 @@
 - Validates private, runtime-only vars:
   - `DATABASE_URL`
   - `SESSION_SECRET` / `ISSUER` / `AUDIENCE`
-  - `LOG_LEVEL`
 - Throws early if required values are missing/invalid
 - Caches + freezes values for immutability
 - Exports both constants and a `getServerEnv()` helper

--- a/src/shared/core/config/server/env-access.utils.ts
+++ b/src/shared/core/config/server/env-access.utils.ts
@@ -12,7 +12,6 @@ const ENV_VARIABLES_TUPLE = [
 	// "CYPRESS_BASE_URL", // TODO: why is this here? consider removing
 	"DATABASE_ENV",
 	"DATABASE_URL",
-	"LOG_LEVEL",
 	"NEXT_PUBLIC_LOG_LEVEL",
 	"NEXT_PUBLIC_NODE_ENV",
 	"NODE_ENV",
@@ -32,7 +31,6 @@ type EnvVariables = (typeof ENV_VARIABLES_TUPLE)[number];
 function getEnvVariableResult<K extends EnvVariables>(
 	key: K,
 ): Result<string, AppError> {
-	console.log(`Retrieving env var: ${key}`);
 	const value = process.env[key];
 	if (!value || value.trim() === "") {
 		console.log(`Env var ${key} is missing or empty`);

--- a/src/shared/core/config/shared/env-shared.ts
+++ b/src/shared/core/config/shared/env-shared.ts
@@ -2,8 +2,6 @@ import { getPublicNodeEnvResult } from "@/shared/core/config/public/env-public";
 import {
 	type DatabaseEnvironment,
 	DatabaseEnvironmentSchema,
-	type LogLevel,
-	LogLevelSchema,
 	type NodeEnvironment,
 	NodeEnvironmentSchema,
 } from "@/shared/core/config/schemas/env-schemas";
@@ -77,41 +75,6 @@ function getDatabaseEnvResult(): Result<DatabaseEnvironment, AppError> {
 		);
 	}
 	return Ok(result.data);
-}
-
-/**
- * Get effective LOG_LEVEL as a Result.
- *
- * @returns A Result containing the validated LogLevel or an AppError.
- */
-function getLogLevelResult(): Result<LogLevel, AppError> {
-	const raw = getEnvVariable("LOG_LEVEL");
-	const result = LogLevelSchema.safeParse(raw);
-	if (!result.success) {
-		return Err(
-			makeAppError(APP_ERROR_KEYS.validation, {
-				cause: "",
-				message: `Invalid LOG_LEVEL value "${raw}": ${result.error.message}`,
-				metadata: {},
-			}),
-		);
-	}
-	return Ok(result.data);
-}
-
-/**
- * Get effective LOG_LEVEL.
- * - Requires LOG_LEVEL to be set and valid
- *
- * @returns The validated LogLevel.
- * @throws {Error} When LOG_LEVEL is invalid.
- */
-function _getLogLevel(): LogLevel {
-	const result = getLogLevelResult();
-	if (result.ok) {
-		return result.value;
-	}
-	throw new Error(result.error.message);
 }
 
 /**


### PR DESCRIPTION
## Summary

Three focused commits from a session that audited `BACKLOG.md` against the code and did the resulting cleanup:

- **`refactor(config)`** — removed dead server-side `LOG_LEVEL` plumbing (`getLogLevelResult` / `_getLogLevel`, their now-orphaned `LogLevel`/`LogLevelSchema` imports, and the `"LOG_LEVEL"` accessor-tuple entry) plus the per-lookup `console.log("Retrieving env var: …")` that spammed function logs on every request. The effective level already comes from `NEXT_PUBLIC_LOG_LEVEL`; `LogLevelSchema` stays in `env-schemas.ts` (still validates the public var). No behaviour change.
- **`docs`** — added `docs/claude-code-command-guide.md` (the `/` palette curated by cadence for this project) and `docs/weekly-maintenance-routine.md` (spec for the new `weekly-maintenance` scheduled cloud agent: weekly codemods, dep-pin checks, migration-drift report, knip + audit).
- **`docs(backlog)`** — ticked items confirmed done against the code (the weekly-codemod routine and the `AUTH_*` / `LOG_LEVEL` / `console.log` env-hygiene sub-items), and reworded two stale items: the migration-drift guard (symptom resolved in prod `0006`; routine now *detects* drift; a CI gate remains) and the cypress item (retitled to its real cause — `DATABASE_URL`/`SESSION_SECRET` exposed via `Cypress.env()`; the `allowCypressEnv` flag was never actually set).

Follow-up intentionally **not** in this PR (tooling can't edit `.env*` files): delete the `LOG_LEVEL=info` line from `.env.example.local`.

## Type of change

- [ ] Feature
- [ ] Fix
- [x] Refactor (no behaviour change)
- [x] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen) — green (one pre-existing `noExcessiveLinesPerFunction` *info* on `toSignupFormResult`, in an untouched file)
- [ ] `pnpm test` (unit)
- [ ] `pnpm cy:e2e` (end-to-end)
- [ ] Manually verified in the running app

Unit/e2e not run — the only code change is non-behavioural config cleanup covered by typecheck; the rest is docs.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed
- [x] Focused change — preserves existing patterns and user-authored work
