### PR TITLE
refactor(forms): consolidate form-error payload onto a single mapper

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -53,10 +53,16 @@ this file is the deliberate workaround.)
         values and form-level errors instead of silently dropping them (fixes the signup
         unique-violation wiping the typed email/username). A `validation`/`conflict` error
         without form metadata still returns undefined.
-  - [ ] **Form error payload overlap** — consolidate `toFormErrorPayload` vs
-        `formErrorPayloadMapper` (TODO in `form-error-payload.mapper.ts`). Production
-        only uses `toFormErrorPayload`; the mapper variant is imported solely by auth
-        integration tests and differs in fallback semantics (`[error.message]`).
+  - [x] **Form error payload overlap** _(2026-06-13)_ — consolidated onto a single
+        `toFormErrorPayload`; deleted the test-only `formErrorPayloadMapper` (zero
+        production callers) and its `[error.message]` form-error fallback. The fallback
+        was dead for every real input except one integration assertion (signup conflict),
+        where it synthesized a form-level error that production never shows — production
+        surfaces conflicts as FIELD-level errors (`fieldErrors.email`, `formErrors` empty,
+        per `toSignupFormResult`). Realigned that assertion to the field-level channel
+        (matching `signup-flow.test.ts`'s documented contract), migrated the 3 auth
+        integration decoders + the unit test to `toFormErrorPayload`, and removed the TODO.
+        Production behavior unchanged. Unit + auth-integration lanes green; typecheck clean.
 - [ ] **Env hygiene** — surfaced during deploy prep (2026-06-11):
   - [x] Remove dead `LOG_LEVEL` plumbing _(2026-06-13)_ — deleted `getLogLevelResult` +
         `_getLogLevel` from `env-shared.ts` (and their orphaned `LogLevel`/`LogLevelSchema`

--- a/src/modules/auth/__tests__/integration/error-propagation.test.ts
+++ b/src/modules/auth/__tests__/integration/error-propagation.test.ts
@@ -2,10 +2,11 @@ import { buildFormData } from "@test-support/forms/form-data";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { loginAction } from "@/modules/auth/presentation/authn/actions/login.action";
 import { signupAction } from "@/modules/auth/presentation/authn/actions/signup.action";
+import type { SignupField } from "@/modules/auth/presentation/authn/transports/signup.transport";
 import { getAppDb } from "@/server/db/db.connection";
 import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
 import type { FormResult } from "@/shared/forms/core/types/form-result.dto";
-import { formErrorPayloadMapper } from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
+import { toFormErrorPayload } from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
 
 describe("Auth Error Propagation Integration", () => {
 	beforeEach(() => {
@@ -29,7 +30,9 @@ describe("Auth Error Propagation Integration", () => {
 
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
-				const payload = formErrorPayloadMapper(result.error);
+				const payload = toFormErrorPayload(result.error);
+				// mapGenericAuthError surfaces the message at the form level for
+				// non-form errors, so the decoded payload carries one form error.
 				expect(payload.formErrors.length).toBeGreaterThan(0);
 				// It's wrapped in safeExecute which maps to 'unexpected'
 				expect(result.error.key).toBe(APP_ERROR_KEYS.unexpected);
@@ -63,12 +66,14 @@ describe("Auth Error Propagation Integration", () => {
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
 				expect(result.error.key).toBe(APP_ERROR_KEYS.conflict);
-				const payload = formErrorPayloadMapper(result.error);
-				expect(payload.formErrors.length).toBeGreaterThan(0);
-				const firstFormError = payload.formErrors[0];
-				expect(firstFormError).toBeDefined();
-				expect(firstFormError?.toLowerCase()).toMatch(
-					/already in use|exists|conflict|unique/,
+				// Conflicts surface as FIELD-level errors, not form-level: the
+				// email-unique constraint maps to fieldErrors.email (see
+				// toSignupFormResult), and formErrors stays empty.
+				const payload = toFormErrorPayload<SignupField>(result.error);
+				const emailErrors = payload.fieldErrors.email;
+				expect(emailErrors.length).toBeGreaterThan(0);
+				expect(emailErrors[0]?.toLowerCase()).toMatch(
+					/already|use|exists|conflict|unique/,
 				);
 			}
 
@@ -91,7 +96,7 @@ describe("Auth Error Propagation Integration", () => {
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
 				expect(result.error.key).toBe(APP_ERROR_KEYS.unexpected);
-				const payload = formErrorPayloadMapper(result.error);
+				const payload = toFormErrorPayload(result.error);
 				// Message may be 'CPU exhausted' or a wrapped variant.
 				expect(payload.message.toLowerCase()).toMatch(
 					/failed|exhausted|unexpected/,
@@ -139,7 +144,7 @@ describe("Auth Error Propagation Integration", () => {
 
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
-				const payload = formErrorPayloadMapper(result.error);
+				const payload = toFormErrorPayload(result.error);
 				expect(payload.message).toContain("unexpected error occurred");
 			}
 

--- a/src/modules/auth/__tests__/integration/login-flow.test.ts
+++ b/src/modules/auth/__tests__/integration/login-flow.test.ts
@@ -7,7 +7,7 @@ import { loginAction } from "@/modules/auth/presentation/authn/actions/login.act
 import type { LoginField } from "@/modules/auth/presentation/authn/transports/login.transport";
 import { getAppDb } from "@/server/db/db.connection";
 import type { FormResult } from "@/shared/forms/core/types/form-result.dto";
-import { formErrorPayloadMapper } from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
+import { toFormErrorPayload } from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
 
 /**
  * Integration tests for the complete login flow.
@@ -76,7 +76,7 @@ describe("Login Flow Integration", () => {
 
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
-				const payload = formErrorPayloadMapper<LoginField>(result.error);
+				const payload = toFormErrorPayload<LoginField>(result.error);
 				expect(payload.fieldErrors?.email).toBeDefined();
 			}
 		});
@@ -106,7 +106,7 @@ describe("Login Flow Integration", () => {
 
 				expect(result.ok, `Expected failure for ${c.name}`).toBe(false);
 				if (!result.ok) {
-					const payload = formErrorPayloadMapper<LoginField>(result.error);
+					const payload = toFormErrorPayload<LoginField>(result.error);
 					const message = payload.formErrors[0] || payload.message;
 					expect(message).toContain("Invalid credentials");
 					messages.push(message);
@@ -128,7 +128,7 @@ describe("Login Flow Integration", () => {
 
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
-				const payload = formErrorPayloadMapper<LoginField>(result.error);
+				const payload = toFormErrorPayload<LoginField>(result.error);
 				expect(payload.formErrors).toBeDefined();
 			}
 

--- a/src/modules/auth/__tests__/integration/signup-flow.test.ts
+++ b/src/modules/auth/__tests__/integration/signup-flow.test.ts
@@ -8,7 +8,7 @@ import type { SignupField } from "@/modules/auth/presentation/authn/transports/s
 import { toHash } from "@/server/crypto/hashing/hashing.value";
 import { getAppDb } from "@/server/db/db.connection";
 import type { FormResult } from "@/shared/forms/core/types/form-result.dto";
-import { formErrorPayloadMapper } from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
+import { toFormErrorPayload } from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
 
 /**
  * Integration tests for the complete signup flow.
@@ -64,7 +64,7 @@ describe("Signup Flow Integration", () => {
 
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
-				const payload = formErrorPayloadMapper<SignupField>(result.error);
+				const payload = toFormErrorPayload<SignupField>(result.error);
 				expect(payload.fieldErrors?.email).toBeDefined();
 				expect(payload.fieldErrors?.password).toBeDefined();
 				expect(payload.fieldErrors?.username).toBeDefined();
@@ -89,7 +89,7 @@ describe("Signup Flow Integration", () => {
 
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
-				const payload = formErrorPayloadMapper<SignupField>(result.error);
+				const payload = toFormErrorPayload<SignupField>(result.error);
 				// Server Action contract: conflicts must return field-level errors.
 				expect(payload.fieldErrors?.email).toBeDefined();
 				expect(payload.fieldErrors.email.length).toBeGreaterThan(0);
@@ -126,7 +126,7 @@ describe("Signup Flow Integration", () => {
 
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
-				const payload = formErrorPayloadMapper<SignupField>(result.error);
+				const payload = toFormErrorPayload<SignupField>(result.error);
 				expect(payload.formErrors).toBeDefined();
 				expect(payload.formErrors.length).toBeGreaterThan(0);
 				// We accept a pg unique violation too, in case state is polluted from a

--- a/src/shared/forms/__tests__/unit/form-error-payload.mapper.test.ts
+++ b/src/shared/forms/__tests__/unit/form-error-payload.mapper.test.ts
@@ -1,19 +1,17 @@
 import { describe, expect, it } from "vitest";
 import type { AppErrorLike } from "@/shared/core/errors/core/app-error.dto";
 import { makeAppError } from "@/shared/core/errors/core/factories/app-error.factory";
-import {
-	formErrorPayloadMapper,
-	toFormErrorPayload,
-} from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
+import { toFormErrorPayload } from "@/shared/forms/presentation/mappers/form-error-payload.mapper";
 
 /**
  * Unit tests for the form error payload mapper (form-error-payload.mapper.ts).
  *
- * Two overlapping exports adapt an AppError for the form UI. Production code
- * uses only `toFormErrorPayload`; `formErrorPayloadMapper` differs in its
- * form-error fallback (`[error.message]`). Both behaviors are pinned so the
- * planned consolidation (BACKLOG: "Form error payload overlap") is a
- * deliberate change, not an accident.
+ * `toFormErrorPayload` is the single mapper that adapts an AppError for the
+ * form UI. The earlier `formErrorPayloadMapper` variant — which synthesized a
+ * form-level error from `error.message` when none was present — was removed in
+ * the "Form error payload overlap" consolidation (BACKLOG). The key behavior
+ * that replaced it is pinned here: a non-form error yields `formErrors: []`,
+ * never `[error.message]`.
  */
 describe("form-error payload mapper", () => {
 	const validationError = makeAppError("validation", {
@@ -57,26 +55,12 @@ describe("form-error payload mapper", () => {
 			expect(Object.isFrozen(payload.fieldErrors)).toBe(true);
 			expect(payload.formData).toEqual({});
 		});
-	});
 
-	describe("formErrorPayloadMapper", () => {
-		it("matches toFormErrorPayload for a validation error with form errors", () => {
-			expect(formErrorPayloadMapper(validationError)).toEqual(
-				toFormErrorPayload(validationError),
-			);
-		});
-
-		it("falls back to [error.message] when there are no form errors (divergence)", () => {
-			// toFormErrorPayload returns [] here; the mapper substitutes the
-			// message — the behavioral difference behind the overlap TODO.
-			const payload = formErrorPayloadMapper(nonFormError);
-
-			expect(payload.formErrors).toEqual(["Nothing here."]);
+		it("never synthesizes a form-level error from the message (no [error.message] fallback)", () => {
+			// The removed formErrorPayloadMapper substituted [error.message]
+			// here; the single mapper surfaces only what the error carries, so a
+			// non-form error has no form-level errors.
 			expect(toFormErrorPayload(nonFormError).formErrors).toEqual([]);
-		});
-
-		it("never builds a dense map — non-form errors get an empty fieldErrors object", () => {
-			expect(formErrorPayloadMapper(nonFormError).fieldErrors).toEqual({});
 		});
 	});
 });

--- a/src/shared/forms/notes/adr/001-model-form-state-as-boundary-dto-with-null-idle.md
+++ b/src/shared/forms/notes/adr/001-model-form-state-as-boundary-dto-with-null-idle.md
@@ -216,6 +216,6 @@ Behind the PR #48 characterization tests:
 ## Out of Scope
 
 Decided elsewhere, deliberately not here: the sensitive-field echo allowlist,
-the `toFormErrorPayload` / `formErrorPayloadMapper` consolidation, and
-validation-funnel unification. Each remains its own BACKLOG item under
-"Forms/error boundary cleanup".
+the form-error payload-mapper consolidation (since resolved — `toFormErrorPayload`
+is now the single mapper), and validation-funnel unification. Each was tracked as
+its own BACKLOG item under "Forms/error boundary cleanup".

--- a/src/shared/forms/presentation/mappers/form-error-payload.mapper.ts
+++ b/src/shared/forms/presentation/mappers/form-error-payload.mapper.ts
@@ -8,11 +8,19 @@ import {
 } from "@/shared/forms/logic/inspectors/form-error.inspector";
 import { makeEmptyDenseFieldErrorMap } from "@/shared/forms/logic/mappers/field-error-map.mapper";
 
-// TODO: THESE FUNCTIONS OVERLAP AND INDICATE A REFACTOR IS NEEDED
-
 /**
  * Adapts a canonical AppError (entity or serialized DTO) into a shape the
  * Form UI can consume.
+ *
+ * This is the single mapper for turning an error into a form payload — both at
+ * the action boundary (mapping a service error into a `FormResult`) and when
+ * decoding a serialized `FormResult.error` back for the UI/tests. It surfaces
+ * exactly what the error carries: `formErrors` comes straight from the error's
+ * form metadata and is `[]` when there is none. It deliberately does NOT
+ * synthesize a form-level error from `error.message` — callers that want the
+ * message surfaced at the form level (e.g. `mapGenericAuthError`) opt into that
+ * fallback explicitly, so conflicts that map to field-level errors keep
+ * `formErrors` empty rather than echoing the raw message twice.
  *
  * @param error - The AppError from the service/action.
  * @param fields - Optional list of field names to ensure a dense error map.
@@ -34,25 +42,6 @@ export function toFormErrorPayload<T extends string>(
 					(Object.freeze({}) as DenseFieldErrorMap<T, string>)),
 		formData: extractFieldValues<T>(error) ?? Object.freeze({}),
 		formErrors: extractFormErrors(error),
-		message: error.message,
-	};
-}
-
-/**
- * Helper to extract form-specific error payload from a generic Result.
- * Essential for UI components to display fieldErrors and formErrors.
- */
-export function formErrorPayloadMapper<F extends string>(
-	error: AppErrorLike,
-): FormErrorPayload<F> {
-	const formErrors = extractFormErrors(error);
-
-	return {
-		fieldErrors:
-			extractFieldErrors<F>(error) ??
-			(Object.freeze({}) as DenseFieldErrorMap<F, string>),
-		formData: extractFieldValues<F>(error) ?? Object.freeze({}),
-		formErrors: formErrors.length > 0 ? formErrors : [error.message],
 		message: error.message,
 	};
 }


### PR DESCRIPTION
## What

Consolidates the two overlapping form-error payload adapters down to one. Deletes the **test-only** `formErrorPayloadMapper`; `toFormErrorPayload` is now the single mapper for turning an `AppError` into a form payload (it was already the only one production used). Closes the last open item in the forms/error refactor roadmap ("Form error payload overlap").

## Why

`form-error-payload.mapper.ts` carried a `// TODO: THESE FUNCTIONS OVERLAP` and two near-identical exports. The only behavioral difference was `formErrorPayloadMapper`'s `formErrors` fallback (`[error.message]` when no form-level errors exist). That fallback:

- had **zero production callers** (`toFormErrorPayload` is what `mapGenericAuthError`/`toLoginFormResult` use), and
- was dead for every real input **except one** integration assertion — the signup-conflict case — where it synthesized a *form-level* error that production never actually shows the user.

Production surfaces conflicts as **field-level** errors (`fieldErrors.email = ["alreadyInUse"]`, `formErrors` empty, per `to-signup-form-result.mapper.ts`); the form banner renders `error.message` independently of `formErrors`. So the old form-level assertion only ever passed because of the dead fallback, and it contradicted `signup-flow.test.ts`'s documented contract ("conflicts must return field-level errors").

## Changes

- **Delete** `formErrorPayloadMapper` + the overlap TODO from `form-error-payload.mapper.ts`; add a docstring stating `toFormErrorPayload` deliberately does not synthesize a form-level error from the message (callers like `mapGenericAuthError` opt into that fallback explicitly).
- **Migrate** the unit test + all 3 auth integration test decoders (`error-propagation`, `login-flow`, `signup-flow`) to `toFormErrorPayload`.
- **Realign** the `error-propagation.test.ts` signup-conflict assertion to the field-level channel (`fieldErrors.email`), matching real UX and `signup-flow.test.ts`.
- Update ADR 001's out-of-scope note (no longer references the deleted symbol) and mark the BACKLOG item done.

## Behavior impact

**None in production.** `toFormErrorPayload`'s body is byte-identical (only its docstring changed), and no production source file changed beyond the dead-export deletion — `map-generic-auth.error.ts` and the `to-*-form-result` mappers are untouched. The change is a code/test cleanup that makes a deliberate, test-only behavioral edit (per the lock-then-refactor protocol the characterization tests were written for).

## Verification

- Mapper unit test: **4/4** ✅
- Auth integration (`error-propagation` + `login-flow` + `signup-flow`): **13/13** ✅
- `pnpm typecheck` ✅ · `pnpm biome:lint` ✅ (600 files) · `pnpm md:check` ✅ (markdownlint + dprint)
- A multi-agent adversarial review independently confirmed: the field-level conflict channel against the actual UI components, no user-facing message regression, and zero dangling references to the deleted symbol.
