### PR TITLE
refactor(auth): apply structure-assessment fixes #1–#3

### DIFF
--- a/src/modules/auth/__tests__/unit/mappers/to-session-principal.mapper.test.ts
+++ b/src/modules/auth/__tests__/unit/mappers/to-session-principal.mapper.test.ts
@@ -1,6 +1,5 @@
 import {
 	makeAuthenticatedUserDto,
-	makeUpdateSessionSuccessDto,
 	TEST_USER_ID,
 } from "@test-support/fixtures/user.fixtures";
 import { describe, expect, it } from "vitest";
@@ -13,7 +12,7 @@ import { toUserId } from "@/modules/users/domain/user-id.mappers";
  * This mapper extracts minimal data (id, role) for JWT claims, implementing
  * the principle of least privilege for session tokens.
  *
- * Transformation: AuthenticatedUserDto | UpdateSessionSuccessDto → SessionPrincipalDto
+ * Transformation: AuthenticatedUserDto → SessionPrincipalDto
  * Layer: Application → Application
  * Security: Minimal data for JWT claims (only id and role)
  */
@@ -40,42 +39,16 @@ describe("toSessionPrincipal Mapper", () => {
 			expect(json).not.toContain("sensitive@example.com");
 			expect(json).not.toContain("sensitive_user");
 		});
