### PR TITLE
chore(knip): cover test-support + database, prune surfaced dead code

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -92,6 +92,16 @@ this file is the deliberate workaround.)
   configs), and 26 unused exports/types — several look like the same
   exported-but-internal pattern (`APP_ERROR_REGISTRY`, `AppErrorCoreDescriptor`).
   Triage each: knip config fix vs. un-export vs. delete.
+  _Progress 2026-06-13:_ fixed the **config** first — `knip.json` now covers `test-support/`
+  and `database/` (both were part of the TS project but invisible to knip), the test
+  `entry` glob includes `src/shared/**/__tests__`, and `database/schema/relations.ts` is
+  an entry (drizzle reads the schema dir by path, no TS importer); `docs/knip.md` rewritten
+  (runs env-free via `pnpm knip`). That surfaced + pruned a dead cluster: revenues
+  leftovers (`REVENUE_SOURCES`, `RevenueSource`, `RevenueId`) + an over-exported test mock
+  (`createNextRedirectError`). Left deliberately: `statusEnum` (drizzle `pgEnum` — un-export
+  risks migration detection) and the `_`-prefixed `$inferInsert` types (intentional-keep).
+  Remaining: 10 unused files, 2 deps + 3 devDeps (dotenv/tailwindcss/@testing-library/dom
+  are config/peer false positives), 18 exports + 13 types.
 - [ ] **Skills exploration** — evaluate reputable-source skills (e.g. Vercel's
   `vercel-react-best-practices`) against `docs/standards/` before adopting.
 - [ ] **e2e port-reuse guard** — `cy:e2e` inherits the session's `PORT` (the

--- a/database/schema/schema.constants.ts
+++ b/database/schema/schema.constants.ts
@@ -5,15 +5,5 @@ export const ADMIN_ROLE: UserRole = "ADMIN";
 export const GUEST_ROLE: UserRole = "GUEST";
 export const USER_ROLE: UserRole = "USER";
 
-export const REVENUE_SOURCES = [
-	"seed",
-	"handler",
-	"invoice_event",
-	"rolling_calculation",
-	"template",
-] as const;
-
-export type RevenueSource = (typeof REVENUE_SOURCES)[number];
-
 export const INVOICE_STATUSES = ["pending", "paid"] as const;
 export type InvoiceStatus = (typeof INVOICE_STATUSES)[number];

--- a/database/schema/schema.types.ts
+++ b/database/schema/schema.types.ts
@@ -2,5 +2,4 @@ export type CustomerId = string;
 export type Hash = string;
 export type InvoiceId = string;
 export type Period = Date;
-export type RevenueId = string;
 export type UserId = string;

--- a/docs/knip.md
+++ b/docs/knip.md
@@ -1,11 +1,57 @@
 # Knip
 
