### PR TITLE
docs(claude): add Workflow, Git Safety, Worktrees, Environment sections to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,22 @@
 Follow the shared repository instructions in `AGENTS.md`.
 Also consult relevant detailed project standards in `docs/standards/`.
 
+## Workflow: PR Creation
+
+After completing any backlog item or fix: run the full test suite + typecheck, verify CI is green, then open a focused PR. Reconcile BACKLOG.md and memory/docs as part of the same flow.
+
+## Git Safety
+
+Never delete branches/worktrees or run destructive DB/git commands without explicit confirmation. When merging stacked PRs, warn before deleting any branch so changes aren't lost. Always confirm you are operating in a worktree, never directly on main.
+
+## Worktrees
+
+This project uses MANY worktrees, not a single checkout. Assume branch-per-architecture and a multi-worktree workflow when reasoning about branches, env files, and isolation. Claude Code checks out work in a git worktree under `.claude/worktrees/`; changes committed there go to a separate branch and do not affect `main` until a PR is merged.
+
+## Environment
+
+This is a macOS/zsh environment: `timeout` and bash `mapfile` are unavailable, and shell access to env/secret files is often blocked. Use targeted single commands instead of compound shell pipelines, and poll CI directly rather than wrapping in `timeout`.
+
 ## Claude-specific context
 
 ### Slash commands
@@ -24,10 +40,6 @@ Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so the
 ### Markdown tooling
 
 Markdown is linted by **markdownlint-cli2** (`.markdownlint-cli2.jsonc`) and formatted by **dprint** (`dprint.json`) — Biome's markdown support is still experimental, so it only owns JS/TS/JSON here. The two tools have non-overlapping responsibilities: formatting rules (whitespace, list/table layout, emphasis markers) are disabled in markdownlint and owned by dprint. Use `pnpm md:check` to verify and `pnpm md:fix` to auto-fix (markdownlint first, dprint last).
-
-### Worktrees
-
-Claude Code may check out work in a git worktree under `.claude/worktrees/`. Changes committed there go to a separate branch and do not affect `main` until a PR is merged.
 
 ### Memory
 


### PR DESCRIPTION
## Summary

Promotes four guidance sections to top-level headings near the top of `CLAUDE.md`, so the recurring workflow and the guardrails are stated up front rather than buried. The content is sourced from this project's `/insights` report.

- **Workflow: PR Creation** — after a backlog item or fix: run the full test suite + typecheck, verify CI is green, then open a focused PR; reconcile `BACKLOG.md` and memory/docs in the same flow.
- **Git Safety** — confirm before destructive branch/worktree/DB/git operations; warn before deleting any branch when merging stacked PRs; never work on `main` directly.
- **Worktrees** — this project uses many worktrees, not a single checkout (assume branch-per-architecture). Folds in the detail from the old `### Worktrees` subsection.
- **Environment** — macOS/zsh: `timeout` and bash `mapfile` are unavailable and env/secret-file access is often blocked; prefer targeted single commands and poll CI directly.

**Reviewer note:** there was already a `### Worktrees` subsection under `## Claude-specific context`. To avoid a duplicate "Worktrees" heading, its concrete detail (the `.claude/worktrees/` path and the "doesn't affect `main` until merged" note) was merged into the new top-level `## Worktrees` section and the old subsection removed. Net: +16 / −4 lines in one file.

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor (no behaviour change)
- [x] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen) — ran the lint portion: biome lint/format, markdownlint-cli2, dprint all clean
- [ ] `pnpm test` (unit) — not applicable (docs-only change)
- [ ] `pnpm cy:e2e` (end-to-end) — not applicable (docs-only change)
- [ ] Manually verified in the running app — not applicable (docs-only change)

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed
- [x] Focused change — preserves existing patterns and user-authored work