### PR TITLE
docs: reorder /ship (reconcile before commit) + dedupe CLAUDE.md vs AGENTS.md

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: Ship the current branch — validate, commit, push, open a focused PR, then reconcile BACKLOG/memory
+description: Ship the current branch — review, reconcile BACKLOG/docs, validate, commit, push, open a PR, watch CI
 allowed-tools: Bash(pnpm check:fast), Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(git rev-parse:*), Bash(git log:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(gh pr checks:*), Bash(gh run:*), Edit, Write
 ---
 
@@ -13,27 +13,29 @@ Run these steps in order. If a step's precondition fails, STOP and report — do
    `main`/`master`, or if the toplevel is the primary checkout rather than a path under `.claude/worktrees/`. This command
    only ships from a worktree feature branch — never commit to main.
 
-2. **Validate (hard gate).** Run `pnpm check:fast` (Biome + Markdown + typecheck + typegen + drift). If anything fails,
-   STOP, report failures with `file:line`, and do not commit. Do not run the unit/e2e suite locally — that's CI's job in
-   step 6 (e2e needs Docker + `.env.test.local`).
+2. **Review the diff.** Run `git status` and `git diff` to see exactly what you're about to ship, and summarize it. Flag
+   any unrelated noise and ask before bundling unrelated changes into one PR.
 
-3. **Review the diff.** Run `git status` and `git diff`. Summarize what actually changed. Stage with `git add -A`, or
-   narrower if there's unrelated noise — ask before bundling unrelated changes into one PR.
+3. **Reconcile — do this _before_ committing, so it lands in the same PR.** If the change closes a `BACKLOG.md` item, mark
+   it done; update `memory/` or `docs/` only if project state actually moved. Keep edits small and factual. If nothing
+   needs reconciling, say so and move on — don't invent entries. (This step is the reason `/ship` exists; running it the
+   first time proved it must come before the commit, not after.)
 
