### PR TITLE
fix(forms): detect form metadata by shape, not by error key

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -47,9 +47,12 @@ this file is the deliberate workaround.)
         AppError branch now says `updateFailed`, not `invalidInput`'s "create" copy),
         and the stale-skipped update-form Cypress error test is re-enabled — its
         serialization blocker was fixed back in PR #41.
-  - [ ] **Fix field-error key coupling** — `makeFormError` stamps form metadata onto any
-        error key, but extractors only honor `validation` | `conflict`; a `database`-keyed
-        form error silently drops its field errors (`form-error.inspector.ts`).
+  - [x] **Fix field-error key coupling** _(2026-06-13)_ — the inspector extractors and the
+        shared `isFormValidationError` guard now detect form metadata by SHAPE (`fieldErrors`
+        present), key-agnostic: `conflict`/`not_found`/etc. form errors round-trip their echoed
+        values and form-level errors instead of silently dropping them (fixes the signup
+        unique-violation wiping the typed email/username). A `validation`/`conflict` error
+        without form metadata still returns undefined.
   - [ ] **Form error payload overlap** — consolidate `toFormErrorPayload` vs
         `formErrorPayloadMapper` (TODO in `form-error-payload.mapper.ts`). Production
         only uses `toFormErrorPayload`; the mapper variant is imported solely by auth

