### PR TITLE
test(invoices,customers): domain breadth + pin unit lane to UTC

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -14,11 +14,18 @@ this file is the deliberate workaround.)
       pnpm/node/override gap; Renovate would still automate grouped updates.)_
 - [ ] **docs/ consolidation** — reconcile `docs/standards/` overlap with the existing
       `project-structure.md`, `when-to-use-app-error.md`, and `ui-refactor-strategy.md`.
-- [ ] **Vitest Phase 3** — remaining breadth (`server`, invoices/customers domain) and
-      consider coverage thresholds once breadth lands. Forms breadth DONE (2026-06-11):
-      68 characterization tests across all 11 testable forms files, pinning the three
-      known quirks (key coupling, sensitive echo, payload-mapper overlap) ahead of the
-      boundary redesign. _Lock behavior first, refactor behind the tests._
+- [ ] **Vitest Phase 3** — remaining breadth and coverage thresholds once breadth
+      lands. _Lock behavior first, refactor behind the tests._ Forms breadth DONE
+      (2026-06-11): 68 characterization tests across all 11 testable forms files,
+      pinning the three known quirks (key coupling, sensitive echo, payload-mapper
+      overlap). **Invoices/customers domain breadth DONE (2026-06-14):** 45
+      characterization tests across 9 new files covering both domains' pure logic —
+      invoice date-utils/codecs/status-validator/id-mappers + the two infra
+      mappers/codecs, and customer id-mappers/table-row mapper + the infra mapper
+      (incl. the null-SUM→0 normalization). Also pinned the unit lane to `TZ=UTC`
+      (`vitest.config.ts`) so the invoice date helpers — which mix UTC and local-time
+      ops — are deterministic across machines (unit lane 222 → 267 tests). Remaining:
+      **`server` breadth** (cookie factory, hashing value/service) + coverage thresholds.
 - [ ] **Forms taxonomy flattening** — the last open piece of the forms/error cleanup
       (the rest of the shrink → lock → decide → reshape roadmap completed 2026-06-13; see
       Done). Unscheduled. Core layering is sound, so don't migrate internals to DTOs.

--- a/src/modules/customers/__tests__/unit/domain/customer-id.mappers.test.ts
+++ b/src/modules/customers/__tests__/unit/domain/customer-id.mappers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { createCustomerId } from "@/modules/customers/domain/customer-id.factory";
+import { toCustomerId } from "@/modules/customers/domain/customer-id.mappers";
+import { isAppError } from "@/shared/core/errors/core/app-error.entity";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+
+const VALID_UUID = "66666666-6666-4666-8666-666666666666";
+
+/**
+ * Characterization tests for CustomerId creation.
+ *
+ * - `createCustomerId` is the Result-returning factory.
+ * - `toCustomerId` is the throwing adapter used at boundaries.
+ */
+describe("CustomerId mappers", () => {
+	describe("createCustomerId (Result)", () => {
+		it("returns Ok with the branded id for a valid UUID", () => {
+			const result = createCustomerId(VALID_UUID);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(String(result.value)).toBe(VALID_UUID);
+			}
+		});
+
+		it("returns Err with a validation AppError for a non-UUID string", () => {
+			const result = createCustomerId("not-a-uuid");
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(isAppError(result.error)).toBe(true);
+				expect(result.error.key).toBe(APP_ERROR_KEYS.validation);
+			}
+		});
+
+		it("returns Err for an empty string", () => {
+			expect(createCustomerId("").ok).toBe(false);
+		});
+	});
+
+	describe("toCustomerId (throwing)", () => {
+		it("returns the branded id string for a valid UUID", () => {
+			expect(String(toCustomerId(VALID_UUID))).toBe(VALID_UUID);
+		});
+
+		it("throws an AppError for an invalid UUID", () => {
+			try {
+				toCustomerId("nope");
+				expect.unreachable("toCustomerId should have thrown");
+			} catch (error) {
+				expect(isAppError(error)).toBe(true);
+			}
+		});
+	});
+});

