### PR TITLE
fix(lint): clear all Biome warnings and info diagnostics

### DIFF
--- a/cypress/node/tasks/create-user.task.ts
+++ b/cypress/node/tasks/create-user.task.ts
@@ -26,6 +26,7 @@ export async function createUserTask(user: {
 	role: UserRole;
 	username: string;
 }): Promise<void> {
+	// biome-ignore lint/suspicious/noUnnecessaryConditions: cy.task args are not type-checked at the call site, so `user` can be undefined at runtime despite the param type.
 	if (!user) {
 		throw new Error("createUser requires a user object");
 	}

--- a/cypress/node/tasks/upsert-e2e-user.task.ts
+++ b/cypress/node/tasks/upsert-e2e-user.task.ts
@@ -29,6 +29,7 @@ export async function upsertE2eUserTask(user: {
 	role: UserRole;
 	username: string;
 }): Promise<void> {
+	// biome-ignore lint/suspicious/noUnnecessaryConditions: cy.task args are not type-checked at the call site, so `user` can be undefined at runtime despite the param type.
 	if (!user) {
 		throw new Error("upsertE2EUser requires user object");
 	}

--- a/src/app/auth/error.tsx
+++ b/src/app/auth/error.tsx
@@ -25,7 +25,7 @@ export default function AuthError({
 			<H3 className="text-center">Auth Error</H3>
 			<button
 				className="mt-4 rounded-md bg-bg-accent px-4 py-2 text-sm text-text-accent transition-colors hover:bg-bg-hover hover:text-text-hover"
-				onClick={(): void => reset()}
+				onClick={reset}
 				type="button"
 			>
 				Try again

--- a/src/app/auth/login/error.tsx
+++ b/src/app/auth/login/error.tsx
@@ -25,7 +25,7 @@ export default function LoginError({
 			<H3 className="text-center">Login Error</H3>
 			<button
 				className="mt-4 rounded-md bg-bg-accent px-4 py-2 text-sm text-text-accent transition-colors hover:bg-bg-hover hover:text-text-hover"
-				onClick={(): void => reset()}
+				onClick={reset}
 				type="button"
 			>
 				Try again

--- a/src/app/auth/signup/error.tsx
+++ b/src/app/auth/signup/error.tsx
@@ -26,7 +26,7 @@ export default function SignupError({
 
 			<button
 				className="mt-4 rounded-md bg-bg-accent px-4 py-2 text-sm text-text-accent transition-colors hover:bg-bg-hover hover:text-text-hover"
-				onClick={(): void => reset()}
+				onClick={reset}
 				type="button"
 			>
 				Try again

--- a/src/app/dashboard/invoices/error.tsx
+++ b/src/app/dashboard/invoices/error.tsx
@@ -24,7 +24,7 @@ export default function InvoicesError({
 			<H3 className="text-center">Invoice Error</H3>
 			<button
 				className="mt-4 rounded-md bg-bg-accent px-4 py-2 text-sm text-text-accent transition-colors hover:bg-bg-hover hover:text-text-hover"
-				onClick={(): void => reset()}
+				onClick={reset}
 				type="button"
 			>
 				Try again

--- a/src/app/dashboard/users/error.tsx
+++ b/src/app/dashboard/users/error.tsx
@@ -24,7 +24,7 @@ export default function UsersError({
 			<H3 className="text-center">User Error</H3>
 			<button
 				className="mt-4 rounded-md bg-bg-accent px-4 py-2 text-sm text-text-accent transition-colors hover:bg-bg-hover hover:text-text-hover"
-				onClick={(): void => reset()}
+				onClick={reset}
 				type="button"
 			>
 				Try again

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -16,7 +16,7 @@ export default function GlobalError({
 				<h3 className="text-center">Global Error</h3>
 				<p>{error.message}</p>
 				{/** biome-ignore lint/a11y/useButtonType: <default> */}
-				<button onClick={(): void => reset()}>Try again</button>
+				<button onClick={reset}>Try again</button>
 			</body>
 		</html>
 	);

--- a/src/modules/auth/__tests__/integration/login-flow.test.ts
+++ b/src/modules/auth/__tests__/integration/login-flow.test.ts
@@ -77,7 +77,7 @@ describe("Login Flow Integration", () => {
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
 				const payload = toFormErrorPayload<LoginField>(result.error);
-				expect(payload.fieldErrors?.email).toBeDefined();
+				expect(payload.fieldErrors.email).toBeDefined();
 			}
 		});
 

--- a/src/modules/auth/__tests__/integration/signup-flow.test.ts
+++ b/src/modules/auth/__tests__/integration/signup-flow.test.ts
@@ -65,9 +65,9 @@ describe("Signup Flow Integration", () => {
 			expect(result.ok).toBe(false);
 			if (!result.ok) {
 				const payload = toFormErrorPayload<SignupField>(result.error);
-				expect(payload.fieldErrors?.email).toBeDefined();
-				expect(payload.fieldErrors?.password).toBeDefined();
-				expect(payload.fieldErrors?.username).toBeDefined();
+				expect(payload.fieldErrors.email).toBeDefined();
+				expect(payload.fieldErrors.password).toBeDefined();
+				expect(payload.fieldErrors.username).toBeDefined();
 			}
 		});
 
@@ -91,7 +91,7 @@ describe("Signup Flow Integration", () => {
 			if (!result.ok) {
 				const payload = toFormErrorPayload<SignupField>(result.error);
 				// Server Action contract: conflicts must return field-level errors.
-				expect(payload.fieldErrors?.email).toBeDefined();
+				expect(payload.fieldErrors.email).toBeDefined();
 				expect(payload.fieldErrors.email.length).toBeGreaterThan(0);
 				expect(payload.fieldErrors.email[0]?.toLowerCase()).toMatch(
 					/already|use|exists|unique|conflict/,

--- a/src/modules/auth/application/session/dtos/responses/update-session-outcome.dto.ts
+++ b/src/modules/auth/application/session/dtos/responses/update-session-outcome.dto.ts
@@ -5,18 +5,6 @@ import type {
 import type { UserId } from "@/modules/users/domain/types/user-id.brand";
 import type { UserRole } from "@/shared/policies/user-role/user-role.constants";
 
-/**
- * Centralized reason literals to avoid magic strings across DTOs, builders, and use cases.
- */
-export const UPDATE_SESSION_OUTCOME_REASON = {
-	absoluteLifetimeExceeded: "absolute_lifetime_exceeded",
-	expired: "expired",
-	invalidOrMissingUser: "invalid_or_missing_user",
-	noCookie: "no_cookie",
-	notNeeded: "not_needed",
-	rotated: "rotated",
-} as const;
-
 type UpdateSessionTerminationNotRotatedDto = Readonly<{
 	readonly ageSec: DurationSeconds;
 	readonly maxSec: DurationSeconds;
@@ -38,6 +26,18 @@ type UpdateSessionNotNeededNotRotatedDto = Readonly<{
 	readonly refreshed: false;
 	readonly timeLeftSec: TimeDeltaSeconds;
 }>;
+
+/**
+ * Centralized reason literals to avoid magic strings across DTOs, builders, and use cases.
+ */
+export const UPDATE_SESSION_OUTCOME_REASON = {
+	absoluteLifetimeExceeded: "absolute_lifetime_exceeded",
+	expired: "expired",
+	invalidOrMissingUser: "invalid_or_missing_user",
+	noCookie: "no_cookie",
+	notNeeded: "not_needed",
+	rotated: "rotated",
+} as const;
 
 export type UpdateSessionNotRotatedDto =
 	| UpdateSessionNoSessionNotRotatedDto

--- a/src/modules/auth/domain/shared/constants/auth-policy.constants.ts
+++ b/src/modules/auth/domain/shared/constants/auth-policy.constants.ts
@@ -1,3 +1,6 @@
+type _AuthPolicyName =
+	(typeof AUTH_POLICY_NAMES)[keyof typeof AUTH_POLICY_NAMES];
+
 export const AUTH_POLICY_REASONS = {
 	NO_TOKEN: "no_token",
 	NOT_AUTHENTICATED: "not_authenticated",
@@ -14,6 +17,3 @@ export const AUTH_POLICY_NAMES = {
 	REGISTRATION: "registration",
 	SESSION_VERIFICATION: "session-verification",
 } as const;
-
-type _AuthPolicyName =
-	(typeof AUTH_POLICY_NAMES)[keyof typeof AUTH_POLICY_NAMES];

--- a/src/modules/banner/presentation/one-time-banner.tsx
+++ b/src/modules/banner/presentation/one-time-banner.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { type JSX, useState, useTransition } from "react";
+import { type JSX, useCallback, useState, useTransition } from "react";
 import { dismissBannerAction } from "@/modules/banner/presentation/actions/dismiss-banner.action";
 
 export function OneTimeBanner(): JSX.Element | null {
 	const [open, setOpen] = useState(true);
 	const [pending, startTransition] = useTransition();
+
+	const handleDismiss = useCallback((): void => {
+		startTransition(async () => {
+			await dismissBannerAction();
+			setOpen(false);
+		});
+	}, []);
 
 	if (!open) {
 		return null;
@@ -25,12 +32,7 @@ export function OneTimeBanner(): JSX.Element | null {
 				<button
 					className="font-semibold text-sm text-text-secondary hover:text-text-primary"
 					disabled={pending}
-					onClick={() => {
-						startTransition(async () => {
-							await dismissBannerAction();
-							setOpen(false);
-						});
-					}}
+					onClick={handleDismiss}
 					type="button"
 				>
 					{pending ? "Saving…" : "Dismiss"}

--- a/src/modules/customers/infrastructure/adapters/customer.mapper.ts
+++ b/src/modules/customers/infrastructure/adapters/customer.mapper.ts
@@ -32,7 +32,7 @@ export function mapCustomerAggregatesRawToDto(
 		id: toCustomerId(row.id),
 		imageUrl: row.imageUrl,
 		name: row.name,
-		totalInvoices: row.totalInvoices ?? 0,
+		totalInvoices: row.totalInvoices,
 		totalPaid: row.totalPaid ?? 0,
 		totalPending: row.totalPending ?? 0,
 	};

--- a/src/modules/invoices/application/dto/invoice.dto.ts
+++ b/src/modules/invoices/application/dto/invoice.dto.ts
@@ -1,8 +1,8 @@
 import type { InvoiceStatus } from "@/modules/invoices/domain/statuses/invoice.statuses";
 
 /** Transport aliases (unambiguous formats) */
-export type IsoDateString = string; // YYYY-MM-DD
 type PeriodFirstDayString = string; // YYYY-MM-01
+export type IsoDateString = string; // YYYY-MM-DD
 
 /**
  * Data Transfer Object for an invoice.

--- a/src/modules/invoices/domain/schema/invoice.schema.ts
+++ b/src/modules/invoices/domain/schema/invoice.schema.ts
@@ -38,13 +38,13 @@ const InvoiceBaseSchema = z.object({
 	status: invoiceStatusSchema,
 });
 
+type CreateInvoiceInput = z.input<typeof CreateInvoiceSchema>;
+type UpdateInvoiceInput = z.input<typeof UpdateInvoiceSchema>;
+
 // biome-ignore lint/nursery/useExplicitType: fix
 export const CreateInvoiceSchema = InvoiceBaseSchema;
 
 export const UpdateInvoiceSchema = InvoiceBaseSchema.partial();
-
-type CreateInvoiceInput = z.input<typeof CreateInvoiceSchema>;
-type UpdateInvoiceInput = z.input<typeof UpdateInvoiceSchema>;
 
 export type CreateInvoicePayload = z.output<typeof CreateInvoiceSchema>;
 export type UpdateInvoicePayload = z.output<typeof UpdateInvoiceSchema>;

--- a/src/modules/invoices/infrastructure/repository/dal/fetch-latest-invoices.dal.ts
+++ b/src/modules/invoices/infrastructure/repository/dal/fetch-latest-invoices.dal.ts
@@ -37,7 +37,7 @@ export async function fetchLatestInvoicesDal(
 		.limit(limit);
 
 	// TODO: Refactor. Empty result does not mean that an error occurred.
-	if (!data || data.length === 0) {
+	if (data.length === 0) {
 		throw makeAppError("database", {
 			cause: "",
 			message: INVOICE_MSG.fetchLatestFailed,

--- a/src/modules/invoices/infrastructure/repository/invoice.repository.ts
+++ b/src/modules/invoices/infrastructure/repository/invoice.repository.ts
@@ -107,6 +107,7 @@ export class InvoiceRepository extends BaseRepository<
 				metadata: {},
 			});
 		}
+		// biome-ignore lint/suspicious/noUnnecessaryConditions: defensive guard at a public method boundary; callers may pass runtime values that violate the static type (e.g. Server Action input or as-casts), and `typeof null === "object"` would not catch a null without the `!data` check.
 		if (!data || typeof data !== "object") {
 			throw makeAppError("validation", {
 				cause: "",

--- a/src/modules/invoices/presentation/components/tables/desktop-table.tsx
+++ b/src/modules/invoices/presentation/components/tables/desktop-table.tsx
@@ -47,7 +47,7 @@ export const DesktopTable = ({
 				</TableRow>
 			</TableHeader>
 			<TableBody>
-				{invoices?.map(
+				{invoices.map(
 					(invoice): JSX.Element => (
 						<TableRow
 							className="w-full border-b py-3 text-sm last-of-type:border-none [&:first-child>td:first-child]:rounded-tl-lg [&:first-child>td:last-child]:rounded-tr-lg [&:last-child>td:first-child]:rounded-bl-lg [&:last-child>td:last-child]:rounded-br-lg"

--- a/src/modules/invoices/presentation/components/tables/mobile-table.tsx
+++ b/src/modules/invoices/presentation/components/tables/mobile-table.tsx
@@ -26,7 +26,7 @@ export const MobileTable = ({
 	return (
 		<div className="md:hidden">
 			{/* Map through invoices and create mobile-friendly cards */}
-			{invoices?.map(
+			{invoices.map(
 				(invoice): JSX.Element => (
 					<div
 						className="mb-2 w-full rounded-md bg-bg-primary p-4"

--- a/src/modules/users/domain/schemas/user.schema.ts
+++ b/src/modules/users/domain/schemas/user.schema.ts
@@ -37,6 +37,10 @@ const passwordEdit = optionalEdit(PasswordSchema);
 const roleEdit = optionalEdit(UserRoleFormSchema);
 const usernameEdit = optionalEdit(UsernameSchema);
 
+// UI/view-model types derived from the shared schema
+// Zod Input (pre-parse) - Raw form values
+type EditUserFormInput = z.input<typeof EditUserFormSchema>;
+
 // biome-ignore lint/nursery/useExplicitType: fix later
 export const CreateUserFormSchema = UserFormBaseSchema;
 
@@ -51,10 +55,6 @@ export const EditUserFormSchema = z.strictObject({
 	username: usernameEdit,
 });
 
-// UI/view-model types derived from the shared schema
-
-// Zod Input (pre-parse) - Raw form values
-type EditUserFormInput = z.input<typeof EditUserFormSchema>;
 export type EditUserFormFieldNames = keyof EditUserFormInput;
 
 // Zod Output (post-parse) - Validated domain data

--- a/src/modules/users/presentation/components/tables/users-table.tsx
+++ b/src/modules/users/presentation/components/tables/users-table.tsx
@@ -19,7 +19,7 @@ export async function UsersTable({
 
 	return (
 		<div data-cy="users-table">
-			{users?.map(
+			{users.map(
 				(user: UserDto): JSX.Element => (
 					<div
 						className="mb-2 w-full rounded-md bg-bg-primary p-4"

--- a/src/shared/core/errors/core/app-error.dto.ts
+++ b/src/shared/core/errors/core/app-error.dto.ts
@@ -2,6 +2,12 @@ import type { AppError } from "@/shared/core/errors/core/app-error.entity";
 import type { AppErrorKey } from "@/shared/core/errors/core/catalog/app-error.registry";
 import type { AppErrorMetadata } from "@/shared/core/errors/core/metadata/error-metadata.value";
 
+type AppErrorCoreDescriptor = Readonly<
+	AppErrorDefinition & {
+		readonly key: AppErrorKey;
+	}
+>;
+
 export const APP_ERROR_SEVERITY = {
 	ERROR: "ERROR",
 	INFO: "INFO",
@@ -41,12 +47,6 @@ export type UnexpectedErrorParams<
 > = Omit<AppErrorParams<T>, "cause" | "key" | "metadata"> & {
 	readonly overrideMetadata?: T;
 };
-
-type AppErrorCoreDescriptor = Readonly<
-	AppErrorDefinition & {
-		readonly key: AppErrorKey;
-	}
->;
 
 export type AppErrorJsonDto<T extends AppErrorMetadata = AppErrorMetadata> =
 	Readonly<

--- a/src/shared/core/errors/core/catalog/app-error.registry.ts
+++ b/src/shared/core/errors/core/catalog/app-error.registry.ts
@@ -23,7 +23,7 @@ type AppErrorDefinitionByKey = (typeof APP_ERROR_REGISTRY)[AppErrorKey];
  * Registry of all available Application Error Keys.
  * Using a constant object ensures type safety and IDE autocompletion across the project.
  */
-export const APP_ERROR_KEYS = {
+const APP_ERROR_KEYS = {
 	conflict: "conflict",
 	database: "database",
 	forbidden: "forbidden",
@@ -39,7 +39,7 @@ export const APP_ERROR_KEYS = {
 	validation: "validation",
 } as const;
 
-export type AppErrorKey = keyof typeof APP_ERROR_KEYS;
+type AppErrorKey = keyof typeof APP_ERROR_KEYS;
 
 /**
  * Single source of truth for Error Definitions and their Metadata Schemas.
@@ -127,19 +127,20 @@ const APP_ERROR_REGISTRY = {
 	},
 } as const satisfies Record<AppErrorKey, AppErrorRegistryEntry>;
 
-export function getAppErrorDefinition(
-	key: AppErrorKey,
-): AppErrorDefinitionByKey {
+function getAppErrorDefinition(key: AppErrorKey): AppErrorDefinitionByKey {
 	return APP_ERROR_REGISTRY[key];
 }
 
 /**
  * Automatically derived mapping of Metadata types by Error Key.
  */
-export type AppErrorMetadataValueByKey = {
+type AppErrorMetadataValueByKey = {
 	[K in AppErrorKey]: z.infer<(typeof APP_ERROR_REGISTRY)[K]["metadataSchema"]>;
 };
 
-export function getMetadataSchemaForKey(key: AppErrorKey): ZodType {
+function getMetadataSchemaForKey(key: AppErrorKey): ZodType {
 	return APP_ERROR_REGISTRY[key].metadataSchema;
 }
+
+export type { AppErrorKey, AppErrorMetadataValueByKey };
+export { APP_ERROR_KEYS, getAppErrorDefinition, getMetadataSchemaForKey };

--- a/src/shared/http/server/request-metadata.ts
+++ b/src/shared/http/server/request-metadata.ts
@@ -63,6 +63,7 @@ function getHeaderValue(
 function extractIpFromForwarded(forwardedValue: string): string | null {
 	const [entry = ""] = forwardedValue.split(",");
 	const match = FORWARDED_FOR_REGEX.exec(entry);
+	// biome-ignore lint/suspicious/noUnnecessaryConditions: RegExp.exec() returns null when there is no match; the optional chain is required (Biome mis-infers the receiver as non-nullish).
 	return match?.[1] ?? null;
 }
 

--- a/src/shared/telemetry/logging/infrastructure/logging.mappers.ts
+++ b/src/shared/telemetry/logging/infrastructure/logging.mappers.ts
@@ -7,6 +7,7 @@ import type { SafeErrorShape } from "@/shared/telemetry/logging/core/logger.dto"
  * Map domain `Severity` to `LogLevel` with an exhaustive check.
  */
 function _mapSeverityToLogLevel(severity: AppErrorSeverity): LogLevel {
+	// biome-ignore-start lint/suspicious/noUnnecessaryConditions: Biome mis-resolves the cross-module `keyof typeof` severity union and wrongly flags these cases as unreachable; the switch is exhaustive and correct.
 	switch (severity) {
 		case "WARN":
 			return "warn";
@@ -19,6 +20,7 @@ function _mapSeverityToLogLevel(severity: AppErrorSeverity): LogLevel {
 			return _exhaustive;
 		}
 	}
+	// biome-ignore-end lint/suspicious/noUnnecessaryConditions: end of exhaustive-switch suppression range
 }
 
 /**

--- a/src/shell/dashboard/components/dashboard-nav-links.tsx
+++ b/src/shell/dashboard/components/dashboard-nav-links.tsx
@@ -7,6 +7,6 @@ import { NavLinks } from "@/shell/dashboard/components/nav-links";
 
 export async function DashboardNavLinks(): Promise<JSX.Element> {
 	const session: SessionVerificationDto = await verifySessionOptimistic();
-	const role: UserRole = normalizeUserRole(session?.role);
+	const role: UserRole = normalizeUserRole(session.role);
 	return <NavLinks role={role} />;
 }

--- a/src/ui/atoms/button.atom.tsx
+++ b/src/ui/atoms/button.atom.tsx
@@ -40,6 +40,7 @@ export function ButtonAtom({
 	...rest
 }: ButtonProps): JSX.Element {
 	const isDisabled: boolean = isLoading || Boolean(disabled);
+	const content: ReactNode = isLoading && loadingText ? loadingText : children;
 
 	return (
 		<button
@@ -57,7 +58,7 @@ export function ButtonAtom({
 			)}
 			disabled={isDisabled}
 		>
-			{isLoading && loadingText ? loadingText : children}
+			{content}
 		</button>
 	);
 }

--- a/src/ui/atoms/select-menu.atom.tsx
+++ b/src/ui/atoms/select-menu.atom.tsx
@@ -92,7 +92,7 @@ export const SelectMenuAtom: SelectMenuComponent = React.memo(
 						</option>
 					))}
 				</select>
-				{Icon && (
+				{Icon ? (
 					<Icon
 						className={cn(
 							"ml-3 shrink-0",
@@ -100,7 +100,7 @@ export const SelectMenuAtom: SelectMenuComponent = React.memo(
 							"h-[18px] w-[18px]",
 						)}
 					/>
-				)}
+				) : null}
 			</div>
 		);
 	},

--- a/src/ui/molecules/input-field.molecule.tsx
+++ b/src/ui/molecules/input-field.molecule.tsx
@@ -60,14 +60,14 @@ export function InputFieldMolecule(props: InputFieldProps): JSX.Element {
 					{icon ? <span aria-hidden="true">{icon}</span> : null}
 				</div>
 				{/* Only render FieldError if error is defined and non-empty */}
-				{hasError && (
+				{hasError ? (
 					<FieldErrorComponentMolecule
 						dataCy={dataCy ? `${dataCy}-errors` : undefined}
 						error={error}
 						id={describedById ?? `${id}-errors`}
 						label={`${label} error:`}
 					/>
-				)}
+				) : null}
 			</div>
 		</InputFieldCardWrapper>
 	);

--- a/src/ui/molecules/page-header.molecule.tsx
+++ b/src/ui/molecules/page-header.molecule.tsx
@@ -26,7 +26,7 @@ export const PageHeaderMolecule: FC<PageHeaderProps> = ({
 }: PageHeaderProps) => {
 	return (
 		<div className="sm:mx-auto sm:w-full sm:max-w-md">
-			{logoSrc && (
+			{logoSrc ? (
 				<Image
 					alt={logoAlt}
 					className="mx-auto h-10 w-auto"
@@ -35,7 +35,7 @@ export const PageHeaderMolecule: FC<PageHeaderProps> = ({
 					src={logoSrc}
 					width={IMAGE_SIZES.medium}
 				/>
-			)}
+			) : null}
 			<h2 className="mt-6 text-center font-bold text-2xl/9 text-text-primary tracking-tight">
 				{title}
 			</h2>

--- a/src/ui/molecules/search-box.molecule.tsx
+++ b/src/ui/molecules/search-box.molecule.tsx
@@ -8,7 +8,7 @@ import {
 	useRouter,
 	useSearchParams,
 } from "next/navigation";
-import { type ChangeEvent, type JSX, useId } from "react";
+import { type ChangeEvent, type JSX, useCallback, useId } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import { DEBOUNCE_MS } from "@/shared/time/time.constants";
 import { LabelAtom } from "@/ui/atoms/label.atom";
@@ -44,6 +44,13 @@ export function SearchBoxMolecule({
 		replace(nextHref);
 	}, DEBOUNCE_MS);
 
+	const handleChange = useCallback(
+		(e: ChangeEvent<HTMLInputElement>): void => {
+			handleSearch(e.target.value);
+		},
+		[handleSearch],
+	);
+
 	return (
 		<div className="relative flex flex-1 shrink-0">
 			<LabelAtom className="sr-only" htmlFor={inputId} text="Search" />
@@ -58,9 +65,7 @@ export function SearchBoxMolecule({
 				)}
 				defaultValue={searchParams.get("query")?.toString()}
 				id={inputId}
-				onChange={(e: ChangeEvent<HTMLInputElement>): void => {
-					handleSearch(e.target.value);
-				}}
+				onChange={handleChange}
 				placeholder={placeholder}
 				type="search"
 			/>

--- a/src/ui/molecules/select-field.molecule.tsx
+++ b/src/ui/molecules/select-field.molecule.tsx
@@ -37,14 +37,14 @@ export function SelectFieldMolecule<T extends { id: string; name: string }>(
 					id={id}
 					{...rest}
 				/>
-				{hasError && (
+				{hasError ? (
 					<FieldErrorComponentMolecule
 						dataCy={dataCy ? `${dataCy}-errors` : undefined}
 						error={error}
 						id={errorId}
 						label={`${label} error:`}
 					/>
-				)}
+				) : null}
 			</div>
 		</InputFieldCardWrapper>
 	);

--- a/src/ui/molecules/server-message.molecule.tsx
+++ b/src/ui/molecules/server-message.molecule.tsx
@@ -110,7 +110,7 @@ export function ServerMessageMolecule<Tdata>({
 
 	return (
 		<div className="relative min-h-[56px]">
-			{message && (
+			{message ? (
 				<div
 					aria-live={success ? "polite" : "assertive"}
 					className={`${baseStyles} ${visibilityStyles} ${semanticStyles}`}
@@ -122,7 +122,7 @@ export function ServerMessageMolecule<Tdata>({
 				>
 					{message}
 				</div>
-			)}
+			) : null}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Brings the project to a clean Biome run: **0 diagnostics**, down from **7 infos + 32 warnings**. No behaviour changes — this is lint cleanup, with defensive runtime guards preserved and suppressed with rationale where Biome's static analysis can't see the boundary.

Resolved by rule (one commit each):

- **`useExportsLast` (7 infos)** — reorder so all exports follow non-export statements. The error registry can't reorder (`APP_ERROR_REGISTRY` uses the exported `APP_ERROR_KEYS` as runtime computed keys), so it declares everything internally and re-exports at the bottom. Public API unchanged.
- **`noLeakedRender` (6)** — rewrite `cond && <jsx>` guards as explicit ternaries (`cond ? <jsx> : null`); for `ButtonAtom`, hoist the loading-text expression into a `const` to preserve exact truthy semantics without an extra boolean cast.
- **`noJsxPropsBind` (8)** — error boundaries pass the stable `reset` prop directly; `OneTimeBanner` and `SearchBox` extract their inline handlers into `useCallback`.
- **`noUnnecessaryConditions` (18)** — two kinds of change:
  - *Genuine redundancies removed* (tsc confirms non-null): optional chaining in flow tests / invoice+user tables / `DashboardNavLinks`; `?? 0` on `totalInvoices` (COUNT() is non-null); the latest-invoices DAL guard simplified to `data.length === 0` (drizzle `.select()` always returns an array).
  - *Defensive guards kept + suppressed with rationale*: `cy.task` user guards (args bypass call-site type checking), the invoice repository input guard (`!data` catches a null that `typeof null === "object"` would miss), `request-metadata` (`RegExp.exec()` returns null — Biome mis-infers the receiver as non-nullish), and the logging severity switch (Biome mis-resolves the cross-module `keyof typeof` union and wrongly calls the exhaustive cases unreachable).

## Type of change

- [ ] Feature
- [x] Fix
- [x] Refactor (no behaviour change)
- [ ] Chore / tooling / docs

## How it was tested

- [x] Biome (`biome check`) — clean, 0 diagnostics across 608 files
- [x] `pnpm typecheck` — pass
- [x] `pnpm test` (unit) — 286 passed / 49 files
- [x] `pnpm test:integration` — 18 passed / 5 files (DB-backed; covers the edited login/signup flow tests)
- [x] `pnpm cy:e2e` (end-to-end) — 32 passed / 20 specs, 0 failing, 0 skipped

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (n/a — no behaviour change)
- [x] Focused change — preserves existing patterns and user-authored work

### Note for reviewer

`_mapSeverityToLogLevel` in `logging.mappers.ts` is currently unused. It was kept and suppressed (rather than deleted) to preserve what looks like intended future infrastructure — happy to delete it instead if preferred, which would drop that suppression.
