### PR TITLE
feat(claude): /clean-worktrees command + stale-worktree session-start reminder

### DIFF
--- a/.claude/commands/clean-worktrees.md
+++ b/.claude/commands/clean-worktrees.md
@@ -1,0 +1,56 @@
+---
+description: Prune stale worktrees + merged branches — find [gone]/merged/empty lanes, auto-remove only CLEAN worktrees, never touch this session or main, then hand you a ready-to-run branch-delete block.
+allowed-tools: Bash(git fetch:*), Bash(git worktree list:*), Bash(git worktree remove:*), Bash(git branch -vv:*), Bash(git branch --list:*), Bash(git status:*), Bash(git -C:*), Bash(git rev-parse:*), Bash(git rev-list:*), Bash(git merge-base:*), Bash(git log:*), Bash(gh pr list:*)
+---
+
+Prune stale git worktrees and the branches behind them, safely. This repo runs many parallel Claude Code
+sessions under `.claude/worktrees/`, so merged and abandoned lanes pile up. Remove only what is provably
+safe; report everything else instead of forcing it.
+
+Two hard rules, no exceptions:
+
+- **Never** pass `--force` to `git worktree remove`. A worktree that refuses to remove has changes — surface
+  them, don't clobber them.
+- **Never** run `git branch -d` or `git branch -D` yourself. Branch deletion is intentionally denied in
+  `.claude/settings.json` (the project's "confirm before delete" guard). Instead, emit the exact delete
+  commands in step 6 for the user to run in their own terminal.
+
+Run these steps in order.
+
+1. **Establish the off-limits set.** Run `git rev-parse --show-toplevel` (this session's worktree) and
+   `git rev-parse --abbrev-ref HEAD`. These are OFF LIMITS and must be skipped everywhere below:
+   - this session's worktree and its branch,
+   - the primary checkout (the path with no `.claude/worktrees/` segment),
+   - `main` / `master`,
+   - any `archive/*` branch.
+
+2. **Refresh and inventory.** Run `git fetch origin --quiet`, then `git worktree list` and `git branch -vv`.
+   Record which branches show `[... : gone]` (upstream deleted) and which worktree (if any) holds each branch.
+
+3. **Classify every candidate branch** (all branches except the off-limits set). A branch is **SAFE** only if
+   at least one of these holds:
+   - `gh pr list --state merged --head <branch> --json number` returns a merged PR, **or**
+   - `git rev-list --count origin/main..<branch>` is `0` (it has no commits that aren't already in main).
+
+   A branch that is `[gone]` but has unmerged commits and **no** merged PR is **NOT safe** — its remote was
+   deleted without merging, so it may be abandoned work. List it under "needs your call" and never delete it.
+
+4. **Remove clean worktrees.** For each SAFE branch that is checked out in a worktree:
+   - Run `git -C <worktree-path> status --porcelain`.
+   - Empty output → clean → `git worktree remove <worktree-path>`.
+   - Any output → DIRTY → skip it. Capture the file list for the report. Do **not** use `--force`.
+
+5. **Leave worktree-held branches' deletes for after removal.** A branch can't be deleted while a worktree
+   holds it, so only branches with no (remaining) worktree are eligible for the delete block.
+
+6. **Emit the branch-delete block.** For every SAFE branch that no longer has a worktree, output a single
+   fenced ```bash block the user can paste, one `git branch -d <branch>` per line. Add a short note: if `-d`
+   refuses for a branch you proved merged in step 3 (squash/merge-commit cases), it's safe to re-run that one
+   line with `-D`. Do not run these yourself.
+
+7. **Report.** A short summary:
+   - **Removed** — worktrees you removed (paths) + branches now queued for deletion.
+   - **Needs your call — dirty** — worktrees skipped, with the blocking files.
+   - **Needs your call — possibly unmerged** — `[gone]` branches with unmerged work and no merged PR.
+
+   End with a fresh `git worktree list` so the result is visible.

--- a/.claude/hooks/stale-worktrees.sh
+++ b/.claude/hooks/stale-worktrees.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SessionStart hook — read-only nudge about stale worktree lanes.
+#
+# Flags worktrees whose branch is either an "empty lane" (no commits beyond
+# origin/main) or has a deleted upstream ([gone]). Skips this session's own
+# worktree, main/master, and archive/* branches. Prints nothing when clean,
+# so it stays quiet unless there's actually something to prune.
+#
+# Deliberately offline (no `git fetch`, no `gh`) so it never slows session
+# start or hangs on the network — it reads the last-fetched refs. Run
+# /clean-worktrees for the authoritative, network-checked pass.
+
+set -uo pipefail
+
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+current="$root"
+
+stale=""
+wt=""
+while IFS= read -r line; do
+	case "$line" in
+	"worktree "*)
+		wt="${line#worktree }"
+		;;
+	"branch "*)
+		br="${line#branch }"
+		br="${br#refs/heads/}"
+		# Skip the session's own worktree and protected branches.
+		[ "$wt" = "$current" ] && continue
+		case "$br" in
+		main | master | archive/*) continue ;;
+		esac
+		# Empty/merged lane: nothing on this branch is absent from origin/main.
+		ahead=$(git rev-list --count "origin/main..$br" 2>/dev/null || echo x)
+		# Upstream gone: tracking ref configured but its remote ref is missing.
+		gone=no
+		if up=$(git rev-parse --abbrev-ref --symbolic-full-name "$br@{upstream}" 2>/dev/null); then
+			git rev-parse --verify --quiet "refs/remotes/$up" >/dev/null 2>&1 || gone=yes
+		fi
+		if [ "$ahead" = "0" ] || [ "$gone" = "yes" ]; then
+			stale="${stale}  - ${br}"$'\n'
+		fi
+		;;
+	"")
+		wt=""
+		;;
+	esac
+done < <(git worktree list --porcelain 2>/dev/null)
+
+if [ -n "$stale" ]; then
+	printf 'Stale worktree lanes (merged or empty, not this session):\n'
+	printf '%s' "$stale"
+	printf 'Run /clean-worktrees to prune them safely.\n'
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stale-worktrees.sh\"",
+						"type": "command"
+					}
+				]
+			}
+		]
+	},
 	"permissions": {
 		"allow": ["Bash(*)", "Read(./**)", "Write(./**)", "Edit(./**)"],
 		"deny": [

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -40,6 +40,15 @@ this file is the deliberate workaround.)
 
 Terse log — newest first. Full detail lives in the `project_*` memory files.
 
+- [x] **Worktree/branch cleanup tooling** _(2026-06-23, #88)_ — added a `/clean-worktrees`
+      command (`.claude/commands/clean-worktrees.md`): fetch → classify `[gone]`/merged/empty
+      lanes (verified via `gh` PR state or `ahead=0`) → auto-remove only **clean** worktrees
+      (never `--force`) → emit a paste-ready `git branch -d` block (branch deletion stays denied
+      in `settings.json`, so the human runs it) → report. Skips the current session, `main`, and
+      `archive/*`. Plus a read-only `SessionStart` hook (`.claude/hooks/stale-worktrees.sh`, wired
+      in `settings.json`) that nudges when stale lanes exist and stays silent when clean. Also
+      fixes the `/clean_gone` plugin command's latent bug: it greps `git branch -v`, which never
+      shows `[gone]` (needs `-vv`).
 - [x] **`/ship` command + insights-report tooling docs** _(2026-06-23, #86 + reorder follow-up)_ —
       added `.claude/commands/ship.md` (end-to-end PR loop: branch-safety → review → reconcile →
       `check:fast` gate → commit → push → PR → CI-watch; worktree-only), an AGENTS.md


### PR DESCRIPTION
## What

Adds tooling to automate the stale-worktree/branch cleanup that piles up when
running many parallel Claude Code sessions under `.claude/worktrees/`.

- **`/clean-worktrees` command** (`.claude/commands/clean-worktrees.md`) — one
  command does the whole chore: `git fetch`, classify every lane as
  `[gone]` / merged / empty, **verify** each is actually merged (via `gh` PR
  state or `ahead=0` over `origin/main`), auto-remove only **clean** worktrees
  (never `--force`), then emit a paste-ready `git branch -d` block for the
  human to run. Skips the current session's worktree, `main`/`master`, and
  `archive/*`.
- **`SessionStart` reminder hook** (`.claude/hooks/stale-worktrees.sh`, wired
  into `.claude/settings.json`) — read-only, offline (no `fetch`/`gh`, so it
  never slows session start), and **silent when clean**. When stale lanes
  exist it prints a one-line nudge to run `/clean-worktrees`.
- **`BACKLOG.md`** — Done-log entry.

## Why

This was a recurring manual chore — inspecting `git worktree list` / `git
branch -vv`, confirming each branch's PR merged, removing worktrees, and
deleting branches by hand every session. The command encodes the safe
procedure; the hook removes the "remember to do it" burden.

## Design note for reviewers

Branch deletion (`git branch -d/-D`) stays **hard-denied** in
`.claude/settings.json` — a deliberate "confirm before delete" guard. So the
command automates the *analysis* and *worktree removal* (the tedious,
error-prone parts) but deliberately does **not** delete branches itself; it
hands back a ready-to-run block the user executes in their own terminal. That
keeps the human as the explicit confirmer for every branch deletion.

Worktree removal is intentionally automated (it's not denied, only `rm -rf`
is) and is safe-by-construction here: it refuses on any uncommitted/untracked
changes rather than forcing.

## Verification

- `pnpm check:fast` green (Biome + Markdown + typecheck + typegen + migration-drift).
- Hook tested: silent on a clean repo; parse + `ahead=0` predicate confirmed to
  flag empty lanes; confirmed it skips `main` and the current session.
- Also fixes a latent bug in the existing `/clean_gone` plugin command, which
  greps `git branch -v` (never shows `[gone]`; needs `-vv`).