-
-		it("should strictly include only id and role from UpdateSessionSuccessDto", () => {
-			const input = makeUpdateSessionSuccessDto({
-				expiresAtMs: 999_999,
-				refreshed: true,
-			});
-
-			const principal = toSessionPrincipal(input);
-
-			expect(principal).toEqual({
-				id: TEST_USER_ID,
-				role: "USER",
-			});
-
-			expect(principal).not.toHaveProperty("userId");
-			expect(principal).not.toHaveProperty("expiresAtMs");
-			expect(principal).not.toHaveProperty("refreshed");
-			expect(principal).not.toHaveProperty("reason");
-		});
 	});
 
 	describe("Successful Transformations", () => {
 		it("should handle different roles correctly", () => {
-			const adminInput = makeAuthenticatedUserDto({ role: "ADMIN" });
-			const userInput = makeUpdateSessionSuccessDto({ role: "USER" });
-
-			expect(toSessionPrincipal(adminInput).role).toBe("ADMIN");
-			expect(toSessionPrincipal(userInput).role).toBe("USER");
-		});
-
-		it("should map userId to id field for session updates", () => {
-			const input = makeUpdateSessionSuccessDto({ userId: TEST_USER_ID });
-			const principal = toSessionPrincipal(input);
-
-			expect(principal.id).toBe(TEST_USER_ID);
-			expect(principal).not.toHaveProperty("userId");
+			expect(
+				toSessionPrincipal(makeAuthenticatedUserDto({ role: "ADMIN" })).role,
+			).toBe("ADMIN");
+			expect(
+				toSessionPrincipal(makeAuthenticatedUserDto({ role: "USER" })).role,
+			).toBe("USER");
 		});
 
 		it("should preserve branded types in the output", () => {
@@ -88,22 +61,6 @@ describe("toSessionPrincipal Mapper", () => {
 	});
 
 	describe("Consistency and Data Integrity", () => {
-		it("should produce identical output for same user from different sources", () => {
-			const authDto = makeAuthenticatedUserDto({
-				id: TEST_USER_ID,
-				role: "USER",
-			});
-			const updateDto = makeUpdateSessionSuccessDto({
-				role: "USER",
-				userId: TEST_USER_ID,
-			});
-
-			const principal1 = toSessionPrincipal(authDto);
-			const principal2 = toSessionPrincipal(updateDto);
-
-			expect(principal1).toEqual(principal2);
-		});
-
 		it("should return a new object and not modify the original input", () => {
 			const input = makeAuthenticatedUserDto();
 			const inputCopy = { ...input };
@@ -125,13 +82,6 @@ describe("toSessionPrincipal Mapper", () => {
 			const principal = toSessionPrincipal(input);
 
 			expect(principal.id).toBe(longId);
-		});
-
-		it("should handle minimum valid numeric values in session update", () => {
-			const input = makeUpdateSessionSuccessDto({ expiresAtMs: 0 });
-			const principal = toSessionPrincipal(input);
-
-			expect(principal.id).toBe(TEST_USER_ID);
 		});
 	});
 });

--- a/src/modules/auth/application/auth-user/commands/create-demo-user.tx.helper.ts
+++ b/src/modules/auth/application/auth-user/commands/create-demo-user.tx.helper.ts
@@ -9,7 +9,6 @@ import {
 	makeInvalidDemoCounterFailure,
 	validateDemoUserCounter,
 } from "@/modules/auth/domain/auth-user/policies/registration.policy";
-import { pgUniqueViolationToSignupConflictError } from "@/modules/auth/infrastructure/persistence/auth-user/mappers/pg-unique-violation-to-signup-conflict-error.mapper";
 import type { AppError } from "@/shared/core/errors/core/app-error.entity";
 import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
 import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
@@ -17,7 +16,17 @@ import { Err, Ok } from "@/shared/core/result/result";
 import type { Result } from "@/shared/core/result/result.dto";
 import type { UserRole } from "@/shared/policies/user-role/user-role.constants";
 
-// TODO: why do i need this pattern? why is it in application?
+/**
+ * Transactional body of the demo-user creation use case.
+ *
+ * @remarks
+ * Lives in the application layer because it orchestrates several application
+ * contracts — the unit of work, password generator/hasher, and a domain policy
+ * — to make demo-user creation atomic (counter increment + signup in one
+ * transaction). It speaks only to contracts and domain code; the repository
+ * behind the unit of work is responsible for translating persistence errors
+ * (e.g. unique violations → conflict) before they cross this boundary.
+ */
 export async function createDemoUserTxHelper(
 	deps: Readonly<{
 		uow: AuthUnitOfWorkContract;
@@ -69,8 +78,7 @@ export async function createDemoUserTxHelper(
 		});
 
 		if (!signupResult.ok) {
-			const mapped = pgUniqueViolationToSignupConflictError(signupResult.error);
-			return Err(mapped ?? signupResult.error);
+			return Err(signupResult.error);
 		}
 
 		return Ok({ entity: signupResult.value, password });

--- a/src/modules/auth/application/auth-user/commands/create-demo-user.use-case.ts
+++ b/src/modules/auth/application/auth-user/commands/create-demo-user.use-case.ts
@@ -1,10 +1,10 @@
 import "server-only";
+import { createDemoUserTxHelper } from "@/modules/auth/application/auth-user/commands/create-demo-user.tx.helper";
 import type { AuthUnitOfWorkContract } from "@/modules/auth/application/auth-user/contracts/repositories/auth-unit-of-work.contract";
 import type { PasswordGeneratorContract } from "@/modules/auth/application/auth-user/contracts/services/password-generator.contract";
 import type { PasswordHasherContract } from "@/modules/auth/application/auth-user/contracts/services/password-hasher.contract";
 import type { CreateDemoUserCommand } from "@/modules/auth/application/auth-user/dtos/requests/create-demo-user.command";
 import type { AuthenticatedUserDto } from "@/modules/auth/application/auth-user/dtos/responses/authenticated-user.dto";
-import { createDemoUserTxHelper } from "@/modules/auth/application/shared/helpers/create-demo-user.tx.helper";
 import { AUTH_USE_CASE_NAMES } from "@/modules/auth/application/shared/logging/auth-logging.constants";
 import { makeAuthUseCaseLoggerHelper } from "@/modules/auth/application/shared/logging/make-auth-use-case-logger.helper";
 import type { AppError } from "@/shared/core/errors/core/app-error.entity";

--- a/src/modules/auth/application/session/dtos/responses/session-principal.dto.ts
+++ b/src/modules/auth/application/session/dtos/responses/session-principal.dto.ts
@@ -1,13 +1,21 @@
 import type { UserId } from "@/modules/users/domain/types/user-id.brand";
 import type { UserRole } from "@/shared/policies/user-role/user-role.constants";
 
-// TODO:  why does this shape have no properties that are specific to sessions, cookies, or tokens?
-
 /**
- * Represents the minimal identity of a user within a session.
+ * The minimal user identity that a session authenticates — the *principal*.
  *
- * This DTO is used by the application layer to identify the user
- * associated with a session and to authorize operations based on their role.
+ * @remarks
+ * This shape carries no session-, cookie-, or token-specific fields by design.
+ * In security terms a "principal" is the actor being authenticated (the user),
+ * not the session machinery itself. Restricting it to `id` + `role` enforces
+ * the principle of least privilege for JWT claims: the token embeds only what
+ * authorization decisions require, and nothing sensitive that could leak if the
+ * token is decoded.
+ *
+ * Session/token mechanics — expiry, rotation, cookie storage, claim encoding —
+ * live in the session service and infrastructure layer, deliberately kept off
+ * this DTO. Expanding it with session state would conflate identity with
+ * transport and widen the token surface, so that is intentionally avoided.
  */
 export interface SessionPrincipalDto {
 	/** The unique identifier of the user. */
@@ -15,5 +23,3 @@ export interface SessionPrincipalDto {
 	/** The role assigned to the user. */
 	readonly role: UserRole;
 }
-
-// TODO: consider expanding to include session state and renaming or creating SessionPrincipalDto

--- a/src/modules/auth/application/shared/mappers/flows/login/to-session-principal.mapper.ts
+++ b/src/modules/auth/application/shared/mappers/flows/login/to-session-principal.mapper.ts
@@ -1,30 +1,18 @@
 import type { AuthenticatedUserDto } from "@/modules/auth/application/auth-user/dtos/responses/authenticated-user.dto";
 import type { SessionPrincipalDto } from "@/modules/auth/application/session/dtos/responses/session-principal.dto";
-import type { UpdateSessionSuccessDto } from "@/modules/auth/application/session/dtos/responses/update-session-outcome.dto";
 
 /**
- * Maps authentication or session update outputs to a session principal.
+ * Maps an authenticated user to the canonical session principal.
  *
  * @remarks
- * This is a pure mapper (no business rules). It consolidates multiple successful
- * outcomes into the canonical `SessionPrincipalDto` shape.
- *
- * TODO: REFACTOR SO IT CAN ONLY TAKE ONE INPUT TYPE
+ * Pure mapper (no business rules). Extracts the minimal identity (`id`, `role`)
+ * needed for JWT claims — the principle of least privilege for session tokens.
  */
 export function toSessionPrincipal(
-	source: AuthenticatedUserDto | UpdateSessionSuccessDto,
+	source: AuthenticatedUserDto,
 ): SessionPrincipalDto {
-	if ("email" in source) {
-		// Mapping from AuthenticatedUserDto
-		return {
-			id: source.id,
-			role: source.role,
-		};
-	}
-
-	// Mapping from UpdateSessionSuccessDto (already has branded userId)
 	return {
-		id: source.userId,
+		id: source.id,
 		role: source.role,
 	};
 }

--- a/test-support/fixtures/user.fixtures.ts
+++ b/test-support/fixtures/user.fixtures.ts
@@ -1,9 +1,5 @@
 import type { UserRow } from "@database/schema/users";
 import type { AuthenticatedUserDto } from "@/modules/auth/application/auth-user/dtos/responses/authenticated-user.dto";
-import {
-	UPDATE_SESSION_OUTCOME_REASON,
-	type UpdateSessionSuccessDto,
-} from "@/modules/auth/application/session/dtos/responses/update-session-outcome.dto";
 import type { AuthUserEntity } from "@/modules/auth/domain/auth-user/entities/auth-user.entity";
 import type { UserEntity } from "@/modules/users/domain/entities/user.entity";
 import { toUserId } from "@/modules/users/domain/user-id.mappers";
@@ -74,20 +70,6 @@ export function makeAuthenticatedUserDto(
 		id: TEST_USER_ID,
 		role: "USER",
 		username: TEST_USERNAME,
-		...overrides,
-	};
-}
-
-/** A successful `UpdateSessionSuccessDto` (e.g. a rotated session). */
-export function makeUpdateSessionSuccessDto(
-	overrides: Partial<UpdateSessionSuccessDto> = {},
-): UpdateSessionSuccessDto {
-	return {
-		expiresAtMs: 1_700_000_000_000,
-		reason: UPDATE_SESSION_OUTCOME_REASON.rotated,
-		refreshed: true,
-		role: "USER",
-		userId: TEST_USER_ID,
 		...overrides,
 	};
 }


### PR DESCRIPTION
Follow-up to #57 (fix #4, flatten leaf dirs). Applies the next three fixes from the 2026-06-12 auth-structure assessment. Each is a small, independent commit.

### #1 — `toSessionPrincipal`: narrow to one input type (`0f1285cb`)
The mapper accepted `AuthenticatedUserDto | UpdateSessionSuccessDto` and dispatched at runtime on `"email" in source`. The `UpdateSessionSuccessDto` branch had **no production caller** (the rotation flow never derives a principal from it), so it was test-only/dead. Narrowed the parameter to `AuthenticatedUserDto`, dropped the runtime dispatch, and removed the now-orphaned `makeUpdateSessionSuccessDto` fixture. Resolves the mapper's own TODO.

### #2 — `SessionPrincipalDto`: resolve the open TODOs (`5b4b61a6`)
Documented *why* the shape carries only `id` + `role` and no session/cookie/token fields: a "principal" is the authenticated actor, and the minimal claim set is the least-privilege boundary for JWTs. Session mechanics live in the session service. Documents the decision not to expand or rename the DTO.

### #3 — demo-user helper: remove the application→infrastructure leak (`177b1206`)
`createDemoUserTxHelper` was auth's **only** application→infrastructure import. It called the infra `pgUniqueViolationToSignupConflictError` mapper after `tx.authUsers.signup()` — but `AuthUserRepository.signup()` already runs that mapper internally, so the error was already a `conflict` by then and the second call was a pure no-op. Dropped the redundant import/call (the translation already lives behind the repo contract) and moved the helper out of `application/shared/helpers` (it isn't shared — its only consumer is `CreateDemoUserUseCase`) into `auth-user/commands`, beside that use case.

## Verification
- `pnpm check:fast` (Biome + `tsc -b` + typegen) — exit 0
- `pnpm test` — **222/222** unit tests
- `grep` confirms **zero** application→infrastructure imports remain in `auth/application`

Remaining from the assessment: **#5** (invoices read actions bypassing `InvoiceService`) — a different module, will be its own PR.
