### PR TITLE
fix(deps): override markdown-it/js-yaml to patched versions (2 Dependabot alerts)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,17 +7,6 @@ this file is the deliberate workaround.)
 
 ## Open
 
-- [ ] **Dependency-audit watch (from weekly-maintenance 2026-06-15; rechecked 2026-06-23)** —
-      `pnpm audit` now reports **2 moderate** advisories, both **transitive dev/test tooling**
-      (none in runtime deps, nothing shipped to prod) and both via `markdownlint-cli2`:
-      `js-yaml` ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68),
-      patched `>=4.1.2`) and `markdown-it`
-      ([GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq), `>=14.1.2`).
-      Both clear once `markdownlint-cli2` bumps its own transitives; decide whether to wait
-      for upstream or add `pnpm.overrides` pins (overrides go in `pnpm-workspace.yaml`, keep
-      lockstep with package.json). _Resolved since 2026-06-15:_ the `form-data` **HIGH**
-      (GHSA-hmw2-7cc7-3qxx, via `cypress` / `wait-on>axios`) has cleared upstream, and
-      **biome 2.5.0** was adopted (schema 2.5.0 + `preset: recommended`, commit `3fa9400b`).
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
       override automation + grouped dep updates (Dependabot can't do those). Replaces
       Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of
@@ -51,6 +40,15 @@ this file is the deliberate workaround.)
 
 Terse log — newest first. Full detail lives in the `project_*` memory files.
 
+- [x] **Dependency-audit watch: 2 moderate alerts cleared** _(2026-06-23, #85)_ — the two
+      transitive dev-tooling quadratic-DoS advisories pulled via `markdownlint-cli2@0.22.1`
+      (latest, which pins both exactly so no upstream bump was possible) fixed with
+      `pnpm-workspace.yaml` overrides: `js-yaml ^4.2.0`
+      ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)) +
+      `markdown-it ^14.2.0`
+      ([GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq)); `pnpm audit`
+      → 0. Earlier: the `form-data` HIGH cleared upstream + biome 2.5.0 adopted. Ongoing audit
+      watch continues via the `weekly-maintenance` routine.
 - [x] **Phase 4 CI: e2e + branch protection** _(2026-06-23)_ — Cypress e2e wired into
       `ci.yml` as a parallel `e2e` job (Postgres service container, runner-generated
       `.env.test.local`, migrate→seed→`cy:e2e`; PR #80, green ~3m), and `main` branch

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   esbuild: ^0.28.1
   vite: ^7.3.5
   postcss: ^8.5.15
+  js-yaml: ^4.2.0
+  markdown-it: ^14.2.0
 
 importers:
 
@@ -118,7 +120,7 @@ importers:
         version: 6.17.1
       markdownlint-cli2:
         specifier: ^0.22.1
-        version: 0.22.1
+        version: 0.22.1(supports-color@8.1.1)
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -127,7 +129,7 @@ importers:
         version: 6.1.3
       start-server-and-test:
         specifier: ^3.0.11
-        version: 3.0.11
+        version: 3.0.11(supports-color@8.1.1)
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -139,7 +141,7 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@6.0.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.1.1(supports-color@8.1.1)(typescript@6.0.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@28.1.0)(vite@7.3.5(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -2200,8 +2202,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -2362,8 +2364,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdownlint-cli2-formatter-default@0.0.6:
@@ -4155,7 +4157,7 @@ snapshots:
   acorn@8.17.0:
     optional: true
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -4214,11 +4216,11 @@ snapshots:
 
   axe-core@4.12.1: {}
 
-  axios@1.18.0(debug@4.4.3):
+  axios@1.18.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -4650,7 +4652,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -4783,9 +4785,9 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -4886,7 +4888,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -5060,7 +5062,7 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -5069,27 +5071,27 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.22.1):
+  markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.22.1(supports-color@8.1.1)):
     dependencies:
-      markdownlint-cli2: 0.22.1
+      markdownlint-cli2: 0.22.1(supports-color@8.1.1)
 
-  markdownlint-cli2@0.22.1:
+  markdownlint-cli2@0.22.1(supports-color@8.1.1):
     dependencies:
       globby: 16.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
-      markdown-it: 14.1.1
-      markdownlint: 0.40.0
-      markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.1)
+      markdown-it: 14.2.0
+      markdownlint: 0.40.0(supports-color@8.1.1)
+      markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.1(supports-color@8.1.1))
       micromatch: 4.0.8
       smol-toml: 1.6.1
     transitivePeerDependencies:
       - supports-color
 
