### PR TITLE
refactor(invoices): route read actions through InvoiceService

### DIFF
--- a/src/app/dashboard/(overview)/page.tsx
+++ b/src/app/dashboard/(overview)/page.tsx
@@ -4,7 +4,6 @@ import { readTotalCustomersCountAction } from "@/modules/customers/presentation/
 import { ITEMS_PER_PAGE_INVOICES } from "@/modules/invoices/domain/invoice.constants";
 import { readInvoicesSummaryAction } from "@/modules/invoices/presentation/actions/read-invoices-summary.action";
 import { readLatestInvoicesAction } from "@/modules/invoices/presentation/actions/read-latest-invoices.action";
-import { getAppDb } from "@/server/db/db.connection";
 import {
 	ADMIN_ROLE,
 	GUEST_ROLE,
@@ -25,13 +24,11 @@ export const dynamic = "force-dynamic";
  * Renders role-appropriate dashboard with new invoice schema compatibility.
  */
 export default async function Page(): Promise<JSX.Element> {
-	const db = getAppDb();
-
 	const [session, invoicesSummary, latestInvoices, totalCustomers] =
 		await Promise.all([
 			verifySessionOptimistic(),
-			readInvoicesSummaryAction(db),
-			readLatestInvoicesAction(db, ITEMS_PER_PAGE_INVOICES),
+			readInvoicesSummaryAction(),
+			readLatestInvoicesAction(ITEMS_PER_PAGE_INVOICES),
 			readTotalCustomersCountAction(),
 		]);
 

--- a/src/modules/invoices/application/services/invoice.service.ts
+++ b/src/modules/invoices/application/services/invoice.service.ts
@@ -3,8 +3,10 @@ import "server-only";
 import type {
 	InvoiceDto,
 	InvoiceFormDto,
+	InvoicesSummary,
 } from "@/modules/invoices/application/dto/invoice.dto";
 import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
+import type { InvoiceListFilter } from "@/modules/invoices/domain/invoice.types";
 import { toInvoiceId } from "@/modules/invoices/domain/invoice-id.mappers";
 import {
 	dtoToCreateInvoiceEntity,
@@ -163,5 +165,26 @@ export class InvoiceService {
 			);
 		}
 		return Ok(await this.repo.delete(toInvoiceId(id)));
+	}
+
+	async readFilteredInvoices(
+		query: string,
+		currentPage: number,
+	): Promise<Result<InvoiceListFilter[], AppError>> {
+		return Ok(await this.repo.readFiltered(query, currentPage));
+	}
+
+	async readInvoicesPages(query: string): Promise<Result<number, AppError>> {
+		return Ok(await this.repo.readPagesCount(query));
+	}
+
+	async readLatestInvoices(
+		limit: number,
+	): Promise<Result<InvoiceListFilter[], AppError>> {
+		return Ok(await this.repo.readLatest(limit));
+	}
+
+	async readInvoicesSummary(): Promise<Result<InvoicesSummary, AppError>> {
+		return Ok(await this.repo.readSummary());
 	}
 }

--- a/src/modules/invoices/infrastructure/repository/invoice.repository.ts
+++ b/src/modules/invoices/infrastructure/repository/invoice.repository.ts
@@ -1,16 +1,26 @@
 import "server-only";
 
-import type { InvoiceDto } from "@/modules/invoices/application/dto/invoice.dto";
+import type {
+	InvoiceDto,
+	InvoicesSummary,
+} from "@/modules/invoices/application/dto/invoice.dto";
 import type {
 	InvoiceFormPartialEntity,
 	InvoiceServiceEntity,
 } from "@/modules/invoices/domain/entities/invoice.entity";
 import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
+import type { InvoiceListFilter } from "@/modules/invoices/domain/invoice.types";
 import type { InvoiceId } from "@/modules/invoices/domain/types/invoice-id.brand";
 import { entityToInvoiceDto } from "@/modules/invoices/infrastructure/adapters/codecs/invoice-codecs";
 import { BaseRepository } from "@/modules/invoices/infrastructure/repository/base-repository";
 import { createInvoiceDal } from "@/modules/invoices/infrastructure/repository/dal/create-invoice.dal";
 import { deleteInvoiceDal } from "@/modules/invoices/infrastructure/repository/dal/delete-invoice.dal";
