### PR TITLE
test(server): breadth for cookie + hashing ports

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,8 +24,15 @@ this file is the deliberate workaround.)
       mappers/codecs, and customer id-mappers/table-row mapper + the infra mapper
       (incl. the null-SUM→0 normalization). Also pinned the unit lane to `TZ=UTC`
       (`vitest.config.ts`) so the invoice date helpers — which mix UTC and local-time
-      ops — are deterministic across machines (unit lane 222 → 267 tests). Remaining:
-      **`server` breadth** (cookie factory, hashing value/service) + coverage thresholds.
+      ops — are deterministic across machines (unit lane 222 → 267 tests). **`server`
+      breadth DONE (2026-06-14):** 19 tests across 5 files for the `src/server` ports
+      — `HashingService`/`CookieService` delegation, their factories, the real
+      `BcryptHashingAdapter` (hash↔compare round-trip + infrastructure-AppError
+      wrapping), the `NextJsCookieAdapter` (forwards to mocked `next/headers`), and
+      `toHash` (lane 267 → 286). Deliberately skipped `crypto.service.ts` — it's
+      genuinely unused (confirms the knip dead-file flag; don't lock dead code).
+      Remaining: **coverage thresholds** (capture a baseline, then wire minimums so
+      coverage can't regress).
 - [ ] **Forms taxonomy flattening** — the last open piece of the forms/error cleanup
       (the rest of the shrink → lock → decide → reshape roadmap completed 2026-06-13; see
       Done). Unscheduled. Core layering is sound, so don't migrate internals to DTOs.

--- a/src/server/__tests__/unit/cookies/cookie.service.test.ts
+++ b/src/server/__tests__/unit/cookies/cookie.service.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CookieContract } from "@/server/cookies/cookie.contract";
+import { createCookieService } from "@/server/cookies/cookie.factory";
+import { CookieService } from "@/server/cookies/cookie.service";
+
+function makeAdapterMock(): CookieContract {
+	return {
+		delete: vi.fn(),
+		get: vi.fn(),
+		set: vi.fn(),
+	};
+}
+
+describe("CookieService", () => {
+	it("delegates get() to the adapter and returns its value", async () => {
+		const adapter = makeAdapterMock();
+		vi.mocked(adapter.get).mockResolvedValue("session-token");
+		const service = new CookieService(adapter);
+
+		const value = await service.get("session");
+
+		expect(adapter.get).toHaveBeenCalledWith("session");
+		expect(value).toBe("session-token");
+	});
+
+	it("forwards set() with the provided options", async () => {
+		const adapter = makeAdapterMock();
+		const service = new CookieService(adapter);
+		const options = { httpOnly: true, path: "/" };
+
+		await service.set("session", "abc", options);
+
+		expect(adapter.set).toHaveBeenCalledWith("session", "abc", options);
+	});
+
+	it("defaults set() options to an empty object when omitted", async () => {
+		const adapter = makeAdapterMock();
+		const service = new CookieService(adapter);
+
+		await service.set("session", "abc");
+
+		expect(adapter.set).toHaveBeenCalledWith("session", "abc", {});
+	});
+
+	it("delegates delete() to the adapter", async () => {
+		const adapter = makeAdapterMock();
+		const service = new CookieService(adapter);
+
+		await service.delete("session");
+
+		expect(adapter.delete).toHaveBeenCalledWith("session");
+	});
+});
+
+describe("createCookieService", () => {
+	it("returns a CookieService instance", () => {
+		expect(createCookieService()).toBeInstanceOf(CookieService);
+	});
+});

--- a/src/server/__tests__/unit/cookies/next-js-cookie.adapter.test.ts
+++ b/src/server/__tests__/unit/cookies/next-js-cookie.adapter.test.ts
@@ -1,0 +1,48 @@
+import { cookies } from "next/headers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextJsCookieAdapter } from "@/server/cookies/next-js-cookie.adapter";
+
+/**
+ * `next/headers` is mocked globally in `vitest.setup.ts`; `cookies()` resolves
+ * to a shared store of vi.fn()s. These tests assert the adapter awaits that
+ * store and forwards each operation correctly.
+ */
+describe("NextJsCookieAdapter", () => {
+	const adapter = new NextJsCookieAdapter();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns the cookie value when present", async () => {
+		const store = await cookies();
+		vi.mocked(store.get).mockReturnValue({ name: "session", value: "tok" });
+
+		expect(await adapter.get("session")).toBe("tok");
+		expect(store.get).toHaveBeenCalledWith("session");
+	});
+
+	it("returns undefined when the cookie is absent", async () => {
+		const store = await cookies();
+		vi.mocked(store.get).mockReturnValue(undefined);
+
+		expect(await adapter.get("missing")).toBeUndefined();
+	});
+
+	it("forwards set() with name, value, and options to the store", async () => {
+		const store = await cookies();
+		const options = { httpOnly: true };
+
+		await adapter.set("session", "tok", options);
+
+		expect(store.set).toHaveBeenCalledWith("session", "tok", options);
+	});
+
+	it("forwards delete() to the store", async () => {
+		const store = await cookies();
+
+		await adapter.delete("session");
+
+		expect(store.delete).toHaveBeenCalledWith("session");
+	});
+});

