### PR TITLE
feat(claude): add /promote command + align git-safety docs with the develop model

### DIFF
--- a/.claude/commands/promote.md
+++ b/.claude/commands/promote.md
@@ -1,0 +1,34 @@
+---
+description: Promote develop → main — open the release PR, run the full gate (check + E2E), watch CI, hand the merge back
+allowed-tools: Bash(git fetch:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git rev-list:*), Bash(git diff:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh pr checks:*), Bash(gh run:*)
+---
+
+Open (or reuse) the `develop → main` release PR, gate it on the full CI suite, and hand the merge
+decision back to me. This is the deliberate production release — it never merges `main` itself.
+Complements `/ship` (which PRs feature work into `develop`); `/promote` moves `develop` into production.
+
+Run these in order. If a precondition fails, STOP and report — don't push ahead.
+
+1. **Sync.** `git fetch origin`. Compare against `origin/main` and `origin/develop` so the result is
+   accurate regardless of local branch or worktree state.
+
+2. **Anything to release?** Run `git rev-list --left-right --count origin/main...origin/develop`. If
+   `develop` is not ahead of `main` (the right-hand count is 0), STOP — there is nothing to promote.
+   Otherwise summarize what will ship with `git log --oneline origin/main..origin/develop`, and flag
+   any commit that looks unfinished or unintended.
+
+3. **Reuse or open the PR.** Check for an existing open promote PR with
+   `gh pr list --base main --head develop --state open`. If one exists, reuse it. Otherwise
+   `gh pr create --base main --head develop` with a release title and a body that lists the promoted
+   commits and any BACKLOG items they close. End the body with the 🤖 Generated-with footer.
+
+4. **Watch the full gate.** This PR runs BOTH required checks — `Lint & type-check` and the slow
+   `E2E (Cypress)` suite (E2E runs here because the base is `main`). Poll `gh pr checks` until they
+   settle. Report green/red plainly; if red, surface the failing job's real log — don't pipe it
+   through `tail`/`head` (a passing pipe can hide a failing command; see AGENTS.md).
+
+5. **Hand back the merge.** Do NOT merge. Report that the PR is green and ready, and let me run the
+   production merge myself. On merge, `main` advances and Vercel builds the production deploy.
+
+6. **Stay safe.** Never force-push, never delete branches, and never merge to `main` automatically —
+   those are mine to decide, and several are blocked outright by `.claude/settings.json`.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -10,8 +10,8 @@ scope/summary to use for the commit and PR title.
 Run these steps in order. If a step's precondition fails, STOP and report — do not push ahead.
 
 1. **Branch safety.** Check `git rev-parse --abbrev-ref HEAD` and `git rev-parse --show-toplevel`. Abort if the branch is
-   `main`/`master`, or if the toplevel is the primary checkout rather than a path under `.claude/worktrees/`. This command
-   only ships from a worktree feature branch — never commit to main.
+   `main`/`master`/`develop`, or if the toplevel is the primary checkout rather than a path under `.claude/worktrees/`. This
+   command only ships from a worktree feature branch — never commit directly to the shared `develop`/`main` branches.
 
 2. **Review the diff.** Run `git status` and `git diff` to see exactly what you're about to ship, and summarize it. Flag
    any unrelated noise and ask before bundling unrelated changes into one PR.
