### PR TITLE
docs: document the develop/promote branch model + CI split

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,12 @@ folder is for the cross-cutting, project-wide docs.
 | ------------------------ | ----------------------------------------------------------------------------- |
 | [testing.md](testing.md) | "How do I run the unit (Vitest) and E2E (Cypress) suites, locally and in CI?" |
 
+## Branching, CI & releases
+
+| Doc                                                    | The question it answers                                                                         |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| [branching-and-releases.md](branching-and-releases.md) | "Which branch do I work on, how does a change reach production, and what CI runs at each step?" |
+
 ## Build tooling & configuration
 
 | Doc                                                            | The question it answers                                                                                         |

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -1,0 +1,95 @@
+# Branching & releases
+
+> The question this answers: _"Which branch do I work on, how does a change reach
+> production, and what CI runs at each step?"_ The visual companion is
+> [diagrams/branch-and-ci-flow.md](diagrams/branch-and-ci-flow.md).
+
+## Why this shape
+
+This repo uses a two-tier branch model — `feature → develop → main` — for three
+reasons:
+
+1. **Parallel work.** Several Claude sessions (or you, across tasks) can each work
+   on their own branch and integrate through `develop` without every merge touching
+   production.
+2. **A clean production face.** `main` is the portfolio/production branch. Half-done
+   work never lands there — it accumulates on `develop` until a deliberate release.
+3. **Cheaper feedback.** The slow end-to-end suite and the Vercel production deploy
+   happen once per _release_, not on every merge.
+
+## The branches
+
+| Branch           | Role                             | How code lands                                  |
+| ---------------- | -------------------------------- | ----------------------------------------------- |
+| `feature` / lane | one unit of work, one session    | its own branch → PR into `develop`              |
+| `develop`        | **default** branch · integration | only through a PR                               |
+| `main`           | production · promote-only        | never directly — only via a `develop → main` PR |
+
+`develop` is the repository's **default branch**, so new clones, new worktrees, and
+`gh pr create` all target it automatically.
+
+## Everyday flow — shipping to `develop`
+
+1. Branch off `develop` (a worktree per session is the norm — see the Worktrees
+   section in [../CLAUDE.md](../CLAUDE.md)).
+2. Make your change.
+3. Open a PR into `develop`. The `/ship` command runs this end-to-end and targets
+   `develop` automatically now that it's the default branch.
+4. The fast **`Lint & type-check`** gate runs (~1 min) — the only required check on
+   `develop`. Green → merge.
+
+No end-to-end suite runs here, by design, so lane work stays fast.
+
+## Release flow — promoting `develop → main`
+
+When `develop` is in a coherent state you want live:
+
+1. Open a PR with **base `main`, head `develop`**:
+   `gh pr create --base main --head develop`.
+2. This PR runs the **full gate**: `Lint & type-check` **and** the slow
+   `E2E (Cypress)` suite. Both are required on `main`.
+3. Merge → `main` advances → Vercel builds a **production** deploy.
+
+A `/promote` command to script this step is planned; until then it's the manual
+`gh pr create --base main` above.
+
+## What runs where
+
+CI is one workflow, [`../.github/workflows/ci.yml`](../.github/workflows/ci.yml),
+with two jobs and a per-branch gate:
+
+| Branch    | `Lint & type-check` (fast) | `E2E (Cypress)` (slow) | Vercel            |
+| --------- | -------------------------- | ---------------------- | ----------------- |
+| `develop` | ✅ required                | ⏭ skipped              | preview URL       |
+| `main`    | ✅ required                | ✅ required            | production deploy |
+
+The E2E job is gated in the workflow with
+`if: github.base_ref == 'main' || github.ref == 'refs/heads/main'`. It is required
+on `main` only — never on `develop`, because a _required_ check that gets skipped
+would block the merge.
+
+The required-check policy itself lives in GitHub **rulesets** (`Protect Important
+Branches` → `main`; `Protect develop (integration)` → `develop`), not in this repo.
+If you rename a CI job, update the ruleset's required-status-check contexts or merges
+will silently block.
+
+## Working in parallel (lanes)
+
+The point of `develop` is to let multiple branches integrate cheaply. Two sessions
+collide only when they edit the same files, so parallel-safe "lanes" are slices with
+disjoint footprints:
+
+- **Parallel-safe:** the feature modules
+  `src/modules/{auth,banner,customers,invoices,users}`, docs/diagrams, and isolated
+  chores (deps, tsconfig, fonts).
+- **Single-thread — never parallel-edit:** the shared kernel `src/shared/**` and
+  `src/server/**`. Almost everything imports these, so two sessions touching them
+  will conflict.
+
+A fuller lane map is planned as its own doc.
+
+## Keeping this honest
+
+Like every doc here, this is a **snapshot**. If you change the branch model, a CI
+trigger, or a ruleset, update this file and
+[diagrams/branch-and-ci-flow.md](diagrams/branch-and-ci-flow.md) in the same PR.

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -12,17 +12,18 @@ in a PR, and sitting right next to the code it describes.
 
 ## The diagrams
 
