### PR TITLE
test(coverage): regression thresholds + run unit lane in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
 # Continuous Integration (CI)
 #
 # Runs fast, dependency-free checks on every push to `main` and every pull
-# request that targets `main`. These are the same checks as `pnpm check:fast`
-# (Biome lint + Markdown lint/format + type-check + Next.js typegen), so if that
-# passes on your machine, this should pass here too.
+# request that targets `main`: `pnpm check:fast` (Biome lint + Markdown
+# lint/format + type-check + Next.js typegen) plus the migration-drift gate and
+# the DB-free unit lane with coverage thresholds.
 #
-# Note: tests, the production build, and Cypress e2e are intentionally NOT here.
-# They need a real database + secret env vars and would fail in a plain CI run.
-# See the README / your `pnpm check` script for how to run those locally.
+# Note: the integration tests, the production build, and Cypress e2e are
+# intentionally NOT here. They need a real database + secret env vars and would
+# fail in a plain CI run. The UNIT lane is different — it injects a dummy env and
+# mocks the DB (see `vitest.config.ts`), so it runs anywhere. See the README /
+# your `pnpm check` script for how to run the rest locally.
 
 name: CI
 
@@ -77,3 +79,10 @@ jobs:
       #    2026-06-11. See BACKLOG "Per-env migration drift guard".
       - name: Migration drift
         run: pnpm db:drift
+
+      # 10. Unit tests + coverage. The unit lane is DB-free (dummy env + mocked
+      #     DB), so it runs in plain CI. `test:coverage` also enforces the
+      #     coverage floors in `vitest.config.ts` — a regression below them fails
+      #     the build.
+      - name: Unit tests + coverage
+        run: pnpm test:coverage

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -14,25 +14,6 @@ this file is the deliberate workaround.)
       pnpm/node/override gap; Renovate would still automate grouped updates.)_
 - [ ] **docs/ consolidation** — reconcile `docs/standards/` overlap with the existing
       `project-structure.md`, `when-to-use-app-error.md`, and `ui-refactor-strategy.md`.
