### PR TITLE
fix(e2e): pin test port and guard server identity in cy:e2e

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -51,20 +51,43 @@ this file is the deliberate workaround.)
       are config/peer false positives), 18 exports + 13 types.
 - [ ] **Skills exploration** — evaluate reputable-source skills (e.g. Vercel's
       `vercel-react-best-practices`) against `docs/standards/` before adopting.
-- [ ] **e2e port-reuse guard** — `cy:e2e` inherits the session's `PORT` (the
-      `env:test*` scripts run dotenv without `-o`, so an exported `PORT` wins over
-      `.env.test.local`), and start-server-and-test reuses ANY server already
-      answering on that port. With a dev preview running on 3001, two full suite
-      runs (2026-06-11) silently executed against the dev server — `/api/db/reset`
-      404s there, so 7 specs "failed" with no hint of the real cause. Fix ideas:
-      add `-o` to the `env:test*` scripts, pin the cypress PORT, or have
-      `cypress-with-server.cli.ts` verify the responding server's `DATABASE_ENV`
-      (the `smoke/db-env-guard` spec already proves the concept).
 - [ ] **TSConfig Version 6** - figure out how to use TSConfig Version 6.
 
 ## Done
 
 <!-- Move finished items here with a date, or delete them. -->
+
+- [x] **e2e port-reuse guard** _(2026-06-13)_ — closed the trap that let `cy:e2e`
+      silently run against the wrong server (the 2026-06-11 incident: 7 specs
+      "failed" with `/api/db/reset` 404s because the suite hit a dev preview, not the
+      test server). Re-auditing the script graph (verified against installed
+      `dotenv-cli@11`/`start-server-and-test@3.0.9` source) showed it was **two
+      distinct bugs**, fixed separately:
+  - **Bug A — wrong port _number_.** The `env:test*` scripts load dotenv without
+    `--override`, so an exported shell `PORT` silently shadows `.env.test.local`'s
+    `PORT` (`dotenv` `populate()` keeps already-set keys). Fix: the harness now
+    **owns the port** — `cypress-with-server.cli.ts` reads `PORT` straight from
+    `.env.test.local` (via `dotenv.parse`), warns if an exported `PORT` differs, and
+    **pins it** in the spawned child env so the server bind, the wait-on probe, and
+    Cypress's `baseUrl` can't diverge. The shared `env:*` wrappers were left
+    untouched (a blanket `-o` is a global precedence change — it's consumed by 37
+    scripts incl. destructive `db:*:prod` and the CI entrypoints — so it was the
+    wrong shape).
+  - **Bug B — wrong server on the _right_ port.** Correcting the old wording:
+    `start-server-and-test` has **no "reuse" feature** — it unconditionally starts
+    its server; the real mechanism is that `wait-on` accepts any 2xx/304 with **no
+    identity check** while `next dev` (no `-p`) steps aside when the port is busy, so
+    a squatter answering the port is used. Fix: a new `cy:preflight` step
+    (`devtools/cli/e2e-preflight.cli.ts`, wired into the harness's test command)
+    asks `/api/health` which DB the live server is on and **aborts before any spec
+    runs** unless `databaseEnv === "test"`. `/api/health` now returns a non-secret
+    `{ databaseEnv, databaseName }` outside production (omitted on the public prod
+    endpoint), reusing the same non-secret derivation as the `smoke/db-env-guard`
+    spec — lifting that check from mid-suite to a fast pre-flight. _Verified live:
+    health returns `databaseEnv` on a 200; preflight refuses a dev server
+    (`databaseEnv=development`, exit 1) and errors cleanly on an unreachable port;
+    `check:fast` green._ Follow-up (unscheduled): `smoke/db-env-guard` could
+    consolidate onto the HTTP endpoint.
 
 - [x] **Env hygiene** _(2026-06-13, PR #67)_ — finished the deploy-prep env cleanup
       (surfaced 2026-06-11). Four fixes: (1) deleted dead `LOG_LEVEL` plumbing

--- a/devtools/cli/cypress-with-server.cli.ts
+++ b/devtools/cli/cypress-with-server.cli.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import process from "node:process";
+import { parse } from "dotenv";
 
 const mode = process.argv[2];
 
@@ -9,27 +12,58 @@ if (mode !== "open" && mode !== "run") {
 	);
 }
 
-const portRaw = process.env.PORT;
+// The e2e harness OWNS the test port (Bug A of the port-reuse trap). Read it
+// straight from .env.test.local rather than trusting process.env.PORT: the
+// env:* scripts load dotenv WITHOUT --override, so an exported shell PORT
+// silently shadows the file's value and the whole suite can target the wrong
+// server. Pinning the authoritative value below removes that ambiguity. See
+// BACKLOG "e2e port-reuse guard".
+const ENV_TEST_FILE = ".env.test.local";
 
-if (!portRaw) {
-	throw new Error("Missing PORT in environment.");
+function readTestPort(): number {
+	let parsed: Record<string, string>;
+	try {
+		parsed = parse(readFileSync(path.resolve(process.cwd(), ENV_TEST_FILE)));
+	} catch (cause) {
+		throw new Error(`Cannot read ${ENV_TEST_FILE}.`, { cause });
+	}
+
+	const portRaw = parsed.PORT;
+	if (!portRaw) {
+		throw new Error(`Missing PORT in ${ENV_TEST_FILE}.`);
+	}
+
+	const port = Number(portRaw);
+	// biome-ignore lint/style/noMagicNumbers: valid TCP port range
+	if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+		throw new Error(`Invalid PORT in ${ENV_TEST_FILE}: ${portRaw}`);
+	}
+	return port;
 }
 
-const port = Number(portRaw);
+const port = readTestPort();
 
-// biome-ignore lint/style/noMagicNumbers: valid TCP port range
-if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-	throw new Error(`Invalid PORT value: ${portRaw}`);
+// A leftover exported PORT would otherwise win at every dotenv layer; warn so
+// the mismatch is visible, then pin the authoritative value in the child env.
+if (process.env.PORT && process.env.PORT !== String(port)) {
+	console.warn(
+		`[cypress-with-server] Ignoring exported PORT=${process.env.PORT}; pinning ${ENV_TEST_FILE} PORT=${port}.`,
+	);
 }
 
 const baseUrl = `http://localhost:${port}`;
 const cypressCommand = mode === "open" ? "pnpm cy:e2e:open" : "pnpm cy:e2e:run";
+// Verify the server that answered is actually the test DB before any spec runs
+// (Bug B: start-server-and-test accepts any 2xx on the port, identity-blind).
+const testCommand = `pnpm cy:preflight ${baseUrl} && ${cypressCommand}`;
 
 const child = spawn(
 	"pnpm",
-	["exec", "start-server-and-test", "pnpm cy:server", baseUrl, cypressCommand],
+	["exec", "start-server-and-test", "pnpm cy:server", baseUrl, testCommand],
 	{
-		env: process.env,
+		// Pin PORT so the spawned server, the wait-on probe, and Cypress all
+		// agree on it regardless of any value inherited from the shell.
+		env: { ...process.env, PORT: String(port) },
 		stdio: "inherit",
 	},
 );

--- a/devtools/cli/e2e-preflight.cli.ts
+++ b/devtools/cli/e2e-preflight.cli.ts
@@ -1,0 +1,55 @@
+import process from "node:process";
+
+/**
+ * E2E identity guard (Bug B of the port-reuse trap).
+ *
+ * start-server-and-test waits on the base URL but is identity-blind: it accepts
+ * ANY 2xx/304 response, so a stale dev/preview server squatting the test port
+ * is silently accepted and specs run against the wrong database. This guard runs
+ * AFTER the server is ready and BEFORE Cypress: it asks `/api/health` which
+ * database the live server is talking to and refuses to continue unless it is
+ * the test DB. The non-secret `databaseEnv` field is exposed by the health route
+ * outside production only. See BACKLOG "e2e port-reuse guard".
+ */
+
+const EXPECTED_DATABASE_ENV = "test";
+const HEALTH_PATH = "/api/health";
+
+async function main(): Promise<void> {
+	const baseUrl = process.argv[2];
+	if (!baseUrl) {
+		throw new Error("Usage: tsx devtools/cli/e2e-preflight.cli.ts <baseUrl>");
+	}
+
+	const healthUrl = new URL(HEALTH_PATH, baseUrl).toString();
+
+	const response = await fetch(healthUrl).catch((cause: unknown) => {
+		throw new Error(`Could not reach ${healthUrl}.`, { cause });
+	});
+
+	if (!response.ok) {
+		throw new Error(`${healthUrl} returned HTTP ${response.status}.`);
+	}
+
+	const body = (await response.json()) as {
+		databaseEnv?: string;
+		databaseName?: string;
+	};
+
+	if (body.databaseEnv !== EXPECTED_DATABASE_ENV) {
+		throw new Error(
+			`Refusing to run e2e against ${baseUrl}: server reports databaseEnv=` +
+				`${body.databaseEnv ?? "(absent)"}, expected "${EXPECTED_DATABASE_ENV}". ` +
+				"A non-test server is occupying the port — stop it and retry.",
+		);
+	}
+
+	console.log(
+		`[e2e-preflight] OK — ${baseUrl} is the test server (databaseEnv=test, db=${body.databaseName ?? "?"}).`,
+	);
+}
+
+void main().catch((error: unknown) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"cy:e2e:run": "pnpm cy:clean && pnpm env:test:pnpm cypress run --e2e",
 		"cy:open": "pnpm cy:e2e:open",
 		"cy:open:with-server": "pnpm cy:clean && pnpm env:test:pnpm tsx --tsconfig tsconfig.json devtools/cli/cypress-with-server.cli.ts open",
+		"cy:preflight": "pnpm tsx --tsconfig tsconfig.json devtools/cli/e2e-preflight.cli.ts",
 		"cy:run": "pnpm cy:e2e:run",
 		"cy:server": "pnpm next:dev:test",
 		"db:generate:dev": "pnpm env:dev drizzle-kit generate",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,6 +1,32 @@
 import { sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { getAppDb } from "@/server/db/db.connection";
+import { DATABASE_URL } from "@/shared/core/config/server/env-server";
+import { getDatabaseEnv, isProd } from "@/shared/core/config/shared/env-shared";
+
+/**
+ * Non-secret database identity, surfaced only outside production.
+ *
+ * The e2e harness uses this to confirm a server is pointed at the test database
+ * before running destructive specs — closing the "right port, wrong server" gap
+ * where start-server-and-test accepts any 2xx response without checking which
+ * DB is behind it. Never includes credentials, and is omitted entirely on the
+ * public production endpoint. See the e2e port-reuse guard in BACKLOG.md.
+ */
+function nonProdDbIdentity():
+	| { databaseEnv: string; databaseName: string }
+	| Record<string, never> {
+	try {
+		if (isProd()) {
+			return {};
+		}
+		const databaseName =
+			new URL(DATABASE_URL).pathname.split("/").filter(Boolean).at(-1) ?? "";
+		return { databaseEnv: getDatabaseEnv(), databaseName };
+	} catch {
+		return {};
+	}
+}
 
 /**
  * Liveness/readiness probe.
@@ -14,15 +40,16 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(): Promise<NextResponse> {
+	const timestamp = new Date().toISOString();
 	try {
 		await getAppDb().execute(sql`select 1`);
 		return NextResponse.json(
-			{ db: "up", status: "ok", timestamp: new Date().toISOString() },
+			{ db: "up", status: "ok", timestamp, ...nonProdDbIdentity() },
 			{ status: 200 },
 		);
 	} catch {
 		return NextResponse.json(
-			{ db: "down", status: "error", timestamp: new Date().toISOString() },
+			{ db: "down", status: "error", timestamp },
 			{ status: 503 },
 		);
 	}


### PR DESCRIPTION
## Summary

Closes the **e2e port-reuse guard** backlog item — the trap that let `cy:e2e` silently run against the wrong server (the 2026-06-11 incident: 7 specs "failed" with `/api/db/reset` 404s because the suite hit a dev preview, not the test server).

Re-auditing the script graph against the installed `dotenv-cli@11` / `start-server-and-test@3.0.9` source showed it was **two distinct bugs** (the old backlog wording bundled them and mis-described the mechanism), fixed separately:

**Bug A — wrong port _number_.** The `env:test*` scripts load dotenv without `--override`, so an exported shell `PORT` silently shadows `.env.test.local`'s `PORT`. The harness now **owns the port**: `cypress-with-server.cli.ts` reads `PORT` straight from `.env.test.local` via `dotenv.parse`, warns if an exported `PORT` differs, and pins it in the spawned child env so the server bind, the `wait-on` probe, and Cypress's `baseUrl` can't diverge. The shared `env:*` wrappers are left untouched on purpose — a blanket `-o` is a global precedence change consumed by 37 scripts (incl. destructive `db:*:prod` and the CI entrypoints).

**Bug B — wrong server on the _right_ port.** Correcting the old wording: `start-server-and-test` has **no "reuse" feature** — it always starts its own server. The real cause is that `wait-on` accepts any 2xx/304 with **no identity check**, while `next dev` (no `-p`) steps aside when the port is busy, so a squatter answering the port is used. A new `cy:preflight` step (`devtools/cli/e2e-preflight.cli.ts`, wired into the harness test command) asks `/api/health` which DB the live server is on and **aborts before any spec runs** unless `databaseEnv === "test"`. `/api/health` now returns a non-secret `{ databaseEnv, databaseName }` outside production (omitted on the public prod endpoint), reusing the same derivation as the `smoke/db-env-guard` spec.

### Changed files
- `devtools/cli/cypress-with-server.cli.ts` — read + pin the test port; wire in the preflight (Bug A).
- `devtools/cli/e2e-preflight.cli.ts` _(new)_ — `/api/health` identity guard (Bug B).
- `src/app/api/health/route.ts` — expose non-secret `databaseEnv`/`databaseName` outside production (non-throwing).
- `package.json` — add the `cy:preflight` script.
- `BACKLOG.md` — move the item to Done, split into Bug A/Bug B, correct the "reuses any server" wording.

## Type of change

- [x] Fix

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen) — green (Biome 602 files, markdown 0 errors)
- [ ] `pnpm test` (unit) — not run (no unit-level surface changed)
- [ ] `pnpm cy:e2e` (end-to-end) — not run as a full suite; positive path is the same code as the verified negative path
- [x] Manually verified in the running app:
  - `/api/health` live (pinned dev preview, :3001) → `200` with `databaseEnv: "development", databaseName: "dev_db"`
  - preflight vs the dev server → **refused**, exit 1: _"server reports databaseEnv=development, expected \"test\"…"_
  - preflight vs an unreachable port → clean error, no hang

> Reviewer note: the public production `/api/health` payload is unchanged (identity fields are gated out when `isProd()`); `databaseEnv`/`databaseName` are non-secret (same data the existing `db-env-guard` spec already treats as non-secret). Follow-up (out of scope): `smoke/db-env-guard.cy.ts` could later consolidate onto this HTTP endpoint.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (BACKLOG updated)
- [x] Focused change — preserves existing patterns and user-authored work