-  markdownlint@0.40.0:
+  markdownlint@0.40.0(supports-color@8.1.1):
     dependencies:
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-core-commonmark: 2.0.3
       micromark-extension-directive: 4.0.0
       micromark-extension-gfm-autolink-literal: 2.1.0
@@ -5262,7 +5264,7 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@8.1.1):
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@8.1.1)
@@ -5732,7 +5734,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  start-server-and-test@3.0.11:
+  start-server-and-test@3.0.11(supports-color@8.1.1):
     dependencies:
       arg: 5.0.2
       check-more-types: 2.24.0
@@ -5740,7 +5742,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 2.0.3
       tree-kill: 1.2.2
-      wait-on: 9.0.10(debug@4.4.3)
+      wait-on: 9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5912,7 +5914,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-tsconfig-paths@6.1.1(supports-color@8.1.1)(typescript@6.0.3)(vite@7.3.5(@types/node@26.0.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       globrex: 0.1.2
@@ -5974,9 +5976,9 @@ snapshots:
       xml-name-validator: 5.0.0
     optional: true
 
-  wait-on@9.0.10(debug@4.4.3):
+  wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      axios: 1.18.0(debug@4.4.3)
+      axios: 1.18.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       joi: 18.2.3
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,5 +17,10 @@ overrides:
   esbuild: ^0.28.1
   vite: ^7.3.5
   postcss: ^8.5.15
+  # Force patched transitive deps of markdownlint-cli2 (dev-only quadratic-complexity DoS fixes).
+  # markdownlint-cli2@0.22.1 (latest) pins the vulnerable versions exactly, so an override is required.
+  # GHSA-h67p-54hq-rp68 (js-yaml >=4.2.0), GHSA-6v5v-wf23-fmfq (markdown-it >=14.2.0).
+  js-yaml: ^4.2.0
+  markdown-it: ^14.2.0
 
 sideEffectsCache: false


### PR DESCRIPTION
## Summary

Resolves the **2 moderate Dependabot alerts** on `main`, both **dev-scope** quadratic-complexity DoS issues:

| Alert | Package | Was | Now | Advisory |
| --- | --- | --- | --- | --- |
| [#28](https://github.com/andrewpetersondev/nextjs-dashboard/security/dependabot/28) | `markdown-it` | 14.1.1 | **14.2.0** | [GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq) — smartquotes DoS |
| [#26](https://github.com/andrewpetersondev/nextjs-dashboard/security/dependabot/26) | `js-yaml` | 4.1.1 | **4.2.0** | [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) — merge-key alias DoS |

### Why an override rather than a dependency bump

Both packages are pulled in **only** by `markdownlint-cli2@0.22.1` (our Markdown linter), which is already the latest release and **pins both to the vulnerable versions exactly**. There's no upstream version to upgrade to, so the fix forces the patched minors via pnpm `overrides`. Both bumps are semver-minor and carry only the DoS fix.

### Where the override lives

Added to `pnpm-workspace.yaml` (alongside the existing `esbuild`/`vite`/`postcss` overrides), **not** `package.json` — pnpm 11 no longer reads the `pnpm.overrides` field from `package.json`.

### Real-world exposure

Low: the only thing this linter ever parses is the repo's own Markdown, and it's dev-only — nothing reaches the production build. Fixing it anyway to clear the alerts and keep the dependency tree clean.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor (no behaviour change)
- [ ] Chore / tooling / docs

## How it was tested

- [x] `pnpm md:check` (markdownlint-cli2 + dprint) — passes, 0 errors, with the patched deps
- [x] `pnpm why markdown-it` / `pnpm why js-yaml` — both resolve to the patched versions
- [ ] `pnpm test` (unit) — not applicable (dev-tooling dependency only)
- [ ] `pnpm cy:e2e` (end-to-end) — not applicable

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (n/a — inline rationale comment added in `pnpm-workspace.yaml`)
- [x] Focused change — preserves existing patterns and user-authored work

<sub>Note: the pre-existing `typescript`/`tsconfck` peer-dependency warning is unrelated to this change and unchanged.</sub>