--- a/src/server/__tests__/unit/crypto/hashing/bcrypt-hashing.adapter.test.ts
+++ b/src/server/__tests__/unit/crypto/hashing/bcrypt-hashing.adapter.test.ts
@@ -1,0 +1,63 @@
+import bcryptjs from "bcryptjs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BcryptHashingAdapter } from "@/server/crypto/hashing/bcrypt-hashing.adapter";
+import { toHash } from "@/server/crypto/hashing/hashing.value";
+import { isAppError } from "@/shared/core/errors/core/app-error.entity";
+import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.registry";
+
+describe("BcryptHashingAdapter", () => {
+	const adapter = new BcryptHashingAdapter();
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("hash + compare round-trip (real bcrypt)", () => {
+		it("produces a bcrypt hash that is not the raw value", async () => {
+			const hash = await adapter.hash("correct horse");
+
+			expect(String(hash)).not.toBe("correct horse");
+			// bcrypt hashes start with the "$2" version prefix.
+			expect(String(hash).startsWith("$2")).toBe(true);
+		});
+
+		it("compares the matching raw value as true and a wrong value as false", async () => {
+			const hash = await adapter.hash("correct horse");
+
+			expect(await adapter.compare("correct horse", hash)).toBe(true);
+			expect(await adapter.compare("battery staple", hash)).toBe(false);
+		});
+	});
+
+	describe("error wrapping", () => {
+		it("wraps a bcrypt hash failure in an infrastructure AppError", async () => {
+			vi.spyOn(bcryptjs, "hash").mockRejectedValue(new Error("boom"));
+
+			try {
+				await adapter.hash("x");
+				expect.unreachable("hash should have thrown");
+			} catch (error) {
+				expect(isAppError(error)).toBe(true);
+				if (isAppError(error)) {
+					expect(error.key).toBe(APP_ERROR_KEYS.infrastructure);
+					expect(error.message).toBe("Failed to hash value");
+				}
+			}
+		});
+
+		it("wraps a bcrypt compare failure in an infrastructure AppError", async () => {
+			vi.spyOn(bcryptjs, "compare").mockRejectedValue(new Error("boom"));
+
+			try {
+				await adapter.compare("x", toHash("$2b$10$whatever"));
+				expect.unreachable("compare should have thrown");
+			} catch (error) {
+				expect(isAppError(error)).toBe(true);
+				if (isAppError(error)) {
+					expect(error.key).toBe(APP_ERROR_KEYS.infrastructure);
+					expect(error.message).toBe("Failed to compare hash");
+				}
+			}
+		});
+	});
+});