--- a/src/modules/customers/__tests__/unit/domain/mappers.test.ts
+++ b/src/modules/customers/__tests__/unit/domain/mappers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { toCustomerId } from "@/modules/customers/domain/customer-id.mappers";
+import { toFormattedCustomersTableRow } from "@/modules/customers/domain/mappers";
+import type { CustomerAggregatesServerDto } from "@/modules/customers/domain/types";
+
+const CUSTOMER_UUID = "77777777-7777-4777-8777-777777777777";
+
+function makeAggregate(
+	overrides: Partial<CustomerAggregatesServerDto> = {},
+): CustomerAggregatesServerDto {
+	return {
+		email: "ada@example.com",
+		id: toCustomerId(CUSTOMER_UUID),
+		imageUrl: "/ada.png",
+		name: "Ada Lovelace",
+		totalInvoices: 3,
+		totalPaid: 2500,
+		totalPending: 199,
+		...overrides,
+	};
+}
+
+describe("toFormattedCustomersTableRow", () => {
+	it("formats cent totals as USD currency strings and passes other fields through", () => {
+		const row = toFormattedCustomersTableRow(makeAggregate());
+
+		expect(row).toEqual({
+			email: "ada@example.com",
+			id: toCustomerId(CUSTOMER_UUID),
+			imageUrl: "/ada.png",
+			name: "Ada Lovelace",
+			totalInvoices: 3,
+			totalPaid: "$25.00",
+			totalPending: "$1.99",
+		});
+	});
+
+	it("formats zero totals as $0.00", () => {
+		const row = toFormattedCustomersTableRow(
+			makeAggregate({ totalPaid: 0, totalPending: 0 }),
+		);
+
+		expect(row.totalPaid).toBe("$0.00");
+		expect(row.totalPending).toBe("$0.00");
+	});
+});

--- a/src/modules/customers/__tests__/unit/infrastructure/adapters/customer.mapper.test.ts
+++ b/src/modules/customers/__tests__/unit/infrastructure/adapters/customer.mapper.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type {
+	CustomerAggregatesRowRaw,
+	CustomerSelectRowRaw,
+} from "@/modules/customers/domain/types";
+import {
+	mapCustomerAggregatesRawToDto,
+	mapCustomerSelectRawToDto,
+} from "@/modules/customers/infrastructure/adapters/customer.mapper";
+
+const CUSTOMER_UUID = "88888888-8888-4888-8888-888888888888";
+
+describe("customer.mapper", () => {
+	describe("mapCustomerSelectRawToDto", () => {
+		it("brands the id and keeps the name", () => {
+			const raw: CustomerSelectRowRaw = { id: CUSTOMER_UUID, name: "Acme" };
+
+			const dto = mapCustomerSelectRawToDto(raw);
+
+			expect(String(dto.id)).toBe(CUSTOMER_UUID);
+			expect(dto.name).toBe("Acme");
+		});
+	});
+
+	describe("mapCustomerAggregatesRawToDto", () => {
+		const base: CustomerAggregatesRowRaw = {
+			email: "acme@example.com",
+			id: CUSTOMER_UUID,
+			imageUrl: "/acme.png",
+			name: "Acme",
+			totalInvoices: 4,
+			totalPaid: 5000,
+			totalPending: 1000,
+		};
+
+		it("maps a fully populated row, branding the id", () => {
+			const dto = mapCustomerAggregatesRawToDto(base);
+
+			expect(dto).toEqual({
+				email: "acme@example.com",
+				id: dto.id,
+				imageUrl: "/acme.png",
+				name: "Acme",
+				totalInvoices: 4,
+				totalPaid: 5000,
+				totalPending: 1000,
+			});
+			expect(String(dto.id)).toBe(CUSTOMER_UUID);
+		});
+
+		it("normalizes null SUM totals to 0", () => {
+			const dto = mapCustomerAggregatesRawToDto({
+				...base,
+				totalPaid: null,
+				totalPending: null,
+			});
+
+			expect(dto.totalPaid).toBe(0);
+			expect(dto.totalPending).toBe(0);
+		});
+	});
+});

