### PR TITLE
docs: record live deploy — README autolink fix + backlog reconcile

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -14,8 +14,6 @@ this file is the deliberate workaround.)
       pnpm/node/override gap; Renovate would still automate grouped updates.)_
 - [ ] **docs/ consolidation** — reconcile `docs/standards/` overlap with the existing
       `project-structure.md`, `when-to-use-app-error.md`, and `ui-refactor-strategy.md`.
-- [ ] **Live deploy** — Vercel + Neon account setup: create projects, set env vars,
-      run prod migrate + seed, paste the live URL into the README.
 - [ ] **Vitest Phase 3** — remaining breadth (`server`, invoices/customers domain) and
       consider coverage thresholds once breadth lands. Forms breadth DONE (2026-06-11):
       68 characterization tests across all 11 testable forms files, pinning the three
@@ -124,6 +122,15 @@ this file is the deliberate workaround.)
 ## Done
 
 <!-- Move finished items here with a date, or delete them. -->
+
+- [x] **Live deploy** _(2026-06-13)_ — the managed Vercel + Neon path is live. The
+      production deployment is promoted and serving at
+      <https://nextjs-dashboard-beige-pi-12.vercel.app/> (verified 200 OK — "Acme"
+      landing page → `admin@admin.com` / `AdminPassword123!` demo login), and the URL is
+      now in the README. Completes deploy Phase 3, building on the Docker standalone
+      stack with `/api/health` + `docs/deployment.md` (#35), the Neon prod DB plus the
+      backfilled `0006` seed fix (#44), and per-PR Vercel previews (#55). Cost: $0 on
+      free tiers.
 
 - [x] **Auth/invoices structure-assessment fixes** _(2026-06-13)_ — applied all 5 fixes
       from the 2026-06-12 module-structure assessment (verdict: **no restructure**; the

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A modern dashboard application built with Next.js (App Router), TypeScript, Drizzle ORM, and Tailwind CSS. It includes
 authentication, middleware-based route protection, database migrations/seeding, and end-to-end tests with Cypress.
 
-> **Live demo:** _add your Vercel URL here_ &nbsp;·&nbsp; **Demo login:** `admin@admin.com` / `AdminPassword123!`
+> **Live demo:** <https://nextjs-dashboard-beige-pi-12.vercel.app/> &nbsp;·&nbsp; **Demo login:** `admin@admin.com` / `AdminPassword123!`
 >
 > Run it yourself in one command: `docker compose up --build` → <http://localhost:3000>. See [Deployment](#deployment).
 


### PR DESCRIPTION
## Summary

Records the now-live Vercel production deploy and reconciles the backlog to match reality.

- **README** — the live-demo URL had been pasted in as a bare URL, which trips `MD034/no-bare-urls` and would fail `md:check` / CI. Wrapped it as an angle-bracket autolink (`<https://…>`), matching the existing convention on the adjacent "run it yourself" line, and dropping the leftover italics from the old placeholder.
- **BACKLOG** — moved **Live deploy** from Open → Done (dated 2026-06-13). The production deploy is promoted and serving (verified 200 OK at <https://nextjs-dashboard-beige-pi-12.vercel.app/>), and the URL is now in the README, so both remaining sub-items are satisfied.

This finishes the "live demo" half of deploy Phase 3. The remaining deploy-adjacent work (Cypress e2e in CI + branch protection on `main`) is Phase 4 and is already tracked.

## Type of change

- [x] Chore / tooling / docs

## How it was tested

- [x] `pnpm md:check` (markdown lint + format) — **0 errors**. This is the relevant gate for a markdown-only change; no TS or app code was touched.
- [x] Manually verified the live URL returns **200 OK** and serves the app landing page.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed
- [x] Focused change — preserves existing patterns and user-authored work