@@ -30,8 +30,9 @@ Run these steps in order. If a step's precondition fails, STOP and report — do
 
    `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
 
-6. **Push & open PR.** `git push -u origin HEAD`, then `gh pr create` with a concise title and a body that summarizes the
-   change and references any backlog item. End the body with the 🤖 Generated-with footer. Never force-push.
+6. **Push & open PR.** `git push -u origin HEAD`, then `gh pr create` (base defaults to `develop`, the repo's default
+   branch) with a concise title and a body that summarizes the change and references any backlog item. End the body with
+   the 🤖 Generated-with footer. Never force-push.
 
 7. **Watch CI.** Poll `gh pr checks` until the required checks settle. Report green/red plainly. If red, surface the
    failing job's actual log — do not pipe it through `tail`/`head` (a passing pipe can hide a failing command; see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@ These instructions apply to AI Assistant, Claude, and ChatGPT when working in th
 - Prefer minimal, focused changes and preserve user-authored work.
 - If rules conflict with each other or with common practice, stop and ask for clarification.
 
+## Branching
+
+Work flows through a two-tier model: feature branch → `develop` (the default, integration branch) →
+`main` (production). Open PRs into `develop`; promote `develop → main` as a deliberate release (Claude
+has a `/promote` command for it). Never commit directly to `develop` or `main` — both are protected and
+require a PR. See [`docs/branching-and-releases.md`](docs/branching-and-releases.md).
+
 ## Next.js: ALWAYS read docs before coding
 
 Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,6 +7,11 @@ this file is the deliberate workaround.)
 
 ## Open
 
+- [ ] **Lane map doc (branch-model Phase 5)** — write the parallel-session lane map as its own
+      doc: `src/modules/{auth,banner,customers,invoices,users}` + docs + isolated chores are
+      parallel-safe lanes; `src/shared/**` + `src/server/**` are the single-thread kernel (never
+      parallel-edit). Map existing BACKLOG items onto lanes. The remaining piece of the
+      develop/promote migration. Detail: memory `project_branch_model_migration`.
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
       override automation + grouped dep updates (Dependabot can't do those). Replaces
       Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of
@@ -40,6 +45,15 @@ this file is the deliberate workaround.)
 
 Terse log — newest first. Full detail lives in the `project_*` memory files.
 
+- [x] **Two-tier branch model: `develop` → `main`** _(2026-06-23)_ — reworked the git strategy for
+      parallel multi-session work: `develop` is now the **default** branch (integration), `main` is
+      promote-only (production). GitHub rulesets gate `develop` (`Lint & type-check`) and `main`
+      (`+ E2E (Cypress)`); `ci.yml` split so the slow E2E runs only for main-targeting PRs (#89);
+      branch model + Mermaid diagram documented (#90); Vercel verified (main=production,
+      develop=free staging URL); added the `/promote` command + updated CLAUDE.md/AGENTS.md
+      git-safety wording. Remaining: the lane map (see Open). ⚠️ Rulesets pin required-status-check
+      contexts to the CI job **names** (`Lint & type-check`, `E2E (Cypress)`) — rename a job and
+      merges silently block. Detail: memory `project_branch_model_migration`.
 - [x] **Worktree/branch cleanup tooling** _(2026-06-23, #88)_ — added a `/clean-worktrees`
       command (`.claude/commands/clean-worktrees.md`): fetch → classify `[gone]`/merged/empty
       lanes (verified via `gh` PR state or `ahead=0`) → auto-remove only **clean** worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,11 @@ After completing any backlog item or fix: run the full test suite + typecheck, v
 
 ## Git Safety
 
-Never delete branches/worktrees or run destructive DB/git commands without explicit confirmation. When merging stacked PRs, warn before deleting any branch so changes aren't lost. Always confirm you are operating in a worktree, never directly on main.
+Never delete branches/worktrees or run destructive DB/git commands without explicit confirmation. When merging stacked PRs, warn before deleting any branch so changes aren't lost. Always work from a worktree feature branch — never commit directly to `develop` (the default, integration branch) or `main` (production). Both are protected; code reaches them only through a PR, and `main` only via a deliberate `develop → main` promote (`/promote`).
 
 ## Worktrees
 
-This project runs in git worktrees under `.claude/worktrees/`, not a single checkout — work committed there lives on a separate branch and does not touch `main` until a PR merges. Expect **multiple worktrees at once**: today usually one per Claude Code session, with the intended direction being branch-per-architecture lanes for running several sessions in parallel. Reason about branches, env files, and isolation with that in mind. (Shell/OS specifics live in `AGENTS.md` → "Shell environment".)
+This project runs in git worktrees under `.claude/worktrees/`, not a single checkout — work committed there lives on a separate branch (cut from `develop`, the default) and does not touch the shared `develop`/`main` branches until a PR merges. Expect **multiple worktrees at once**: today usually one per Claude Code session, with the intended direction being branch-per-architecture lanes for running several sessions in parallel. Reason about branches, env files, and isolation with that in mind. The full branch/CI/release model is in [`docs/branching-and-releases.md`](docs/branching-and-releases.md). (Shell/OS specifics live in `AGENTS.md` → "Shell environment".)
 
 ## Claude-specific context
 
@@ -21,18 +21,19 @@ This project runs in git worktrees under `.claude/worktrees/`, not a single chec
 
 Project-level slash commands are defined in `.claude/commands/`:
 
-| Command       | Runs                                                                                         |
-| ------------- | -------------------------------------------------------------------------------------------- |
-| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                |
-| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)        |
-| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)             |
-| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                 |
-| `/test`       | `pnpm test` — unit tests only (report-only)                                                  |
-| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                            |
-| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                     |
-| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI |
+| Command       | Runs                                                                                                 |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                        |
+| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)                |
+| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)                     |
+| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                         |
+| `/test`       | `pnpm test` — unit tests only (report-only)                                                          |
+| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                                    |
+| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                             |
+| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI         |
+| `/promote`    | open the `develop → main` release PR, run the full gate (check + E2E), watch CI, hand the merge back |
 
-Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit). `/ship` is the one command that writes git history — it commits, pushes, and opens a PR, and only ever runs from a worktree branch, never `main`.
+Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit). `/ship` commits, pushes, and opens a PR into `develop` from a worktree feature branch (never `develop`/`main` directly); `/promote` opens the `develop → main` release PR and watches the full gate but never merges `main` itself — that stays a human decision.
 
 ### Markdown tooling
 

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -50,7 +50,8 @@ When `develop` is in a coherent state you want live:
    `E2E (Cypress)` suite. Both are required on `main`.
 3. Merge → `main` advances → Vercel builds a **production** deploy.
 
-A `/promote` command to script this step is planned; until then it's the manual
+The `/promote` command scripts this step — it opens the `develop → main` PR, runs the full gate,
+watches CI, and hands you the merge (it never merges `main` itself). The manual equivalent is the
 `gh pr create --base main` above.
 
 ## What runs where
@@ -72,6 +73,10 @@ The required-check policy itself lives in GitHub **rulesets** (`Protect Importan
 Branches` → `main`; `Protect develop (integration)` → `develop`), not in this repo.
 If you rename a CI job, update the ruleset's required-status-check contexts or merges
 will silently block.
+
+`develop` also has a persistent **staging URL** you can share or test against —
+`https://nextjs-dashboard-git-develop-andrew-petersons-projects-15cc2fda.vercel.app` — which Vercel
+auto-updates on every push to `develop`.
 
 ## Working in parallel (lanes)
 


### PR DESCRIPTION
Phase 4 of the branch-model migration — the tooling + git-safety docs to match the now-live `develop → main` model.

## Adds / changes
- **`.claude/commands/promote.md`** (new) — `/promote` opens the `develop → main` release PR, runs the full gate (`Lint & type-check` + `E2E (Cypress)`), watches CI, and hands the merge back. It never merges `main` itself.
- **`/ship`** — branch-safety now also aborts on `develop` (not just `main`/`master`); PR base clarified as `develop` (the repo default).
- **CLAUDE.md** — Git Safety + Worktrees wording updated for the two-tier model; `/promote` added to the slash-command table.
- **AGENTS.md** — new "Branching" section so the cross-tool rule is explicit (never commit directly to `develop`/`main`).
- **docs/branching-and-releases.md** — `/promote` now documented as existing (not "planned"), plus the free `develop` staging URL.
- **BACKLOG.md** — Done entry for the migration + an Open item for Phase 5 (the lane map).

## Notes
- Docs- and command-only; no app code. `pnpm md:check` is green locally.
- Leaves **Phase 5 (lane map)** as the one remaining piece, now tracked in BACKLOG + memory.