--- a/src/modules/invoices/__tests__/unit/domain/invoice-id.mappers.test.ts
+++ b/src/modules/invoices/__tests__/unit/domain/invoice-id.mappers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { createInvoiceId } from "@/modules/invoices/domain/invoice-id.factory";
+import { toInvoiceId } from "@/modules/invoices/domain/invoice-id.mappers";
+import { isAppError } from "@/shared/core/errors/core/app-error.entity";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+
+const VALID_UUID = "11111111-1111-4111-8111-111111111111";
+
+/**
+ * Characterization tests for InvoiceId creation.
+ *
+ * - `createInvoiceId` is the Result-returning factory (validates a UUID).
+ * - `toInvoiceId` is the throwing adapter used at boundaries.
+ */
+describe("InvoiceId mappers", () => {
+	describe("createInvoiceId (Result)", () => {
+		it("returns Ok with the branded id for a valid UUID", () => {
+			const result = createInvoiceId(VALID_UUID);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(String(result.value)).toBe(VALID_UUID);
+			}
+		});
+
+		it("returns Err with a validation AppError for a non-UUID string", () => {
+			const result = createInvoiceId("not-a-uuid");
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(isAppError(result.error)).toBe(true);
+				expect(result.error.key).toBe(APP_ERROR_KEYS.validation);
+			}
+		});
+
+		it("returns Err for a non-string input", () => {
+			expect(createInvoiceId(42).ok).toBe(false);
+		});
+	});
+
+	describe("toInvoiceId (throwing)", () => {
+		it("returns the branded id string for a valid UUID", () => {
+			expect(String(toInvoiceId(VALID_UUID))).toBe(VALID_UUID);
+		});
+
+		it("throws an AppError for an invalid UUID", () => {
+			try {
+				toInvoiceId("nope");
+				expect.unreachable("toInvoiceId should have thrown");
+			} catch (error) {
+				expect(isAppError(error)).toBe(true);
+			}
+		});
+	});
+});

--- a/src/modules/invoices/__tests__/unit/domain/invoice-status.validator.test.ts
+++ b/src/modules/invoices/__tests__/unit/domain/invoice-status.validator.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { validateInvoiceStatus } from "@/modules/invoices/domain/invoice-status.validator";
+import { isAppError } from "@/shared/core/errors/core/app-error.entity";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+
+/**
+ * Characterization tests for the invoice-status enum validator.
+ * Allowed values are exactly "pending" and "paid".
+ */
+describe("validateInvoiceStatus", () => {
+	it.each([
+		"pending",
+		"paid",
+	] as const)("accepts the valid status %j", (status) => {
+		const result = validateInvoiceStatus(status);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value).toBe(status);
+		}
+	});
+
+	it("rejects an unknown status string with a validation AppError", () => {
+		const result = validateInvoiceStatus("cancelled");
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(isAppError(result.error)).toBe(true);
+			expect(result.error.key).toBe(APP_ERROR_KEYS.validation);
+			expect(result.error.message).toContain("cancelled");
+		}
+	});
+
+	it("is case-sensitive (rejects 'Paid')", () => {
+		expect(validateInvoiceStatus("Paid").ok).toBe(false);
+	});
+
+	it.each([
+		["a number", 1],
+		["null", null],
+		["undefined", undefined],
+		["an object", {}],
+	])("rejects non-string input: %s", (_label, input) => {
+		const result = validateInvoiceStatus(input);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.key).toBe(APP_ERROR_KEYS.validation);
+			expect(result.error.message).toContain("expected string");
+		}
+	});
+});

--- a/src/modules/invoices/__tests__/unit/domain/invoice.codecs.test.ts
+++ b/src/modules/invoices/__tests__/unit/domain/invoice.codecs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+	encodeInvoiceDateToIso,
+	encodePeriodToFirstDay,
+} from "@/modules/invoices/domain/invoice.codecs";
+import { toPeriod } from "@/shared/primitives/period/period.mappers";
+
+/**
+ * Characterization tests for the invoice transport codecs.
+ *
+ * The unit lane runs in UTC (see `vitest.config.ts`); `encodePeriodToFirstDay`
+ * uses date-fns `format`, which reads the local timezone, so UTC keeps the
+ * "first day of month" output stable.
+ */
+describe("invoice.codecs", () => {
+	describe("encodeInvoiceDateToIso", () => {
+		it("encodes a Date to a YYYY-MM-DD string (UTC calendar day)", () => {
+			expect(encodeInvoiceDateToIso(new Date("2025-08-12T00:00:00Z"))).toBe(
+				"2025-08-12",
+			);
+		});
+
+		it("drops the time component", () => {
+			expect(encodeInvoiceDateToIso(new Date("2025-08-12T23:59:59Z"))).toBe(
+				"2025-08-12",
+			);
+		});
+	});
+
+	describe("encodePeriodToFirstDay", () => {
+		it("encodes a Period to a YYYY-MM-01 first-of-month string", () => {
+			const period = toPeriod("2025-08-01");
+
+			expect(encodePeriodToFirstDay(period)).toBe("2025-08-01");
+		});
+
+		it("normalizes any day in the month to the first (via Period)", () => {
+			// toPeriod accepts a Date and snaps it to the first of the month.
+			const period = toPeriod(new Date("2025-08-23T00:00:00Z"));
+
+			expect(encodePeriodToFirstDay(period)).toBe("2025-08-01");
+		});
+	});
+});

