### PR TITLE
docs: add the lane map for parallel sessions (branch-model Phase 5)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,11 +7,6 @@ this file is the deliberate workaround.)
 
 ## Open
 
-- [ ] **Lane map doc (branch-model Phase 5)** — write the parallel-session lane map as its own
-      doc: `src/modules/{auth,banner,customers,invoices,users}` + docs + isolated chores are
-      parallel-safe lanes; `src/shared/**` + `src/server/**` are the single-thread kernel (never
-      parallel-edit). Map existing BACKLOG items onto lanes. The remaining piece of the
-      develop/promote migration. Detail: memory `project_branch_model_migration`.
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
       override automation + grouped dep updates (Dependabot can't do those). Replaces
       Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of
@@ -51,7 +46,7 @@ Terse log — newest first. Full detail lives in the `project_*` memory files.
       (`+ E2E (Cypress)`); `ci.yml` split so the slow E2E runs only for main-targeting PRs (#89);
       branch model + Mermaid diagram documented (#90); Vercel verified (main=production,
       develop=free staging URL); added the `/promote` command + updated CLAUDE.md/AGENTS.md
-      git-safety wording. Remaining: the lane map (see Open). ⚠️ Rulesets pin required-status-check
+      git-safety wording; the lane map landed (`docs/lane-map.md` + diagram). ⚠️ Rulesets pin required-status-check
       contexts to the CI job **names** (`Lint & type-check`, `E2E (Cypress)`) — rename a job and
       merges silently block. Detail: memory `project_branch_model_migration`.
 - [x] **Worktree/branch cleanup tooling** _(2026-06-23, #88)_ — added a `/clean-worktrees`

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,9 +27,10 @@ folder is for the cross-cutting, project-wide docs.
 
 ## Branching, CI & releases
 
-| Doc                                                    | The question it answers                                                                         |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| [branching-and-releases.md](branching-and-releases.md) | "Which branch do I work on, how does a change reach production, and what CI runs at each step?" |
+| Doc                                                    | The question it answers                                                                            |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| [branching-and-releases.md](branching-and-releases.md) | "Which branch do I work on, how does a change reach production, and what CI runs at each step?"    |
+| [lane-map.md](lane-map.md)                             | "If I want to run several Claude sessions at once, how do I split the work so they don't collide?" |
 
 ## Build tooling & configuration
 

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -84,14 +84,15 @@ The point of `develop` is to let multiple branches integrate cheaply. Two sessio
 collide only when they edit the same files, so parallel-safe "lanes" are slices with
 disjoint footprints:
 
-- **Parallel-safe:** the feature modules
-  `src/modules/{auth,banner,customers,invoices,users}`, docs/diagrams, and isolated
-  chores (deps, tsconfig, fonts).
-- **Single-thread — never parallel-edit:** the shared kernel `src/shared/**` and
-  `src/server/**`. Almost everything imports these, so two sessions touching them
-  will conflict.
+- **Parallel-safe:** the feature modules — `auth`+`users` move together (they import each
+  other), then `customers`, `invoices` (downstream), and `banner` — plus docs/diagrams and
+  isolated chores (deps, tsconfig, fonts).
+- **Single-thread — never parallel-edit:** the shared kernel `src/shared/**`, `src/ui/**`,
+  `src/server/**`, and the centralized `database/schema/**`. Almost everything imports these,
+  so two sessions touching them will conflict.
 
-A fuller lane map is planned as its own doc.
+See [lane-map.md](lane-map.md) for the full lane map — the verified module-coupling graph and
+today's BACKLOG mapped onto lanes.
 
 ## Keeping this honest
 

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -24,6 +24,7 @@ in a PR, and sitting right next to the code it describes.
 | [session-lifecycle.md](session-lifecycle.md)               | "What states can a session be in, and what moves it between them?"                            | State machine                        |
 | [dependency-injection.md](dependency-injection.md)         | "How do application contracts and infrastructure implementations actually get connected?"     | Component graph                      |
 | [branch-and-ci-flow.md](branch-and-ci-flow.md)             | "Which branch do I work on, how does a change reach production, and what CI gate runs where?" | Flowchart                            |
+| [lane-map.md](lane-map.md)                                 | "Which slices can be edited in parallel sessions, and which must stay single-threaded?"       | Flowchart                            |
 
 ## Pick the question first
 

--- a/docs/diagrams/lane-map.md
+++ b/docs/diagrams/lane-map.md
@@ -1,0 +1,45 @@
+# Lane map — what can run in parallel
+
+> The question this answers: _"Which slices of the codebase can be edited in separate sessions at the
+> same time, and which must stay single-threaded?"_ The prose companion (per-lane table + BACKLOG
+> mapping) is [../lane-map.md](../lane-map.md).
+
+## Lanes vs. the single-thread kernel
+
+```mermaid
+flowchart TD
+    subgraph LANES["Parallel-safe lanes — each its own session + worktree"]
+        direction LR
+        AU["auth ⇄ users<br/>(coupled → ONE lane)"]
+        CU["customers"]
+        INV["invoices"]
+        BAN["banner"]
+        DOC["docs / diagrams"]
+        CHO["isolated chores"]
+    end
+
+    subgraph KERNEL["Single-thread zone — at most ONE session at a time"]
+        direction LR
+        SH["src/shared"]
+        UI["src/ui"]
+        SRV["src/server"]
+        DB["database/schema"]
+    end
+
+    INV -.->|consumes| AU
+    INV -.->|consumes| CU
+    LANES ==>|"every lane imports the kernel —<br/>editing it ripples into all of them"| KERNEL
+```
+
+## How to read it
+
+- **Top box = parallel-safe lanes.** Each can be a separate worktree + session because their _edit_
+  footprints don't overlap. `auth` and `users` import each other, so they collapse into one lane;
+  `invoices` reads `auth`/`customers` but edits only itself (downstream).
+- **Bottom box = the kernel.** `shared`, the `ui` design system, `server`, and the centralized
+  `database/schema` are imported by everything, so a change here ripples up into every lane. Edit it in
+  **one** session at a time, and don't run a kernel refactor next to a module lane it will break.
+- **The rule:** lanes collide on shared _edits_, not shared _imports_. Two lanes importing the same
+  kernel file is fine — until both try to change it.
+
+See [../lane-map.md](../lane-map.md) for the per-lane table and today's BACKLOG mapped onto lanes.

--- a/docs/lane-map.md
+++ b/docs/lane-map.md
@@ -1,0 +1,94 @@
+# Lane map — running sessions in parallel
+
+> The question this answers: _"If I want to run several Claude sessions (or tasks) at once, how do I
+> split the work so they don't collide?"_ The visual companion is
+> [diagrams/lane-map.md](diagrams/lane-map.md); the branch mechanics are in
+> [branching-and-releases.md](branching-and-releases.md).
+
+## The one rule
+
+Two sessions collide only when they **edit the same files** — not when they import the same files. A
+"lane" is a slice of work whose **edit footprint** doesn't overlap another lane's. Two lanes can both
+_depend on_ `src/shared/core`; they conflict only if both _change_ it. So parallelizing safely is mostly
+about picking work whose edits land in different places.
+
+## The dependency reality (verified, not assumed)
+
+The codebase has three tiers — the documented rule is `shared/ui → modules → shell → app` (see
+[project-structure.md](project-structure.md)):
+
+- **Shared kernel** — `src/shared/**`, `src/ui/**`, `src/server/**`, and the centralized
+  `database/schema/**`. Almost everything imports these, so an edit here ripples into every lane.
+- **Feature modules** — `src/modules/*`, the domain slices. These are the parallel lanes — but they are
+  **not all independent**:
+
+  | Module      | Coupling (verified via imports)     | Lane                       |
+  | ----------- | ----------------------------------- | -------------------------- |
+  | `auth`      | imports `users` (mutual)            | **one lane with `users`**  |
+  | `users`     | imports `auth` (mutual)             | (same lane as `auth`)      |
+  | `customers` | none                                | standalone lane            |
+  | `banner`    | none                                | standalone lane            |
+  | `invoices`  | reads `auth`, `customers` (one-way) | own lane, but _downstream_ |
+
+  `auth` and `users` import each other, so they must move together as a single lane. `invoices` _reads_
+  `auth` and `customers` but doesn't edit them — it's its own edit footprint, just downstream: fine to
+  run beside the others, with the caveat that if an upstream lane changes a contract `invoices` uses,
+  `invoices` may need a follow-up (CI's type-check catches it at integration).
+
+- **Composition** — `src/app/**`, `src/shell/**`. Thin, route-specific glue at the top of the stack.
+
+## The lanes
+
+| Lane                | Edit footprint                                                      | Parallel?                   |
+| ------------------- | ------------------------------------------------------------------- | --------------------------- |
+| **auth + users**    | `src/modules/auth`, `src/modules/users`                             | ✅ (one lane, both modules) |
+| **customers**       | `src/modules/customers`                                             | ✅                          |
+| **invoices**        | `src/modules/invoices`                                              | ✅ (downstream — see above) |
+| **banner**          | `src/modules/banner`                                                | ✅                          |
+| **docs**            | `docs/**` (stable areas not under active code change)               | ✅                          |
+| **chore**           | one isolated file/config (a dep, `tsconfig`, a font)                | ✅ (if footprints disjoint) |
+| **kernel / schema** | `src/shared/**`, `src/ui/**`, `src/server/**`, `database/schema/**` | ⛔ **single-thread**        |
+
+The kernel row is the exception: cross-cutting changes to shared code, the design system, infra, or the
+DB schema should be **one session at a time**, because everything depends on them. Don't run two kernel
+refactors at once, and don't run a kernel refactor next to a module lane it will break.
+
+## How many at once
+
+The realistic ceiling isn't the kernel or your tokens — it's **your steering bandwidth**. Two or three
+sessions you can actually review and unblock beats five you can't. Start with 2, grow toward ~4 once the
+rhythm is comfortable. Each lane is its own worktree + branch off `develop`, opening its own PR.
+
+## Today's BACKLOG, mapped onto lanes
+
+Most open items are tooling/docs/config rather than feature work, which makes them _very_
+parallel-friendly:
+
+| BACKLOG item                  | Lane                       | Edit footprint                 |
+| ----------------------------- | -------------------------- | ------------------------------ |
+| docs/ consolidation           | docs                       | `docs/standards/**`, `docs/**` |
+| Font experiment (finish/drop) | chore (UI)                 | `src/ui/styles/fonts.ts`       |
+| TSConfig modernization        | chore (config)             | `tsconfig*.json`               |
+| Renovate adoption             | chore (CI/config)          | CI + workspace config          |
+| Integration lane in CI        | chore (CI)                 | `.github/workflows/ci.yml`     |
+| Skills exploration            | research (no code)         | none                           |
+| **Forms taxonomy flattening** | **kernel — single-thread** | `src/shared/forms/**`          |
+
+A clean four-session day right now could be **docs consolidation** + **font experiment** + **TSConfig
+modernization** + **skills exploration** — four near-disjoint footprints. **Forms taxonomy flattening**
+is the one to keep solo: it lives in the shared kernel, so don't pair it with another kernel task.
+
+## The protocol
+
+1. Pick lanes with disjoint edit footprints (use the tables above).
+2. Give each its own worktree + branch off `develop`.
+3. Let each open its own PR into `develop`; the fast `Lint & type-check` gate runs per PR.
+4. If a task must touch the **kernel / schema**, run it **solo** — pause module lanes it could break.
+5. Promote `develop → main` with `/promote` once the integrated set is coherent.
+
+## Keeping this honest
+
+This maps the dependency graph as of now (`auth`⇄`users` coupled; `invoices` downstream of `auth` +
+`customers`; schema centralized in `database/schema/`). If you split a module, add a cross-module
+import, or move the schema, re-derive the coupling — `grep -rho '@/modules/[a-z-]*' src/modules/<m>`
+shows what a module imports.


### PR DESCRIPTION
Phase 5 (final) of the branch-model migration — the doc that actually enables the parallel-session goal that kicked this off.

## Adds
- **`docs/lane-map.md`** — "If I want to run several Claude sessions at once, how do I split the work so they don't collide?" The one rule (lanes collide on shared *edits*, not shared *imports*), the per-lane table, the single-thread kernel, how many to run, and **today's BACKLOG mapped onto lanes**.
- **`docs/diagrams/lane-map.md`** — a Mermaid companion (parallel-safe lanes vs. the single-thread kernel).

## Grounded in the *verified* dependency graph
Not assumed — checked via imports:
- `auth ⇄ users` import each other → **one lane**.
- `invoices` reads `auth` + `customers` (one-way) → its own lane, but downstream.
- `customers`, `banner` → standalone.
- `src/shared`, `src/ui`, `src/server`, and the centralized `database/schema/**` → **single-thread kernel** (everything imports them).

This corrected the branching doc's earlier "all five modules are parallel-safe" oversimplification.

## Reconciliation
- Refines `branching-and-releases.md` "Working in parallel" section + links the map.
- Wires both new docs into `docs/README.md` and `docs/diagrams/README.md`.
- BACKLOG: Phase 5 open item → done; migration entry marked complete.
- Docs-only. `pnpm md:check` green.

With this, **the branch-model migration (Phases 1–5) is complete.**