-4. **Commit.** One focused commit, conventional-commit style. Use `$ARGUMENTS` as the scope/summary when provided. End the
-   message with:
+4. **Validate (hard gate).** Run `pnpm check:fast` (Biome + Markdown + typecheck + typegen + drift) — this now also covers
+   the reconcile edits from step 3. If anything fails, STOP, report failures with `file:line`, and do not commit. Don't run
+   the unit/e2e suite locally; that's CI's job in step 7 (e2e needs Docker + `.env.test.local`).
+
+5. **Commit.** Stage the change set (code + reconcile edits), then make one focused commit, conventional-commit style. Use
+   `$ARGUMENTS` as the scope/summary when provided. End the message with:
 
    `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
 
-5. **Push & open PR.** `git push -u origin HEAD`, then `gh pr create` with a concise title and a body that summarizes the
-   change and references the backlog item. End the body with the 🤖 Generated-with footer. Never force-push.
+6. **Push & open PR.** `git push -u origin HEAD`, then `gh pr create` with a concise title and a body that summarizes the
+   change and references any backlog item. End the body with the 🤖 Generated-with footer. Never force-push.
 
-6. **Watch CI.** Poll `gh pr checks` until the required checks settle. Report green/red plainly. If red, surface the
+7. **Watch CI.** Poll `gh pr checks` until the required checks settle. Report green/red plainly. If red, surface the
    failing job's actual log — do not pipe it through `tail`/`head` (a passing pipe can hide a failing command; see
    AGENTS.md). Don't block indefinitely: report status and hand the decision back to me.
-
-7. **Reconcile (the step nothing else does).** Mark the shipped item done in `BACKLOG.md`, and update `memory/` or `docs/`
-   only if this change moved project state. Keep these edits small and factual.
 
 8. **Stay safe.** Never delete branches/worktrees, force-push, or run destructive git/DB commands — those require my
    explicit go-ahead, and several are blocked outright by `.claude/settings.json`.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -40,6 +40,14 @@ this file is the deliberate workaround.)
 
 Terse log — newest first. Full detail lives in the `project_*` memory files.
 
+- [x] **`/ship` command + insights-report tooling docs** _(2026-06-23, #86 + reorder follow-up)_ —
+      added `.claude/commands/ship.md` (end-to-end PR loop: branch-safety → review → reconcile →
+      `check:fast` gate → commit → push → PR → CI-watch; worktree-only), an AGENTS.md
+      "Shell environment" section (macOS/zsh footguns: no `timeout`/`mapfile`, the `tail`/`head`
+      exit-code mask), and CLAUDE.md workflow/git-safety/worktree context from the report blocks,
+      deduped against AGENTS.md. Sourced from a `/insights` report; its
+      first run (#86) exposed a step-order bug — reconcile ran after the commit — fixed in the
+      follow-up so doc/backlog updates land in the same PR.
 - [x] **Dependency-audit watch: 2 moderate alerts cleared** _(2026-06-23, #85)_ — the two
       transitive dev-tooling quadratic-DoS advisories pulled via `markdownlint-cli2@0.22.1`
       (latest, which pins both exactly so no upstream bump was possible) fixed with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,7 @@ Never delete branches/worktrees or run destructive DB/git commands without expli
 
 ## Worktrees
 
-This project uses MANY worktrees, not a single checkout. Assume branch-per-architecture and a multi-worktree workflow when reasoning about branches, env files, and isolation. Claude Code checks out work in a git worktree under `.claude/worktrees/`; changes committed there go to a separate branch and do not affect `main` until a PR is merged.
-
-## Environment
-
-This is a macOS/zsh environment: `timeout` and bash `mapfile` are unavailable, and shell access to env/secret files is often blocked. Use targeted single commands instead of compound shell pipelines, and poll CI directly rather than wrapping in `timeout`.
+This project runs in git worktrees under `.claude/worktrees/`, not a single checkout — work committed there lives on a separate branch and does not touch `main` until a PR merges. Expect **multiple worktrees at once**: today usually one per Claude Code session, with the intended direction being branch-per-architecture lanes for running several sessions in parallel. Reason about branches, env files, and isolation with that in mind. (Shell/OS specifics live in `AGENTS.md` → "Shell environment".)
 
 ## Claude-specific context
 
@@ -25,16 +21,16 @@ This is a macOS/zsh environment: `timeout` and bash `mapfile` are unavailable, a
 
 Project-level slash commands are defined in `.claude/commands/`:
 
-| Command       | Runs                                                                                   |
-| ------------- | -------------------------------------------------------------------------------------- |
-| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)          |
-| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)  |
-| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)       |
-| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue           |
-| `/test`       | `pnpm test` — unit tests only (report-only)                                            |
-| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                      |
-| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)               |
-| `/ship`       | gate on `pnpm check:fast`, commit, push, open a PR, watch CI, reconcile BACKLOG/memory |
+| Command       | Runs                                                                                         |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                |
+| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)        |
+| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)             |
+| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                 |
+| `/test`       | `pnpm test` — unit tests only (report-only)                                                  |
+| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                            |
+| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                     |
+| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI |
 
 Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit). `/ship` is the one command that writes git history — it commits, pushes, and opens a PR, and only ever runs from a worktree branch, never `main`.
 


### PR DESCRIPTION
## What

Follow-up to #86, opened by the **corrected** `/ship` on its first run.

- **`/ship` reorder** — reconcile moves to step 3 (before the commit); the validate gate follows it so `pnpm check:fast` also covers reconcile edits. Running `/ship` the first time (#86) exposed the bug: reconcile-after-commit means `BACKLOG.md`/doc updates cannot land in the same PR without a second commit + CI cycle.
- **CLAUDE.md dedupe** — drop `## Environment`, which duplicated the `## Shell environment` section AGENTS.md gained in #86 (CLAUDE.md already says "Follow the shared repository instructions in `AGENTS.md`"). Reframe `## Worktrees` as a direction — branch-per-architecture intent kept, since parallel multi-session is a real goal — with a pointer to AGENTS.md for shell/OS specifics.
- **`/ship` table row** in CLAUDE.md updated to the new step order.
- **BACKLOG.md** — Done-log entry for the whole insights-report tooling arc.

## Validation

`pnpm check:fast` green locally (Biome 608 files, Markdown 78 files, typecheck, typegen, migration-drift OK). Full unit + e2e run in CI.