-| File                                                       | The question it answers                                                                   | Diagram type                         |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------ |
-| [c4-architecture.md](c4-architecture.md)                   | "How is the whole system carved into pieces?"                                             | C4 (context → container → component) |
-| [database-erd.md](database-erd.md)                         | "What tables exist and how do they relate?"                                               | Entity-relationship                  |
-| [module-layers.md](module-layers.md)                       | "How is a module layered, and which way do dependencies point?"                           | Layered flowchart                    |
-| [auth-login-flow.md](auth-login-flow.md)                   | "Step by step, what happens when someone logs in?"                                        | Sequence                             |
-| [request-flow-update-user.md](request-flow-update-user.md) | "How does a form submission travel through the layers?"                                   | Sequence                             |
-| [error-handling-flow.md](error-handling-flow.md)           | "How does a failure travel from the database to a red field error — without a `throw`?"   | Sequence + type map                  |
-| [route-authorization.md](route-authorization.md)           | "Before a page renders, what decides whether I'm allowed in?"                             | Sequence + decision                  |
-| [session-lifecycle.md](session-lifecycle.md)               | "What states can a session be in, and what moves it between them?"                        | State machine                        |
-| [dependency-injection.md](dependency-injection.md)         | "How do application contracts and infrastructure implementations actually get connected?" | Component graph                      |
+| File                                                       | The question it answers                                                                       | Diagram type                         |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------ |
+| [c4-architecture.md](c4-architecture.md)                   | "How is the whole system carved into pieces?"                                                 | C4 (context → container → component) |
+| [database-erd.md](database-erd.md)                         | "What tables exist and how do they relate?"                                                   | Entity-relationship                  |
+| [module-layers.md](module-layers.md)                       | "How is a module layered, and which way do dependencies point?"                               | Layered flowchart                    |
+| [auth-login-flow.md](auth-login-flow.md)                   | "Step by step, what happens when someone logs in?"                                            | Sequence                             |
+| [request-flow-update-user.md](request-flow-update-user.md) | "How does a form submission travel through the layers?"                                       | Sequence                             |
+| [error-handling-flow.md](error-handling-flow.md)           | "How does a failure travel from the database to a red field error — without a `throw`?"       | Sequence + type map                  |
+| [route-authorization.md](route-authorization.md)           | "Before a page renders, what decides whether I'm allowed in?"                                 | Sequence + decision                  |
+| [session-lifecycle.md](session-lifecycle.md)               | "What states can a session be in, and what moves it between them?"                            | State machine                        |
+| [dependency-injection.md](dependency-injection.md)         | "How do application contracts and infrastructure implementations actually get connected?"     | Component graph                      |
+| [branch-and-ci-flow.md](branch-and-ci-flow.md)             | "Which branch do I work on, how does a change reach production, and what CI gate runs where?" | Flowchart                            |
 
 ## Pick the question first
 

--- a/docs/diagrams/branch-and-ci-flow.md
+++ b/docs/diagrams/branch-and-ci-flow.md
@@ -1,0 +1,51 @@
+# Branch & CI flow — from a lane branch to production
+
+> The question this answers: _"Which branch do I work on, how does a change reach
+> production, and what CI gate runs at each step?"_ The prose companion is
+> [../branching-and-releases.md](../branching-and-releases.md).
+
+## The two-tier flow
+
+```mermaid
+flowchart LR
+    F["feature / lane branch<br/>(one per session)"]
+    DEV["develop<br/>(default, integration)"]
+    MAIN["main<br/>(production)"]
+    PROD["Vercel production"]
+    PREV["Vercel preview URL"]
+
+    F -->|"open PR — gate: fast check (~1 min)"| DEV
+    DEV -->|"promote PR — gate: fast check + E2E"| MAIN
+    MAIN ==>|"merge, then deploy"| PROD
+    F -.->|"push: preview"| PREV
+    DEV -.->|"push: preview"| PREV
+```
+
+## How to read it
+
+- **`develop` is the default branch** — your day-to-day base. Every feature or
+  lane branch opens a PR into `develop`, gated only by the fast
+  `Lint & type-check` job (Biome + Markdown + type-check + typegen + drift + the
+  DB-free unit lane). Feedback is ~1 minute.
+- **`main` is production, and promote-only.** Code reaches it through a single
+  `develop → main` "promote" PR, which runs the full gate — the fast check **and**
+  the slow `E2E (Cypress)` suite — so the end-to-end tests run once per release
+  instead of on every merge.
+- **Vercel** builds a throwaway **preview** for every branch push (your live WIP
+  URL) and a **production** deploy only when `main` advances. Production redeploys
+  at release cadence, not on every change.
+
+## Where the gates are enforced
+
+The two CI jobs live in [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml);
+which ones are _required_ to merge is enforced by GitHub rulesets:
+
+| Branch    | Required to merge                     | Vercel            |
+| --------- | ------------------------------------- | ----------------- |
+| `develop` | `Lint & type-check`                   | preview URL       |
+| `main`    | `Lint & type-check` + `E2E (Cypress)` | production deploy |
+
+The slow `E2E (Cypress)` job is gated in the workflow with
+`if: github.base_ref == 'main' || github.ref == 'refs/heads/main'`, so it runs only
+for main-targeting work. It is a _required_ check on `main` only — never on
+`develop`, because a required check that gets skipped would block the merge.


### PR DESCRIPTION
Documents the branch-model migration (Phases 1–2, already live on GitHub) so the workflow is discoverable in `docs/`.

## Adds
- **`docs/branching-and-releases.md`** — answers "Which branch do I work on, how does a change reach production, and what CI runs at each step?" Covers the `feature → develop → main` model, the everyday ship-to-develop flow, the develop→main promote flow, the per-branch CI gates + rulesets, and a short parallel-work/lanes pointer.
- **`docs/diagrams/branch-and-ci-flow.md`** — a Mermaid flowchart companion (one question per diagram, per the diagrams README convention).
- Index entries in `docs/README.md` (new "Branching, CI & releases" section) and `docs/diagrams/README.md`.

## Notes
- Docs-only. `pnpm md:check` is green locally.
- The `/promote` command referenced as "planned" is Phase 4; this PR doesn't add it.
- CLAUDE.md / AGENTS.md git-safety wording still says "never directly on main" — accurate but incomplete now that `develop` is the default. Updating that is the next step (Phase 4), kept out of this docs-only PR.
