### PR TITLE
ci: run Cypress e2e suite in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,18 @@
 # Continuous Integration (CI)
 #
-# Runs fast, dependency-free checks on every push to `main` and every pull
-# request that targets `main`: `pnpm check:fast` (Biome lint + Markdown
-# lint/format + type-check + Next.js typegen) plus the migration-drift gate and
-# the DB-free unit lane with coverage thresholds.
+# Two jobs run on every push to `main` and every pull request targeting `main`:
 #
-# Note: the integration tests, the production build, and Cypress e2e are
-# intentionally NOT here. They need a real database + secret env vars and would
-# fail in a plain CI run. The UNIT lane is different — it injects a dummy env and
-# mocks the DB (see `vitest.config.ts`), so it runs anywhere. See the README /
-# your `pnpm check` script for how to run the rest locally.
+#   • check — fast, dependency-free checks: `pnpm check:fast` (Biome lint +
+#     Markdown lint/format + type-check + Next.js typegen) plus the migration-
+#     drift gate and the DB-free unit lane with coverage thresholds.
+#   • e2e — the Cypress end-to-end suite against a real `next dev` server backed
+#     by an ephemeral Postgres service container. The job recreates the
+#     `.env.test.local` the harness expects from non-secret CI values, so it
+#     needs no configured GitHub secrets.
+#
+# Still intentionally NOT here: the integration vitest lane and the production
+# build. They also need a database/secrets; the e2e job's service-container
+# pattern could bring the integration lane in later if wanted.
 
 name: CI
 
@@ -86,3 +89,86 @@ jobs:
       #     the build.
       - name: Unit tests + coverage
         run: pnpm test:coverage
+
+  e2e:
+    name: E2E (Cypress)
+    runs-on: ubuntu-latest
+    # Generous ceiling: a cold `next dev` (Turbopack compiles routes on first
+    # hit) plus 20 specs. The warm local run is ~35s; this is a safety net.
+    timeout-minutes: 15
+
+    # Ephemeral test database. POSTGRES_DB MUST be `test_db`: the `db-env-guard`
+    # smoke spec asserts databaseName==="test_db", and the e2e preflight asserts
+    # databaseEnv==="test" — both read from /api/health.
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d test_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      # Cache the Cypress binary (~/.cache/Cypress). Restored BEFORE install so
+      # the `cypress` postinstall finds it instead of re-downloading every run.
+      - name: Cache Cypress binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            cypress-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The e2e harness (cypress-with-server.cli.ts) treats .env.test.local as
+      # the single source of truth for PORT + the DB env. Recreate it from
+      # non-secret CI values; SESSION_SECRET is generated per run (specs never
+      # assert on it, only that it is present and valid).
+      - name: Write .env.test.local
+        run: |
+          {
+            echo "AUTH_BCRYPT_SALT_ROUNDS=12"
+            echo "DATABASE_ENV=test"
+            echo "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/test_db"
+            echo "NODE_ENV=test"
+            echo "PORT=3000"
+            echo "SESSION_SECRET=$(openssl rand -base64 48)"
+            echo "NEXT_PUBLIC_LOG_LEVEL=info"
+            echo "NEXT_PUBLIC_NODE_ENV=test"
+          } > .env.test.local
+
+      # Apply the committed TEST migrations (drizzle-kit migrate, scope=test):
+      # the production-like path that also exercises the drift-guarded set.
+      - name: Apply test migrations
+        run: pnpm db:migrate:test
+
+      # Seed the demo users/invoices the specs expect.
+      - name: Seed test database
+        run: pnpm db:seed:test
+
+      # Boots `next dev` (test env) on PORT, waits for it, runs the /api/health
+      # identity preflight, then the Cypress suite. start-server-and-test tears
+      # the server down afterward and propagates the suite's exit code.
+      - name: Run Cypress e2e
+        run: pnpm cy:e2e

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,6 +7,15 @@ this file is the deliberate workaround.)
 
 ## Open
 
+- [ ] **Phase 4 CI: e2e + branch protection** — the Cypress e2e suite is now wired into
+      `ci.yml` as a parallel `e2e` job (`postgres:17-alpine` service container,
+      `.env.test.local` regenerated on the runner from non-secret values + a per-run
+      `openssl` `SESSION_SECRET`, then `db:migrate:test` → `db:seed:test` → `cy:e2e`) —
+      **PR open** from `claude/vibrant-darwin-fe91f7`. Remaining after merge: enable branch
+      protection on `main` requiring the `check` + `e2e` status checks (repo-admin setting).
+      Closes the last item of the deploy plan (`project_dashboard_plan` in memory). Possible
+      follow-up: bring the integration vitest lane into CI via the same service-container
+      pattern.
 - [ ] **Dependency-audit watch (from weekly-maintenance 2026-06-15)** — `pnpm audit`
       reports 3 advisories, all in **transitive dev/test tooling** (none in runtime
       deps, nothing shipped to prod): `form-data` **HIGH**


### PR DESCRIPTION
## What

Adds a parallel **`e2e`** job to `ci.yml` so the Cypress end-to-end suite runs on every push / PR to `main`. This is the last remaining piece of the deploy plan's **Phase 4 CI** — fast checks and the DB-free unit lane already run in CI; the e2e suite was local-only until now.

## How it works

- **`postgres:17-alpine` service container**, DB named `test_db`. That name is load-bearing: the `db-env-guard` smoke spec asserts `databaseName === "test_db"`, and the e2e preflight asserts `databaseEnv === "test"` — both read from `/api/health`.
- **Self-contained env, zero GitHub secrets.** The job regenerates `.env.test.local` on the runner from non-secret values plus a per-run `openssl rand` `SESSION_SECRET`. The harness (`cypress-with-server.cli.ts`) treats that file as the single source of truth for `PORT` + DB env, so its port/preflight guards run in CI exactly as they do locally. Anyone who forks gets green CI with no secret setup.
- **Production-like DB setup:** `db:migrate:test` (drizzle-kit migrate, scope `test` — the same migration set the drift gate guards) → `db:seed:test` → `pnpm cy:e2e` (boots `next dev`, waits, runs the `/api/health` identity preflight, then the suite).
- Cypress binary is cached; the job runs **independently of `check`** so branch protection can require both status checks.

## Verification

The full suite is green locally — **32/32 specs, 0 skips** (`pnpm cy:e2e`), and the whole `pnpm check` pipeline passes (lint, markdown, typecheck, typegen, 286 unit + 18 integration tests). YAML structure validated.

CI on this PR is the real test of the runner-side DB setup.

## Remaining (not in this PR)

Enable **branch protection** on `main` requiring the `check` + `e2e` checks — a repo-admin setting (Settings → Branches), left for you to flip. That closes Phase 4. Tracked in `BACKLOG.md`.