--- a/src/modules/invoices/__tests__/unit/domain/invoice.date-utils.test.ts
+++ b/src/modules/invoices/__tests__/unit/domain/invoice.date-utils.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	formatInvoiceDateLocalized,
+	getCurrentIsoDate,
+} from "@/modules/invoices/domain/invoice.date-utils";
+
+/**
+ * Characterization tests for the invoice date helpers.
+ *
+ * The unit lane runs in UTC (see `vitest.config.ts`), so the values below are
+ * deterministic regardless of the developer's machine timezone.
+ */
+describe("invoice.date-utils", () => {
+	describe("getCurrentIsoDate", () => {
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("returns the current date as a YYYY-MM-DD string", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2025-08-12T15:30:00Z"));
+
+			expect(getCurrentIsoDate()).toBe("2025-08-12");
+		});
+
+		it("uses the UTC calendar day, not local time", () => {
+			vi.useFakeTimers();
+			// Late-UTC instant: still the same UTC day.
+			vi.setSystemTime(new Date("2025-12-31T23:59:59Z"));
+
+			expect(getCurrentIsoDate()).toBe("2025-12-31");
+		});
+
+		it("always matches the YYYY-MM-DD shape", () => {
+			expect(getCurrentIsoDate()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		});
+	});
+
+	describe("formatInvoiceDateLocalized", () => {
+		it("formats a YYYY-MM-DD date in the default en-US locale", () => {
+			expect(formatInvoiceDateLocalized("2025-08-12")).toBe("Aug 12, 2025");
+		});
+
+		it("honors a non-default locale", () => {
+			expect(formatInvoiceDateLocalized("2025-08-12", "de-DE")).toBe(
+				"12. Aug. 2025",
+			);
+		});
+
+		it("formats single-digit days without zero padding (en-US)", () => {
+			expect(formatInvoiceDateLocalized("2025-01-05")).toBe("Jan 5, 2025");
+		});
+	});
+});

