### PR TITLE
docs: add /ship command, shell-environment guidance, and CLAUDE.md sync

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,39 @@
+---
+description: Ship the current branch — validate, commit, push, open a focused PR, then reconcile BACKLOG/memory
+allowed-tools: Bash(pnpm check:fast), Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git rev-parse:*), Bash(git log:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh run:*), Edit, Write
+---
+
+End-to-end PR loop for this repo. Complements (does not replace) `/check-full`, which only validates, and the generic
+`commit-push-pr` skill, which doesn't know this repo's gate, branch safety, or `BACKLOG.md`. Optional `$ARGUMENTS` is the
+scope/summary to use for the commit and PR title.
+
+Run these steps in order. If a step's precondition fails, STOP and report — do not push ahead.
+
+1. **Branch safety.** Check `git rev-parse --abbrev-ref HEAD` and `git rev-parse --show-toplevel`. Abort if the branch is
+   `main`/`master`, or if the toplevel is the primary checkout rather than a path under `.claude/worktrees/`. This command
+   only ships from a worktree feature branch — never commit to main.
+
+2. **Validate (hard gate).** Run `pnpm check:fast` (Biome + Markdown + typecheck + typegen + drift). If anything fails,
+   STOP, report failures with `file:line`, and do not commit. Do not run the unit/e2e suite locally — that's CI's job in
+   step 6 (e2e needs Docker + `.env.test.local`).
+
+3. **Review the diff.** Run `git status` and `git diff`. Summarize what actually changed. Stage with `git add -A`, or
+   narrower if there's unrelated noise — ask before bundling unrelated changes into one PR.
+
+4. **Commit.** One focused commit, conventional-commit style. Use `$ARGUMENTS` as the scope/summary when provided. End the
+   message with:
+
+   `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+
+5. **Push & open PR.** `git push -u origin HEAD`, then `gh pr create` with a concise title and a body that summarizes the
+   change and references the backlog item. End the body with the 🤖 Generated-with footer. Never force-push.
+
+6. **Watch CI.** Poll `gh pr checks` until the required checks settle. Report green/red plainly. If red, surface the
+   failing job's actual log — do not pipe it through `tail`/`head` (a passing pipe can hide a failing command; see
+   AGENTS.md). Don't block indefinitely: report status and hand the decision back to me.
+
+7. **Reconcile (the step nothing else does).** Mark the shipped item done in `BACKLOG.md`, and update `memory/` or `docs/`
+   only if this change moved project state. Keep these edits small and factual.
+
+8. **Stay safe.** Never delete branches/worktrees, force-push, or run destructive git/DB commands — those require my
+   explicit go-ahead, and several are blocked outright by `.claude/settings.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,17 @@ the files you are touching.
 - Coverage (unit lane): `pnpm test:coverage`
 - E2E tests: `pnpm cy:e2e`
 
+## Shell environment
+
+Development happens on macOS with `zsh`. Some GNU/Linux idioms are missing or behave differently — don't assume them:
+
+- `timeout` is not installed. Don't wrap commands in it; to wait on CI, poll `gh run watch` / `gh pr checks` directly.
+- bash-only builtins (e.g. `mapfile`) aren't in `zsh`. Avoid them in one-off commands, or they fail silently.
+- Don't pipe a command you care about through `tail`/`head` — the pipe reports the _last_ command's exit code and hides
+  an upstream failure (a green-looking `head` over a failing test run). Check the raw exit code, or write to a file and read it.
+- Prefer targeted single commands over long compound pipelines. Several destructive/compound forms are blocked by
+  `.claude/settings.json` and will simply fail, so build them up granularly and confirm before anything destructive.
+
 ## Safety and context
 
 - Do not read, print, or commit local environment files such as `.env*.local`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,18 @@ Also consult relevant detailed project standards in `docs/standards/`.
 
 Project-level slash commands are defined in `.claude/commands/`:
 
-| Command       | Runs                                                                                  |
-| ------------- | ------------------------------------------------------------------------------------- |
-| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)         |
-| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only) |
-| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)      |
-| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue          |
-| `/test`       | `pnpm test` — unit tests only (report-only)                                           |
-| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                     |
-| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)              |
+| Command       | Runs                                                                                   |
+| ------------- | -------------------------------------------------------------------------------------- |
+| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)          |
+| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)  |
+| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)       |
+| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue           |
+| `/test`       | `pnpm test` — unit tests only (report-only)                                            |
+| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                      |
+| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)               |
+| `/ship`       | gate on `pnpm check:fast`, commit, push, open a PR, watch CI, reconcile BACKLOG/memory |
 
-Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit).
+Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit). `/ship` is the one command that writes git history — it commits, pushes, and opens a PR, and only ever runs from a worktree branch, never `main`.
 
 ### Markdown tooling
 


### PR DESCRIPTION
## What

- **New `/ship` command** (`.claude/commands/ship.md`) — an end-to-end PR loop tailored to this repo: branch-safety (worktree only, never `main`), gate on `pnpm check:fast`, focused commit, push, `gh pr create`, CI watch, then reconcile `BACKLOG.md` + memory/docs. Complements `/check-full` (validate-only) and the generic `commit-push-pr` skill.
- **AGENTS.md → Shell environment** — documents macOS/zsh footguns that recurred in practice: no `timeout`, no `mapfile`, the `tail`/`head` exit-code mask, prefer granular commands.
- **CLAUDE.md** — slash-command table synced with the new `/ship` row + a note that it is the one history-writing command.

## Why

Sourced from a `/insights` report that surfaced the repeating implement → validate → PR → reconcile-backlog loop and recurring macOS/zsh command failures. Self-hosted: this PR was opened by the new `/ship` command on its first run.

## Validation

`pnpm check:fast` green locally (Biome 608 files, Markdown 78 files, typecheck, typegen, migration-drift OK). Full unit + e2e run in CI.