--- a/src/shared/forms/__tests__/unit/form-error.inspector.test.ts
+++ b/src/shared/forms/__tests__/unit/form-error.inspector.test.ts
@@ -11,11 +11,12 @@ import {
  * Unit tests for the form error inspector (form-error.inspector.ts).
  *
  * The inspectors read form metadata back out of an AppError (entity or
- * serialized DTO). They are key-coupled: `extractFieldErrors` honors
- * `validation | conflict`, while `extractFieldValues` / `extractFormErrors`
- * honor only `validation`. A form error under any other key silently drops
- * its metadata — pinned below; see the "Fix field-error key coupling"
- * BACKLOG item before changing this.
+ * serialized DTO). They are key-AGNOSTIC: any error whose metadata
+ * structurally carries `fieldErrors` is treated as a form error, so
+ * `validation`, `conflict`, and any other metadata-carrying key all
+ * round-trip their field errors, echoed values, and form-level errors
+ * identically. A `validation`/`conflict` error WITHOUT a `fieldErrors`
+ * property still yields undefined / frozen [].
  */
 describe("form-error inspector", () => {
 	const formMetadata = {
@@ -67,10 +68,10 @@ describe("form-error inspector", () => {
 			});
 		});
 
-		it("silently drops field errors for a database-keyed form error (known coupling bug)", () => {
-			// The metadata carries fieldErrors, but the inspector only looks at
-			// the key — BACKLOG: "Fix field-error key coupling".
-			expect(extractFieldErrors(databaseFormError)).toBeUndefined();
+		it("returns field errors for a database-keyed form error (structural read)", () => {
+			expect(extractFieldErrors(databaseFormError)).toEqual({
+				email: ["Required"],
+			});
 		});
 
 		it("returns undefined for a conflict error without form metadata", () => {
@@ -91,8 +92,10 @@ describe("form-error inspector", () => {
 			});
 		});
 
-		it("returns undefined for a conflict-keyed form error (asymmetric with extractFieldErrors)", () => {
-			expect(extractFieldValues(conflictError)).toBeUndefined();
+		it("returns echoed form data for a conflict-keyed form error", () => {
+			expect(extractFieldValues(conflictError)).toEqual({
+				email: "a@b.c",
+			});
 		});
 
 		it("returns undefined when validation metadata has no fieldErrors shape", () => {
@@ -104,6 +107,16 @@ describe("form-error inspector", () => {
 
 			expect(extractFieldValues(bare)).toBeUndefined();
 		});
+
+		it("returns echoed form data for any metadata-carrying key (structural read)", () => {
+			const notFoundForm: AppErrorLike = {
+				key: "not_found",
+				message: "x",
+				metadata: formMetadata,
+			};
+
+			expect(extractFieldValues(notFoundForm)).toEqual({ email: "a@b.c" });
+		});
 	});
 
 	describe("extractFormErrors", () => {
@@ -113,15 +126,16 @@ describe("form-error inspector", () => {
 			]);
 		});
 
-		it("returns a frozen empty array for a conflict-keyed form error (asymmetric)", () => {
-			const formErrors = extractFormErrors(conflictError);
-
-			expect(formErrors).toEqual([]);
-			expect(Object.isFrozen(formErrors)).toBe(true);
+		it("returns form-level errors for a conflict-keyed form error", () => {
+			expect(extractFormErrors(conflictError)).toEqual([
+				"Fix the fields below.",
+			]);
 		});
 
-		it("returns an empty array for a database-keyed form error", () => {
-			expect(extractFormErrors(databaseFormError)).toEqual([]);
+		it("returns form-level errors for a database-keyed form error", () => {
+			expect(extractFormErrors(databaseFormError)).toEqual([
+				"Fix the fields below.",
+			]);
 		});
 	});
 });

--- a/src/shared/forms/__tests__/unit/form-result.guard.test.ts
+++ b/src/shared/forms/__tests__/unit/form-result.guard.test.ts
@@ -6,9 +6,10 @@ import { isFormValidationError } from "@/shared/forms/core/guards/form-result.gu
 /**
  * Unit tests for the form result guard (form-result.guard.ts).
  *
- * `isFormValidationError` is the single live guard: validation key AND a
- * `fieldErrors` property in metadata. Both conditions are pinned — a
- * conflict-keyed form error fails the guard even with identical metadata.
+ * `isFormValidationError` is the single live guard. It is key-AGNOSTIC: it
+ * accepts any AppError (entity or DTO) whose metadata structurally carries a
+ * `fieldErrors` property, regardless of `error.key`. An error without a
+ * `fieldErrors` property still fails the guard.
  */
 describe("isFormValidationError", () => {
 	const formMetadata = {
@@ -47,11 +48,21 @@ describe("isFormValidationError", () => {
 		expect(isFormValidationError(error)).toBe(false);
 	});
 
-	it("rejects a conflict-keyed error even when it carries form metadata", () => {
+	it("accepts a conflict-keyed error that carries form metadata", () => {
 		const error: AppErrorLike = {
 			key: "conflict",
 			message: "Email already exists.",
 			metadata: formMetadata,
+		};
+
+		expect(isFormValidationError(error)).toBe(true);
+	});
+
+	it("rejects a conflict-keyed error without a fieldErrors property", () => {
+		const error: AppErrorLike = {
+			key: "conflict",
+			message: "duplicate key",
+			metadata: { pgCode: "23505" },
 		};
 
 		expect(isFormValidationError(error)).toBe(false);

--- a/src/shared/forms/core/guards/form-result.guard.ts
+++ b/src/shared/forms/core/guards/form-result.guard.ts
@@ -1,10 +1,21 @@
 import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
-import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
 import type { FormValidationMetadata } from "@/shared/forms/core/types/validation.types";
 
 /**
- * Type guard: checks if an AppError (entity or serialized DTO) contains form
- * validation details.
+ * Type guard: checks if an AppError (entity or serialized DTO) structurally
+ * carries form validation metadata.
+ *
+ * Key-agnostic by design. The shared writer (`makeFormError`) stamps
+ * {@link FormValidationMetadata} (`fieldErrors` / `formData` / `formErrors`)
+ * onto whatever key the action chose — `validation` on the happy path,
+ * `conflict` for a duplicate-email/username signup, etc. — so the read side
+ * must recognize form metadata by SHAPE, not by `error.key`. Gating on the key
+ * caused the writer/reader divergence where a `conflict` error returned field
+ * errors but dropped the echoed `formData`/`formErrors`.
+ *
+ * The structural `fieldErrors`-presence check is retained, so a `validation`-
+ * or `conflict`-keyed error WITHOUT form metadata (e.g. a bare-pgCode conflict)
+ * still fails the guard and the extractors still return undefined / frozen [].
  */
 export function isFormValidationError<TFields extends string>(
 	error: AppErrorLike,
@@ -12,7 +23,6 @@ export function isFormValidationError<TFields extends string>(
 	readonly metadata: FormValidationMetadata<TFields>;
 } {
 	return (
-		error.key === APP_ERROR_KEYS.validation &&
 		error.metadata !== undefined &&
 		error.metadata !== null &&
 		typeof error.metadata === "object" &&

--- a/src/shared/forms/logic/inspectors/form-error.inspector.ts
+++ b/src/shared/forms/logic/inspectors/form-error.inspector.ts
@@ -1,30 +1,21 @@
 import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
-import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
 import { isFormValidationError } from "@/shared/forms/core/guards/form-result.guard";
 import type {
 	DenseFieldErrorMap,
 	FormErrors,
 } from "@/shared/forms/core/types/field-error.types";
 import type { SparseFieldValueMap } from "@/shared/forms/core/types/field-value.types";
-import type { FormValidationMetadata } from "@/shared/forms/core/types/validation.types";
-
-// Helper internal to the inspector. Accepts AppError entities and their
-// serialized DTOs alike, since form results carry DTOs across the boundary.
-function hasFormMetadata<T extends string>(
-	error: AppErrorLike,
-): error is AppErrorLike & { readonly metadata: FormValidationMetadata<T> } {
-	return (
-		error.key === APP_ERROR_KEYS.validation ||
-		error.key === APP_ERROR_KEYS.conflict
-	);
-}
 
 /**
  * Extracts dense field errors from an AppError or its serialized DTO.
- * Returns undefined if not a form validation error.
+ * Returns undefined if the error carries no form validation metadata.
+ *
+ * Key-agnostic: detection is by the SHAPE of `metadata` (see
+ * `isFormValidationError`), so a `conflict`-keyed duplicate-signup error and
+ * any other metadata-carrying key round-trip their field errors identically.
  *
  * @example
- * const errors = getFieldErrors<'email' | 'password'>(AppError);
+ * const errors = extractFieldErrors<'email' | 'password'>(appError);
  * if (errors) {
  *   console.log(errors.email); // readonly string[]
  * }
@@ -32,7 +23,7 @@ function hasFormMetadata<T extends string>(
 export const extractFieldErrors = <T extends string>(
 	error: AppErrorLike,
 ): DenseFieldErrorMap<T, string> | undefined => {
-	if (hasFormMetadata<T>(error)) {
+	if (isFormValidationError<T>(error)) {
 		return error.metadata.fieldErrors;
 	}
 
@@ -55,7 +46,7 @@ export const extractFieldValues = <T extends string>(
 
 /**
  * Extracts form-level errors from an AppError or its serialized DTO.
- * Returns empty array if not present.
+ * Returns a frozen empty array if not present.
  */
 export const extractFormErrors = (error: AppErrorLike): FormErrors => {
 	if (isFormValidationError(error)) {

--- a/src/shared/forms/notes/adr/001-model-form-state-as-boundary-dto-with-null-idle.md
+++ b/src/shared/forms/notes/adr/001-model-form-state-as-boundary-dto-with-null-idle.md
@@ -216,6 +216,6 @@ Behind the PR #48 characterization tests:
 ## Out of Scope
 
 Decided elsewhere, deliberately not here: the sensitive-field echo allowlist,
-the field-error key coupling fix, the `toFormErrorPayload` /
-`formErrorPayloadMapper` consolidation, and validation-funnel unification.
-Each remains its own BACKLOG item under "Forms/error boundary cleanup".
+the `toFormErrorPayload` / `formErrorPayloadMapper` consolidation, and
+validation-funnel unification. Each remains its own BACKLOG item under
+"Forms/error boundary cleanup".


### PR DESCRIPTION
## Summary

Fixes the field-error **key coupling** in the form-error read path: the three
inspector extractors and the shared `isFormValidationError` guard gated on
`error.key`, and the two guards disagreed (`extractFieldErrors` honored
`validation | conflict`; `extractFieldValues` / `extractFormErrors` honored
`validation` only). Any form error under another key silently dropped its
metadata.

The fix makes `isFormValidationError` **key-agnostic** — it detects form metadata
by *shape* (`metadata` is an object carrying `fieldErrors`) — and routes all
three extractors through that one guard, deleting the divergent `hasFormMetadata`
helper. A `validation`/`conflict` error **without** form metadata (e.g. a
bare-`pgCode` conflict) still returns `undefined` (the structural `fieldErrors`
check is retained).

Closes the **"Fix field-error key coupling"** BACKLOG item.

### Why shape-based, not a key allowlist

`makeAppError` / the `AppError` constructor validates metadata **non-rejecting**
(sanitize + passthrough, no throw — `app-error.entity.ts`), so a form error is
constructible under *any* key. A key allowlist can therefore never be complete;
the read side must key on the metadata shape.

### Behavior changes (both match the mappers' documented intent)

The bug was broader than the backlog note (which only cited a theoretical
`database` case). Two real, user-visible paths were affected:

1. **Signup unique-violation** (`conflict`): the typed email/username were
   **wiped** from the inputs (echoed `formData` dropped on read). Now they
   repopulate.
2. **Login invalid-credentials** (`invalid_credentials`): the unified per-field
   errors that `mapLoginInvalidCredentialsError` builds for anti-enumeration
   **never rendered** (only the form-level banner showed). They now render and
   the email repopulates. This is the mapper's documented intent;
   anti-enumeration safety is preserved (email and password show the *same*
   message). **Confirmed desired** by the author.

`not_found` / `unexpected` / `unknown` form errors also become readable but carry
empty metadata, so there is no visible change on those paths.

## Type of change

- [x] Fix

## How it was tested

- [x] `pnpm test` (unit) — **224 pass** (35 files), incl. the 5 re-pinned
      assertions + 2 new regression tests (bare-`pgCode` conflict still rejected;
      echoed values round-trip for a non-`validation`/`conflict` key).
- [x] `pnpm check:fast` (lint + typecheck + typegen + markdown) — clean.
- [x] Adversarial regression sweep on the shape-based widening: the only non-form
      metadata carrying `fieldErrors` is `env-access.utils.ts`, which is
      `validation`-keyed (identical under old/new) and never crosses a form
      boundary; the infra pg-conflict mapper stamps only `pgCode`. No regression.
- [ ] `pnpm cy:e2e` (end-to-end) — not run. The auth e2e specs assert the
      form-level message (unchanged); the newly-rendered per-field errors are not
      asserted by existing specs.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs updated — checked off the BACKLOG item; removed the item from ADR 001's
      "Out of Scope" deferred list
- [x] Focused change — preserves existing patterns and user-authored work

## Reviewer notes

- Source change is tiny: delete the `error.key === validation` clause from the
  guard, delete the inspector's `hasFormMetadata`, point `extractFieldErrors` at
  the shared guard. The rest is test re-pinning + docs.
- The test file headers previously documented the asymmetry as a "known coupling
  bug"; those are rewritten to describe the corrected key-agnostic contract.