--- a/src/modules/invoices/__tests__/unit/infrastructure/adapters/invoice-codecs.test.ts
+++ b/src/modules/invoices/__tests__/unit/infrastructure/adapters/invoice-codecs.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { toCustomerId } from "@/modules/customers/domain/customer-id.mappers";
+import type { InvoiceFormDto } from "@/modules/invoices/application/dto/invoice.dto";
+import type { InvoiceEntity } from "@/modules/invoices/domain/entities/invoice.entity";
+import { toInvoiceId } from "@/modules/invoices/domain/invoice-id.mappers";
+import {
+	dtoToCreateInvoiceEntity,
+	entityToInvoiceDto,
+	partialDtoToCreateInvoiceEntity,
+} from "@/modules/invoices/infrastructure/adapters/codecs/invoice-codecs";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+import { toPeriod } from "@/shared/primitives/period/period.mappers";
+
+const CUSTOMER_UUID = "44444444-4444-4444-8444-444444444444";
+const INVOICE_UUID = "55555555-5555-4555-8555-555555555555";
+
+function makeEntity(): InvoiceEntity {
+	return {
+		amount: 12_345,
+		customerId: toCustomerId(CUSTOMER_UUID),
+		date: new Date("2025-08-12T00:00:00Z"),
+		id: toInvoiceId(INVOICE_UUID),
+		revenuePeriod: toPeriod("2025-08-01"),
+		sensitiveData: "secret",
+		status: "paid",
+	};
+}
+
+function makeFormDto(overrides: Partial<InvoiceFormDto> = {}): InvoiceFormDto {
+	return {
+		amount: 999,
+		customerId: CUSTOMER_UUID,
+		date: "2025-08-12",
+		sensitiveData: "secret",
+		status: "pending",
+		...overrides,
+	};
+}
+
+describe("invoice-codecs", () => {
+	describe("entityToInvoiceDto", () => {
+		it("strips branding into a plain, transport-ready DTO", () => {
+			const dto = entityToInvoiceDto(makeEntity());
+
+			expect(dto).toEqual({
+				amount: 12_345,
+				customerId: CUSTOMER_UUID,
+				date: "2025-08-12",
+				id: INVOICE_UUID,
+				revenuePeriod: "2025-08-01",
+				sensitiveData: "secret",
+				status: "paid",
+			});
+		});
+
+		it("produces only plain serializable values (round-trips through JSON)", () => {
+			const dto = entityToInvoiceDto(makeEntity());
+
+			expect(JSON.parse(JSON.stringify(dto))).toEqual(dto);
+		});
+	});
+
+	describe("dtoToCreateInvoiceEntity", () => {
+		it("brands a valid form DTO into a form entity", () => {
+			const result = dtoToCreateInvoiceEntity(makeFormDto());
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value.amount).toBe(999);
+				expect(result.value.status).toBe("pending");
+				expect(String(result.value.customerId)).toBe(CUSTOMER_UUID);
+				expect(result.value.date).toEqual(new Date("2025-08-12"));
+				// revenuePeriod is derived later, not on the form entity.
+				expect(result.value).not.toHaveProperty("revenuePeriod");
+			}
+		});
+
+		it("returns Err for an invalid status", () => {
+			const result = dtoToCreateInvoiceEntity(
+				makeFormDto({ status: "cancelled" as InvoiceFormDto["status"] }),
+			);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.key).toBe(APP_ERROR_KEYS.validation);
+			}
+		});
+	});
+
+	describe("partialDtoToCreateInvoiceEntity", () => {
+		it("maps only the provided fields", () => {
+			const result = partialDtoToCreateInvoiceEntity({ amount: 500 });
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toEqual({ amount: 500 });
+			}
+		});
+
+		it("validates status when present and brands customerId", () => {
+			const result = partialDtoToCreateInvoiceEntity({
+				customerId: CUSTOMER_UUID,
+				status: "paid",
+			});
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value.status).toBe("paid");
+				expect(String(result.value.customerId)).toBe(CUSTOMER_UUID);
+			}
+		});
+
+		it("returns an empty object when given no fields", () => {
+			const result = partialDtoToCreateInvoiceEntity({});
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toEqual({});
+			}
+		});
+
+		it("returns Err when the provided status is invalid", () => {
+			const result = partialDtoToCreateInvoiceEntity({
+				status: "cancelled" as InvoiceFormDto["status"],
+			});
+
+			expect(result.ok).toBe(false);
+		});
+	});
+});