-## What is Knip?
+[Knip](https://knip.dev) finds **dead code** — unused files, exports, types, and
+dependencies — by building an import graph from a set of entry points.
 
-A tool for finding unused exports, files, and dependencies.
-
-## How to Use
+## Running it
 
 ```sh
-pnpm env:dev knip
+pnpm knip          # static analysis — no env vars or database needed
+pnpm check:repo    # the full gate: pnpm check (lint+types+tests+e2e) && pnpm knip
 ```
+
+Knip parses source statically; it never executes the app, so it does **not** need a
+running database or `.env` file. (It is intentionally kept env-free — see the drizzle
+note below.) Knip is **not** part of CI (`.github/workflows/ci.yml` runs `check:fast`
+only); run it locally, or let the `weekly-maintenance` `/schedule` routine report new
+findings each week.
+
+Exit code `1` just means "findings were reported" — it is not a crash.
+
+## How this repo configures it (`knip.json`)
+
+- **`project`** — every folder Knip should analyze for dead code: `src/`, `devtools/`,
+  `cypress/`, `test-support/`, `database/`, and root `*.{ts,mjs}`. A `.ts` file inside
+  these that no entry reaches is reported as an **unused file**.
+- **`entry`** — the roots Knip starts from (never themselves "unused"): the Next.js app
+  (`src/app/**`), all tests (`src/**/__tests__/**`), the devtools CLIs, the Cypress
+  config/specs/support, and `drizzle.config.ts`.
+- **Plugins** — `cypress` and `drizzle` plugin blocks tune detection for those tools.
+
+### Two non-obvious entries (don't remove without reading this)
+
+- **`database/schema/relations.ts`** is listed as an `entry` even though no TypeScript
+  file imports it. drizzle-kit consumes the whole `./database/schema` directory by path
+  (`schema: "./database/schema"` in `drizzle.config.ts`), so `relations.ts` is live at
+  migration time but invisible to the import graph. Without the entry, Knip would
+  false-flag it as unused.
+- The **`drizzle` plugin is left with `"config": []`** (disabled config discovery) on
+  purpose: `drizzle.config.ts` throws `"DATABASE_URL is not set."` at module load, so
+  letting the plugin load it would force every `knip` run to provide env. Disabling it
+  keeps `pnpm knip` env-free; the `relations.ts` entry above covers what the plugin
+  would otherwise have contributed.
+
+## Acting on findings
+
+Triage each finding — not everything reported should be deleted:
+
+- **Genuinely dead** → delete (e.g. leftovers from the gutted revenues module:
+  `REVENUE_SOURCES`, `RevenueSource`, `RevenueId`).
+- **Intentionally kept** → leave it. The repo uses a leading `_` to mark
+  deliberately-unused symbols (e.g. `_NewInvoiceRow` insert types, `_isDev`); Knip does
+  not honor that convention, so these show up as noise.
+- **Config-only / peer dependencies** → not real dead deps. `dotenv` and `tailwindcss`
+  are used via scripts/PostCSS config, and `@testing-library/dom` is a peer of
+  `@testing-library/cypress` — none are imported in code, so Knip lists them.
+
+The running triage list lives in `BACKLOG.md` ("knip full-report triage").

--- a/knip.json
+++ b/knip.json
@@ -8,17 +8,20 @@
 	},
 	"entry": [
 		"src/app/**/*.{ts,tsx}",
-		"src/modules/**/__tests__/**/*.{test,spec}.{ts,tsx}",
+		"src/**/__tests__/**/*.{test,spec}.{ts,tsx}",
 		"devtools/cli/**/*.cli.ts",
 		"cypress.config.ts",
 		"cypress/**/*.cy.{ts,tsx}",
 		"cypress/support/**/*.{ts,tsx}",
-		"drizzle.config.ts"
+		"drizzle.config.ts",
+		"database/schema/relations.ts"
 	],
 	"project": [
 		"src/**/*.{ts,tsx}",
 		"devtools/**/*.{ts,tsx}",
 		"cypress/**/*.{ts,tsx}",
+		"test-support/**/*.{ts,tsx}",
+		"database/**/*.{ts,tsx}",
 		"*.{ts,mjs}"
 	]
 }

--- a/test-support/next-mocks.ts
+++ b/test-support/next-mocks.ts
@@ -67,9 +67,4 @@ const mockNextHeaders = (): NextHeadersMock => {
 	};
 };
 
-export {
-	createNextRedirectError,
-	mockNextCache,
-	mockNextHeaders,
-	mockNextNavigation,
-};
+export { mockNextCache, mockNextHeaders, mockNextNavigation };


### PR DESCRIPTION
## Summary

Fixes knip's coverage and cleans up the dead code that fix surfaces. Follows up the repo-hygiene thread from #55 (which merged before these landed, so they're their own PR).

`knip.json` wasn't analyzing `test-support/` or `database/` — both are part of the TypeScript project (tsconfig alias + include) but were invisible to knip, so dead code in them went undetected. The test `entry` glob also only matched `src/modules/**/__tests__`, missing `src/shared/**/__tests__` (errors/result/forms).

- **`chore(knip)`** — added `test-support/` and `database/` to `project`, broadened the test `entry` to `src/**/__tests__`, and added `database/schema/relations.ts` as an `entry` (drizzle-kit consumes the schema dir by path, so it has no TS importer and would otherwise be false-flagged as unused). knip stays **env-free**: the drizzle plugin is deliberately left disabled (`config: []`) because `drizzle.config.ts` throws when `DATABASE_URL` is unset. Rewrote the stale `docs/knip.md` (`pnpm knip`, not `pnpm env:dev knip`; documents the two non-obvious entries + triage guidance) and updated the BACKLOG knip-triage item.
- **`refactor(schema)`** — pruned the dead exports the broadened coverage surfaced: revenues-module leftovers (`REVENUE_SOURCES`, `RevenueSource`, `RevenueId`, dead since the module was gutted) and an over-exported test mock (`createNextRedirectError`, used only internally). Left `statusEnum` exported (drizzle `pgEnum` used by the invoices table — un-exporting risks migration detection) and the `_`-prefixed `$inferInsert` types (the repo's intentional-keep convention).

## Type of change

- [ ] Feature
- [ ] Fix
- [x] Refactor (no behaviour change)
- [x] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen) — green
- [ ] `pnpm test` (unit)
- [ ] `pnpm cy:e2e` (end-to-end)
- [ ] Manually verified in the running app

Also re-ran `pnpm knip`: the four pruned exports are cleared, no new false positives, and all `test-support/` + `database/` files are correctly seen as used (no spurious "unused file").

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed
- [x] Focused change — preserves existing patterns and user-authored work