-- [ ] **Vitest Phase 3** — remaining breadth and coverage thresholds once breadth
-      lands. _Lock behavior first, refactor behind the tests._ Forms breadth DONE
-      (2026-06-11): 68 characterization tests across all 11 testable forms files,
-      pinning the three known quirks (key coupling, sensitive echo, payload-mapper
-      overlap). **Invoices/customers domain breadth DONE (2026-06-14):** 45
-      characterization tests across 9 new files covering both domains' pure logic —
-      invoice date-utils/codecs/status-validator/id-mappers + the two infra
-      mappers/codecs, and customer id-mappers/table-row mapper + the infra mapper
-      (incl. the null-SUM→0 normalization). Also pinned the unit lane to `TZ=UTC`
-      (`vitest.config.ts`) so the invoice date helpers — which mix UTC and local-time
-      ops — are deterministic across machines (unit lane 222 → 267 tests). **`server`
-      breadth DONE (2026-06-14):** 19 tests across 5 files for the `src/server` ports
-      — `HashingService`/`CookieService` delegation, their factories, the real
-      `BcryptHashingAdapter` (hash↔compare round-trip + infrastructure-AppError
-      wrapping), the `NextJsCookieAdapter` (forwards to mocked `next/headers`), and
-      `toHash` (lane 267 → 286). Deliberately skipped `crypto.service.ts` — it's
-      genuinely unused (confirms the knip dead-file flag; don't lock dead code).
-      Remaining: **coverage thresholds** (capture a baseline, then wire minimums so
-      coverage can't regress).
 - [ ] **Forms taxonomy flattening** — the last open piece of the forms/error cleanup
       (the rest of the shrink → lock → decide → reshape roadmap completed 2026-06-13; see
       Done). Unscheduled. Core layering is sound, so don't migrate internals to DTOs.
@@ -62,6 +43,25 @@ this file is the deliberate workaround.)
 ## Done
 
 <!-- Move finished items here with a date, or delete them. -->
+
+- [x] **Vitest Phase 3** _(2026-06-14)_ — breadth + coverage thresholds, all merged.
+      Characterization tests ("lock behavior first") landed across the suite: forms
+      (68 tests, 2026-06-11, PR #48), invoices/customers domain (45 tests, PR #70),
+      and the `src/server` ports (19 tests, PR #71) — unit lane grew to **286 tests**.
+      Along the way: pinned the unit lane to `TZ=UTC` so the invoice date helpers
+      (which mix UTC and local-time ops) are deterministic across machines; and
+      deliberately left `crypto.service.ts` untested because it's genuinely unused
+      (folded into the knip item). Closed out with **coverage thresholds**: captured
+      the 2026-06-14 baseline (stmts 22.53 / branch 20.25 / funcs 20.41 / lines
+      22.44 — low because coverage `include`s the whole untested breadth) and set
+      regression floors a couple points below it in `vitest.config.ts`
+      (`thresholds: stmts 20 / branch 18 / funcs 18 / lines 20`), to ratchet up over
+      time. Made them enforceable by adding a CI step that runs the **DB-free unit
+      lane with coverage** (`pnpm test:coverage`) — also resolving the long-standing
+      "the unit lane could be a fast CI step" opportunity (CI previously ran
+      `check:fast` only). Verified both ways: passes at the floor; fails when a
+      threshold is raised above current. _Remaining test work, tracked separately:
+      integration-lane deep-DRY (see memory `project_vitest_improvement`)._
 
 - [x] **Per-env migration drift guard** _(2026-06-14)_ — added the enforcement half
       the `weekly-maintenance` routine's drift _report_ was missing. A new env-free CLI,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -61,8 +61,7 @@ export default defineConfig({
 		 * Coverage is a root-level concern: it aggregates across whichever
 		 * project(s) run. Listing every source file in `include` makes the report
 		 * count files that have no tests yet, so it shows true breadth rather than
-		 * just the slice that happens to be exercised. Thresholds are intentionally
-		 * omitted until we have a baseline — see `test:coverage`.
+		 * just the slice that happens to be exercised.
 		 */
 		coverage: {
 			exclude: [
@@ -75,6 +74,22 @@ export default defineConfig({
 			provider: "v8",
 			reporter: ["text", "html"],
 			reportsDirectory: "./coverage",
+			/**
+			 * Regression floors, not targets. These sit a couple points below the
+			 * 2026-06-14 baseline (stmts 22.53 / branch 20.25 / funcs 20.41 /
+			 * lines 22.44 — low because `include` counts the whole untested
+			 * breadth: UI, actions, repositories, DALs). The buffer keeps trivial
+			 * line-count shifts from breaking CI while still catching real drops.
+			 * Ratchet these up as breadth lands; never down to "fix" a red build.
+			 * Enforced by `pnpm test:coverage`, which CI runs (the unit lane is
+			 * DB-free).
+			 */
+			thresholds: {
+				branches: 18,
+				functions: 18,
+				lines: 20,
+				statements: 20,
+			},
 		},
 
 		globals: true,


### PR DESCRIPTION
## What

Closes the **Vitest Phase 3** item. Now that breadth has landed (forms + invoices/customers + server, unit lane at **286 tests**), this captures a coverage baseline and locks it against regression — and makes that enforceable in CI.

- **`vitest.config.ts`** — add coverage **thresholds as regression floors**, set a couple points below the 2026-06-14 baseline. Floors: `statements 20 / branches 18 / functions 18 / lines 20`.
- **`ci.yml`** — add a **"Unit tests + coverage"** step (`pnpm test:coverage`). The unit lane is DB-free (dummy env + mocked DB per `vitest.config.ts`), so it runs in plain CI and now enforces the floors. Resolves the standing "the unit lane could be a fast CI step" opportunity, and updates the header comment (CI previously ran `check:fast` only and claimed *all* tests need a DB — the unit lane doesn't).

## Baseline (2026-06-14)

| Metric | Current | Floor |
|---|---|---|
| Statements | 22.53% | 20 |
| Branches | 20.25% | 18 |
| Functions | 20.41% | 18 |
| Lines | 22.44% | 20 |

The absolute numbers are low because coverage `include`s the **whole** `src/` tree — UI, actions, repositories, DALs — most of which is untested breadth, not regressions. These are **floors to ratchet up**, not targets; the rule is never lower them to fix a red build.

## Why floors, not tight pins

A small buffer keeps trivial line-count shifts from breaking CI on unrelated PRs while still catching real drops. As more breadth lands, raise the floors.

## Verification

- ✅ `pnpm test:coverage` passes at the floor (exit 0).
- ✅ Raising a threshold above current makes it **fail** (exit 1) — confirmed the gate actually fires, then reverted.
- ✅ `check:fast` (incl. migration-drift gate) + `md:check` green.