--- a/src/modules/invoices/__tests__/unit/infrastructure/adapters/invoice.mapper.test.ts
+++ b/src/modules/invoices/__tests__/unit/infrastructure/adapters/invoice.mapper.test.ts
@@ -1,0 +1,97 @@
+import type { InvoiceRow } from "@database/schema/invoices";
+import { describe, expect, it } from "vitest";
+import { toCustomerId } from "@/modules/customers/domain/customer-id.mappers";
+import type { InvoiceFormEntity } from "@/modules/invoices/domain/entities/invoice.entity";
+import { encodePeriodToFirstDay } from "@/modules/invoices/domain/invoice.codecs";
+import {
+	invoiceFormEntityToServiceEntity,
+	rawDbToInvoiceEntity,
+} from "@/modules/invoices/infrastructure/adapters/mappers/invoice.mapper";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+
+const CUSTOMER_UUID = "22222222-2222-4222-8222-222222222222";
+const INVOICE_UUID = "33333333-3333-4333-8333-333333333333";
+
+function makeRow(overrides: Partial<InvoiceRow> = {}): InvoiceRow {
+	return {
+		amount: 2500,
+		customerId: CUSTOMER_UUID,
+		date: new Date("2025-08-12T00:00:00Z"),
+		id: INVOICE_UUID,
+		revenuePeriod: new Date("2025-08-01T00:00:00Z"),
+		sensitiveData: "cantTouchThis",
+		status: "paid",
+		...overrides,
+	} as InvoiceRow;
+}
+
+describe("invoice.mapper", () => {
+	describe("rawDbToInvoiceEntity", () => {
+		it("maps a valid row to a branded entity", () => {
+			const result = rawDbToInvoiceEntity(makeRow());
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				const entity = result.value;
+				expect(entity.amount).toBe(2500);
+				expect(entity.status).toBe("paid");
+				expect(entity.sensitiveData).toBe("cantTouchThis");
+				expect(entity.date).toEqual(new Date("2025-08-12T00:00:00Z"));
+				expect(String(entity.id)).toBe(INVOICE_UUID);
+				expect(String(entity.customerId)).toBe(CUSTOMER_UUID);
+				expect(encodePeriodToFirstDay(entity.revenuePeriod)).toBe("2025-08-01");
+			}
+		});
+
+		it("returns Err when the row status is not a valid enum value", () => {
+			const result = rawDbToInvoiceEntity(
+				makeRow({ status: "cancelled" as InvoiceRow["status"] }),
+			);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.key).toBe(APP_ERROR_KEYS.validation);
+			}
+		});
+	});
+
+	describe("invoiceFormEntityToServiceEntity", () => {
+		function makeFormEntity(
+			overrides: Partial<InvoiceFormEntity> = {},
+		): InvoiceFormEntity {
+			return {
+				amount: 999,
+				customerId: toCustomerId(CUSTOMER_UUID),
+				date: new Date("2025-08-23T00:00:00Z"),
+				sensitiveData: "secret",
+				status: "pending",
+				...overrides,
+			};
+		}
+
+		it("derives revenuePeriod as the first day of the entity's month", () => {
+			const result = invoiceFormEntityToServiceEntity(makeFormEntity());
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(encodePeriodToFirstDay(result.value.revenuePeriod)).toBe(
+					"2025-08-01",
+				);
+				// Carries the rest of the form entity through unchanged.
+				expect(result.value.amount).toBe(999);
+				expect(result.value.status).toBe("pending");
+			}
+		});
+
+		it("returns Err for an invalid date", () => {
+			const result = invoiceFormEntityToServiceEntity(
+				makeFormEntity({ date: new Date("not-a-date") }),
+			);
+
+			expect(result.ok).toBe(false);
+			if (!result.ok) {
+				expect(result.error.key).toBe(APP_ERROR_KEYS.validation);
+			}
+		});
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,15 @@ const unitEnv = {
 	SESSION_AUDIENCE: "web",
 	SESSION_ISSUER: "my-app",
 	SESSION_SECRET: "unit-test-session-secret-not-a-real-secret",
+	/**
+	 * Pin the unit lane to UTC so date logic is deterministic everywhere.
+	 * Several invoice helpers mix UTC and local-time operations (`toISOString`
+	 * vs date-fns `format` vs the `new Date(y, m, d)` local constructor), so a
+	 * runner in a negative-offset zone (e.g. US Central) would format the same
+	 * instant as the previous day and the tests would pass in CI but fail
+	 * locally. UTC removes that machine dependence.
+	 */
+	TZ: "UTC",
 } as const;
 
 export default defineConfig({


### PR DESCRIPTION
## What

Vitest Phase 3 breadth for the **invoices** and **customers** domains — **45 characterization tests across 9 new files**, locking current behavior before any future refactor. The customers domain previously had **zero** tests.

**Invoices** (pure domain + infra adapters)
- `invoice.date-utils`, `invoice.codecs`, `invoice-status.validator`, `invoice-id.mappers`
- infra `invoice.mapper` (`rawDbToInvoiceEntity` / `invoiceFormEntityToServiceEntity`)
- infra `invoice-codecs` (entity↔DTO + partial mapping)

**Customers** (domain + infra adapter)
- `customer-id.mappers`, domain `mappers` (`toFormattedCustomersTableRow`)
- infra `customer.mapper`, including the **null-SUM → 0** normalization

## Notable: unit lane pinned to UTC

`vitest.config.ts` now sets `TZ: "UTC"` for the unit lane. The invoice date helpers mix UTC (`toISOString`) and local-time ops (date-fns `format`, the `new Date(y, m, d)` local constructor), so a runner in a negative-offset zone (e.g. US Central) would format the same instant as the *previous day* — tests would pass in CI (UTC) but fail locally. UTC removes that machine dependence. (`server-only` modules are testable because `vitest.setup.ts` mocks `server-only`.)

## Why

"Lock behavior first, refactor behind the tests" — the same characterization approach used for the forms breadth. These pin real quirks (money-cents formatting, first-of-month period derivation, enum validation, null-aggregate normalization) so a later boundary cleanup can't silently change them.

## Verification

- ✅ Unit lane **222 → 267** tests, all passing.
- ✅ `check:fast` green (Biome, typecheck, typegen, migration-drift gate), `md:check` clean.

Follow-up on the Vitest backlog item: `server` breadth (cookie factory, hashing value/service) + coverage thresholds.
