### PR TITLE
chore: weekly maintenance 2026-06-15

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,6 +7,20 @@ this file is the deliberate workaround.)
 
 ## Open
 
+- [ ] **Dependency-audit watch (from weekly-maintenance 2026-06-15)** — `pnpm audit`
+      reports 3 advisories, all in **transitive dev/test tooling** (none in runtime
+      deps, nothing shipped to prod): `form-data` **HIGH**
+      ([GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx),
+      patched `>=4.0.6`) reachable via `cypress` and `start-server-and-test>wait-on>axios`;
+      `js-yaml` moderate ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68),
+      `>=4.1.2`) and `markdown-it` moderate
+      ([GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq), `>=14.1.2`),
+      both via `markdownlint-cli2`. All three clear once those tools bump their own
+      transitives; decide whether to wait for upstream or add `pnpm.overrides` pins
+      (overrides go in `pnpm-workspace.yaml`, keep lockstep with package.json). Also
+      pending: **biome 2.5.0** (current 2.4.16) was deferred by the weekly routine on
+      2026-06-15 — it published 2026-06-12, right at the 3-day freshness threshold; due
+      to be picked up (with `biome migrate --write`) on the next maintenance run.
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
       override automation + grouped dep updates (Dependabot can't do those). Replaces
       Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of


### PR DESCRIPTION
Automated weekly maintenance run for 2026-06-15. **No dependency bumps this week** — the only behind-by-a-minor package (biome) fell under the 3-day freshness rule. This PR only records report-only findings in `BACKLOG.md`.

## Release scan (3-day freshness applied)

| Package | Current | Latest | Action |
| --- | --- | --- | --- |
| `next` | 16.2.9 | 16.2.9 | up to date — no codemod |
| `@biomejs/biome` | 2.4.16 | 2.5.0 | **deferred** — published 2026-06-12, at the 3-day boundary; due next run (`biome migrate --write`) |
| `pnpm` | 11.5.3 | 11.7.0 | report-only; published today (too fresh) |
| `vitest` | 4.1.8 | 4.1.9 | report-only; published today (too fresh) |
| Node (`.nvmrc`) | 26 | 26 | current |
| `react` / `react-dom` | 19.2.7 | 19.2.7 | current |
| `drizzle-kit` / `drizzle-orm` | 0.31.10 / 0.45.2 | same | current |
| `cypress` | 15.17.0 | 15.17.0 | current |
| `typescript` | 6.0.3 | 6.0.3 | current |

No codemods ran (next current; biome deferred). No `overrides` / `pnpm-workspace.yaml` lockstep changes needed.

## Verify

No code changed beyond the `BACKLOG.md` note, so `pnpm check:fast` / `pnpm test:unit` were not re-run. Markdown was validated: `pnpm md:check` → **0 errors**, dprint clean.

## Report-only findings

**Migration drift:** ✅ OK — `dev`, `test`, `prod` all at `0006` and describe the same final schema (tables: customers, demo_user_counters, invoices, users). No drift.

**knip:** No new findings vs the tracked baseline in `BACKLOG.md` (10 unused files, 2 deps + 2 devDeps, 17 exports + 13 types — same as, or slightly fewer than, the 2026-06-13 baseline, as expected on an unchanged `main`).

**`pnpm audit`:** 3 advisories — **all transitive dev/test tooling, none in runtime/production deps:**

- **HIGH** `form-data <4.0.6` ([GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx)) — via `cypress` and `start-server-and-test > wait-on > axios`
- moderate `js-yaml <=4.1.1` ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)) — via `markdownlint-cli2`
- moderate `markdown-it <=14.1.1` ([GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq)) — via `markdownlint-cli2`

All three resolve once the parent tools bump their transitives; an alternative is `pnpm.overrides` pins (kept lockstep with package.json). Tracked as a new BACKLOG item for a decision. Per the routine's rules, no code was changed for audit findings.