--- a/src/server/__tests__/unit/crypto/hashing/hashing.service.test.ts
+++ b/src/server/__tests__/unit/crypto/hashing/hashing.service.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HashingContract } from "@/server/crypto/hashing/hashing.contract";
+import { createHashingService } from "@/server/crypto/hashing/hashing.factory";
+import { HashingService } from "@/server/crypto/hashing/hashing.service";
+import { toHash } from "@/server/crypto/hashing/hashing.value";
+
+function makeHasherMock(): HashingContract {
+	return {
+		compare: vi.fn(),
+		hash: vi.fn(),
+	};
+}
+
+describe("HashingService", () => {
+	it("delegates hash() to the port and returns its result", async () => {
+		const hasher = makeHasherMock();
+		vi.mocked(hasher.hash).mockResolvedValue(toHash("hashed"));
+		const service = new HashingService(hasher);
+
+		const result = await service.hash("raw-password");
+
+		expect(hasher.hash).toHaveBeenCalledWith("raw-password");
+		expect(String(result)).toBe("hashed");
+	});
+
+	it("delegates compare() to the port and returns its boolean result", async () => {
+		const hasher = makeHasherMock();
+		vi.mocked(hasher.compare).mockResolvedValue(true);
+		const service = new HashingService(hasher);
+		const stored = toHash("hashed");
+
+		const result = await service.compare("raw-password", stored);
+
+		expect(hasher.compare).toHaveBeenCalledWith("raw-password", stored);
+		expect(result).toBe(true);
+	});
+
+	it("propagates a false comparison", async () => {
+		const hasher = makeHasherMock();
+		vi.mocked(hasher.compare).mockResolvedValue(false);
+		const service = new HashingService(hasher);
+
+		expect(await service.compare("wrong", toHash("hashed"))).toBe(false);
+	});
+});
+
+describe("createHashingService", () => {
+	it("wires a HashingService backed by the real bcrypt adapter", async () => {
+		const service = createHashingService();
+
+		expect(service).toBeInstanceOf(HashingService);
+
+		// Smoke-check the wiring end-to-end (real bcrypt): a hash round-trips.
+		const hash = await service.hash("secret");
+		expect(String(hash)).not.toBe("secret");
+		expect(await service.compare("secret", hash)).toBe(true);
+	});
+});

--- a/src/server/__tests__/unit/crypto/hashing/hashing.value.test.ts
+++ b/src/server/__tests__/unit/crypto/hashing/hashing.value.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { toHash } from "@/server/crypto/hashing/hashing.value";
+
+/**
+ * `toHash` is a pure branding pass-through for values already hashed by the
+ * system (or read from the DB). It must not transform the string.
+ */
+describe("toHash", () => {
+	it("returns the same string value, branded", () => {
+		const raw = "$2b$10$abcdefghijklmnopqrstuv";
+
+		expect(String(toHash(raw))).toBe(raw);
+	});
+
+	it("does not alter an empty string", () => {
+		expect(String(toHash(""))).toBe("");
+	});
+});


### PR DESCRIPTION
## What

Vitest Phase 3 **server breadth** — **19 tests across 5 files** locking the behavior of the `src/server` ports before any future refactor.

- **`HashingService` / `CookieService`** — delegation to their port; plus `CookieService`'s default-`{}` options behavior when `set` is called without options.
- **`createHashingService` / `createCookieService`** — factory wiring (correct instance; the hashing factory also gets a real-bcrypt round-trip smoke check).
- **`BcryptHashingAdapter`** — hash↔compare round-trip with **real bcrypt**, and the `infrastructure`-`AppError` wrapping on hash/compare failure (`bcryptjs` spied to throw).
- **`NextJsCookieAdapter`** — forwards `get`/`set`/`delete` to the mocked `next/headers` store.
- **`toHash`** — pure branding pass-through.

## Deliberately skipped

`src/server/crypto/crypto.service.ts` (`CryptoService` / `cryptoClient`) is **genuinely unused** — a grep for its symbols finds only auth's own unrelated crypto services. This confirms the existing knip dead-file flag, so I did **not** add tests for it (locking dead code would be counterproductive; it belongs in the knip-triage backlog item).

## Why

"Lock behavior first, refactor behind the tests" — same characterization approach as the forms and invoices/customers breadth. These pin the delegation contracts, the bcrypt round-trip + error-wrapping, and the cookie default-options behavior.

## Verification

- ✅ Unit lane **267 → 286** tests, all passing.
- ✅ `check:fast` green (Biome, typecheck, typegen, migration-drift gate), `md:check` clean.

Follow-up: this leaves **coverage thresholds** as the last piece of the Vitest item (capture a baseline, then wire minimums so coverage can't regress).