+import { fetchFilteredInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-filtered-invoices.dal";
+import { fetchInvoicesPagesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-invoices-pages.dal";
+import { fetchLatestInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-latest-invoices.dal";
+import { fetchTotalInvoicesCountDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-total-invoices-count.dal";
+import { fetchTotalPaidInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-total-paid-invoices.dal";
+import { fetchTotalPendingInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-total-pending-invoices.dal";
 import { readInvoiceDal } from "@/modules/invoices/infrastructure/repository/dal/read-invoice.dal";
 import { updateInvoiceDal } from "@/modules/invoices/infrastructure/repository/dal/update-invoice.dal";
 import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
@@ -133,5 +143,50 @@ export class InvoiceRepository extends BaseRepository<
 
 		// Transform Entity (branded) → DTO (plain)
 		return entityToInvoiceDto(deletedEntity);
+	}
+
+	/**
+	 * Reads the filtered, paginated invoice list for the invoices table.
+	 * @param query - Search query string.
+	 * @param currentPage - 1-based page number.
+	 * @returns Promise resolving to the matching invoice list rows.
+	 */
+	async readFiltered(
+		query: string,
+		currentPage: number,
+	): Promise<InvoiceListFilter[]> {
+		return await fetchFilteredInvoicesDal(this.db, query, currentPage);
+	}
+
+	/**
+	 * Reads the total number of pages for the filtered invoice list.
+	 * @param query - Search query string.
+	 * @returns Promise resolving to the total page count.
+	 */
+	async readPagesCount(query: string): Promise<number> {
+		return await fetchInvoicesPagesDal(this.db, query);
+	}
+
+	/**
+	 * Reads the most recent invoices for the dashboard overview.
+	 * @param limit - Maximum number of invoices to return.
+	 * @returns Promise resolving to the latest invoice list rows.
+	 */
+	async readLatest(limit: number): Promise<InvoiceListFilter[]> {
+		return await fetchLatestInvoicesDal(this.db, limit);
+	}
+
+	/**
+	 * Reads the aggregate invoice totals for the dashboard summary cards.
+	 * @returns Promise resolving to the invoices summary.
+	 */
+	async readSummary(): Promise<InvoicesSummary> {
+		const [totalInvoices, totalPending, totalPaid] = await Promise.all([
+			fetchTotalInvoicesCountDal(this.db),
+			fetchTotalPendingInvoicesDal(this.db),
+			fetchTotalPaidInvoicesDal(this.db),
+		]);
+
+		return { totalInvoices, totalPaid, totalPending };
 	}
 }

--- a/src/modules/invoices/presentation/actions/read-filtered-invoices.action.ts
+++ b/src/modules/invoices/presentation/actions/read-filtered-invoices.action.ts
@@ -1,6 +1,7 @@
 "use server";
+import { InvoiceService } from "@/modules/invoices/application/services/invoice.service";
 import type { InvoiceListFilter } from "@/modules/invoices/domain/invoice.types";
-import { fetchFilteredInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-filtered-invoices.dal";
+import { InvoiceRepository } from "@/modules/invoices/infrastructure/repository/invoice.repository";
 import { getAppDb } from "@/server/db/db.connection";
 
 /**
@@ -13,6 +14,12 @@ export async function readFilteredInvoicesAction(
 	query: string = "",
 	currentPage: number = 1,
 ): Promise<InvoiceListFilter[]> {
-	const db = getAppDb();
-	return await fetchFilteredInvoicesDal(db, query, currentPage);
+	const service = new InvoiceService(new InvoiceRepository(getAppDb()));
+	const result = await service.readFilteredInvoices(query, currentPage);
+
+	if (!result.ok) {
+		throw result.error;
+	}
+
+	return result.value;
 }

--- a/src/modules/invoices/presentation/actions/read-invoices-pages.action.ts
+++ b/src/modules/invoices/presentation/actions/read-invoices-pages.action.ts
@@ -1,7 +1,8 @@
 "use server";
 
+import { InvoiceService } from "@/modules/invoices/application/services/invoice.service";
 import { INVOICE_MSG } from "@/modules/invoices/domain/i18n/invoice-messages";
-import { fetchInvoicesPagesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-invoices-pages.dal";
+import { InvoiceRepository } from "@/modules/invoices/infrastructure/repository/invoice.repository";
 import { getAppDb } from "@/server/db/db.connection";
 import { logger } from "@/shared/telemetry/logging/infrastructure/logging.client";
 
@@ -14,9 +15,15 @@ export async function readInvoicesPagesAction(
 	query: string = "",
 ): Promise<number> {
 	try {
-		const db = getAppDb();
 		const sanitizedQuery = query.trim();
-		const totalPages = await fetchInvoicesPagesDal(db, sanitizedQuery);
+		const service = new InvoiceService(new InvoiceRepository(getAppDb()));
+		const result = await service.readInvoicesPages(sanitizedQuery);
+
+		if (!result.ok) {
+			throw result.error;
+		}
+
+		const totalPages = result.value;
 
 		if (!Number.isInteger(totalPages) || totalPages < 1) {
 			logger.error("Invalid totalPages returned from DAL", {

--- a/src/modules/invoices/presentation/actions/read-invoices-summary.action.ts
+++ b/src/modules/invoices/presentation/actions/read-invoices-summary.action.ts
@@ -1,18 +1,20 @@
 "use server";
 import type { InvoicesSummary } from "@/modules/invoices/application/dto/invoice.dto";
-import { fetchTotalInvoicesCountDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-total-invoices-count.dal";
-import { fetchTotalPaidInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-total-paid-invoices.dal";
-import { fetchTotalPendingInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-total-pending-invoices.dal";
-import type { AppDatabase } from "@/server/db/db.connection";
+import { InvoiceService } from "@/modules/invoices/application/services/invoice.service";
+import { InvoiceRepository } from "@/modules/invoices/infrastructure/repository/invoice.repository";
+import { getAppDb } from "@/server/db/db.connection";
 
-export async function readInvoicesSummaryAction(
-	db: AppDatabase,
-): Promise<InvoicesSummary> {
-	const [totalInvoices, totalPending, totalPaid] = await Promise.all([
-		fetchTotalInvoicesCountDal(db),
-		fetchTotalPendingInvoicesDal(db),
-		fetchTotalPaidInvoicesDal(db),
-	]);
+/**
+ * Server action to fetch the aggregate invoice totals for the dashboard cards.
+ * @returns The invoices summary (totals for all / paid / pending)
+ */
+export async function readInvoicesSummaryAction(): Promise<InvoicesSummary> {
+	const service = new InvoiceService(new InvoiceRepository(getAppDb()));
+	const result = await service.readInvoicesSummary();
 
-	return { totalInvoices, totalPaid, totalPending };
+	if (!result.ok) {
+		throw result.error;
+	}
+
+	return result.value;
 }

--- a/src/modules/invoices/presentation/actions/read-latest-invoices.action.ts
+++ b/src/modules/invoices/presentation/actions/read-latest-invoices.action.ts
@@ -1,10 +1,23 @@
+"use server";
+import { InvoiceService } from "@/modules/invoices/application/services/invoice.service";
 import type { InvoiceListFilter } from "@/modules/invoices/domain/invoice.types";
-import { fetchLatestInvoicesDal } from "@/modules/invoices/infrastructure/repository/dal/fetch-latest-invoices.dal";
-import type { AppDatabase } from "@/server/db/db.connection";
+import { InvoiceRepository } from "@/modules/invoices/infrastructure/repository/invoice.repository";
+import { getAppDb } from "@/server/db/db.connection";
 
+/**
+ * Server action to fetch the most recent invoices for the dashboard overview.
+ * @param limit - Maximum number of invoices to return
+ * @returns Array of InvoiceListFilter
+ */
 export async function readLatestInvoicesAction(
-	db: AppDatabase,
 	limit: number = 5,
 ): Promise<InvoiceListFilter[]> {
-	return await fetchLatestInvoicesDal(db, limit);
+	const service = new InvoiceService(new InvoiceRepository(getAppDb()));
+	const result = await service.readLatestInvoices(limit);
+
+	if (!result.ok) {
+		throw result.error;
+	}
+
+	return result.value;
 }


### PR DESCRIPTION
Implements **fix #5** from the 2026-06-12 structure assessment — the one genuine service-layer violation. Separate from the auth PRs (#57, #58) since it's a different module.

## Problem
Four invoices **read** actions imported infrastructure DALs directly, bypassing `InvoiceService`:
- `read-filtered-invoices` → `fetchFilteredInvoicesDal`
- `read-invoices-pages` → `fetchInvoicesPagesDal`
- `read-latest-invoices` → `fetchLatestInvoicesDal`
- `read-invoices-summary` → `fetchTotal{Count,Paid,Pending}InvoicesDal`

The mutations (create/update/delete) and `read-invoice-by-id` already went through the service, so this restores a consistent presentation → application → infrastructure → DAL path.

## Change
- **`InvoiceRepository`**: new `readFiltered` / `readPagesCount` / `readLatest` / `readSummary` methods that own the DAL calls.
- **`InvoiceService`**: matching `Result`-returning read methods.
- **Actions**: rewired to `new InvoiceService(new InvoiceRepository(getAppDb()))` (the `read-invoice-by-id` pattern); no DAL imports remain in the presentation layer.
- **Bonus**: dropped the non-serializable `db: AppDatabase` param from the `summary`/`latest` actions — a `"use server"` action can't legitimately receive a DB connection. They now resolve `getAppDb()` internally; the lone caller (dashboard overview page) no longer plumbs `db` through.

Behavior preserved: same return types, same pages validation/logging.

## Verification
- `pnpm check:fast` (Biome + `tsc -b` + typegen) — exit 0
- `pnpm test` — **226/226** unit tests
- `grep` confirms **no** DAL imports remain under `invoices/presentation/actions`
