### PR TITLE
release: promote develop → main (two-tier branch model + lane map)

### DIFF
--- a/.claude/commands/promote.md
+++ b/.claude/commands/promote.md
@@ -1,0 +1,34 @@
+---
+description: Promote develop → main — open the release PR, run the full gate (check + E2E), watch CI, hand the merge back
+allowed-tools: Bash(git fetch:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git rev-list:*), Bash(git diff:*), Bash(gh pr create:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(gh pr checks:*), Bash(gh run:*)
+---
+
+Open (or reuse) the `develop → main` release PR, gate it on the full CI suite, and hand the merge
+decision back to me. This is the deliberate production release — it never merges `main` itself.
+Complements `/ship` (which PRs feature work into `develop`); `/promote` moves `develop` into production.
+
+Run these in order. If a precondition fails, STOP and report — don't push ahead.
+
+1. **Sync.** `git fetch origin`. Compare against `origin/main` and `origin/develop` so the result is
+   accurate regardless of local branch or worktree state.
+
+2. **Anything to release?** Run `git rev-list --left-right --count origin/main...origin/develop`. If
+   `develop` is not ahead of `main` (the right-hand count is 0), STOP — there is nothing to promote.
+   Otherwise summarize what will ship with `git log --oneline origin/main..origin/develop`, and flag
+   any commit that looks unfinished or unintended.
+
+3. **Reuse or open the PR.** Check for an existing open promote PR with
+   `gh pr list --base main --head develop --state open`. If one exists, reuse it. Otherwise
+   `gh pr create --base main --head develop` with a release title and a body that lists the promoted
+   commits and any BACKLOG items they close. End the body with the 🤖 Generated-with footer.
+
+4. **Watch the full gate.** This PR runs BOTH required checks — `Lint & type-check` and the slow
+   `E2E (Cypress)` suite (E2E runs here because the base is `main`). Poll `gh pr checks` until they
+   settle. Report green/red plainly; if red, surface the failing job's real log — don't pipe it
+   through `tail`/`head` (a passing pipe can hide a failing command; see AGENTS.md).
+
+5. **Hand back the merge.** Do NOT merge. Report that the PR is green and ready, and let me run the
+   production merge myself. On merge, `main` advances and Vercel builds the production deploy.
+
+6. **Stay safe.** Never force-push, never delete branches, and never merge to `main` automatically —
+   those are mine to decide, and several are blocked outright by `.claude/settings.json`.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -10,8 +10,8 @@ scope/summary to use for the commit and PR title.
 Run these steps in order. If a step's precondition fails, STOP and report — do not push ahead.
 
 1. **Branch safety.** Check `git rev-parse --abbrev-ref HEAD` and `git rev-parse --show-toplevel`. Abort if the branch is
-   `main`/`master`, or if the toplevel is the primary checkout rather than a path under `.claude/worktrees/`. This command
-   only ships from a worktree feature branch — never commit to main.
+   `main`/`master`/`develop`, or if the toplevel is the primary checkout rather than a path under `.claude/worktrees/`. This
+   command only ships from a worktree feature branch — never commit directly to the shared `develop`/`main` branches.
 
 2. **Review the diff.** Run `git status` and `git diff` to see exactly what you're about to ship, and summarize it. Flag
    any unrelated noise and ask before bundling unrelated changes into one PR.
@@ -30,8 +30,9 @@ Run these steps in order. If a step's precondition fails, STOP and report — do
 
    `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
 
-6. **Push & open PR.** `git push -u origin HEAD`, then `gh pr create` with a concise title and a body that summarizes the
-   change and references any backlog item. End the body with the 🤖 Generated-with footer. Never force-push.
+6. **Push & open PR.** `git push -u origin HEAD`, then `gh pr create` (base defaults to `develop`, the repo's default
+   branch) with a concise title and a body that summarizes the change and references any backlog item. End the body with
+   the 🤖 Generated-with footer. Never force-push.
 
 7. **Watch CI.** Poll `gh pr checks` until the required checks settle. Report green/red plainly. If red, surface the
    failing job's actual log — do not pipe it through `tail`/`head` (a passing pipe can hide a failing command; see

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,21 @@
 # Continuous Integration (CI)
 #
-# Two jobs run on every push to `main` and every pull request targeting `main`:
+# Two-tier gate, matching the branch model (feature -> develop -> main):
 #
-#   • check — fast, dependency-free checks: `pnpm check:fast` (Biome lint +
-#     Markdown lint/format + type-check + Next.js typegen) plus the migration-
-#     drift gate and the DB-free unit lane with coverage thresholds.
-#   • e2e — the Cypress end-to-end suite against a real `next dev` server backed
-#     by an ephemeral Postgres service container. The job recreates the
-#     `.env.test.local` the harness expects from non-secret CI values, so it
-#     needs no configured GitHub secrets.
+#   • check — fast, dependency-free checks (Biome lint + Markdown lint/format +
+#     type-check + Next.js typegen) plus the migration-drift gate and the DB-free
+#     unit lane with coverage thresholds. Runs on EVERY push/PR to `develop` and
+#     `main` — this is day-to-day feedback for lane work (~1 min).
+#   • e2e — the slow Cypress end-to-end suite against a real `next dev` server
+#     backed by an ephemeral Postgres service container (recreates the
+#     `.env.test.local` from non-secret CI values, so no GitHub secrets needed).
+#     Gated via `if:` to MAIN-targeting work only — the `develop -> main` promote
+#     PR and pushes to `main` — so the slow suite runs once per release, not on
+#     every develop PR.
+#
+# Required checks (rulesets): `develop` -> `Lint & type-check`; `main` ->
+# `Lint & type-check` + `E2E (Cypress)`. E2E is required on `main` only, so its
+# `if:`-skip on develop never blocks a develop merge.
 #
 # Still intentionally NOT here: the integration vitest lane and the production
 # build. They also need a database/secrets; the e2e job's service-container
@@ -19,9 +26,9 @@ name: CI
 # When should this workflow run?
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 # If you push again before a run finishes, cancel the old run (saves CI minutes).
 concurrency:
@@ -92,6 +99,10 @@ jobs:
 
   e2e:
     name: E2E (Cypress)
+    # Slow suite: only for main-targeting work — the develop -> main promote PR
+    # (github.base_ref == 'main') and pushes to main (github.ref). Skipped on
+    # develop PRs/pushes so day-to-day lane work gets fast check-only feedback.
+    if: github.base_ref == 'main' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # Generous ceiling: a cold `next dev` (Turbopack compiles routes on first
     # hit) plus 20 specs. The warm local run is ~35s; this is a safety net.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@ These instructions apply to AI Assistant, Claude, and ChatGPT when working in th
 - Prefer minimal, focused changes and preserve user-authored work.
 - If rules conflict with each other or with common practice, stop and ask for clarification.
 
+## Branching
+
+Work flows through a two-tier model: feature branch → `develop` (the default, integration branch) →
+`main` (production). Open PRs into `develop`; promote `develop → main` as a deliberate release (Claude
+has a `/promote` command for it). Never commit directly to `develop` or `main` — both are protected and
+require a PR. See [`docs/branching-and-releases.md`](docs/branching-and-releases.md).
+
 ## Next.js: ALWAYS read docs before coding
 
 Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,6 +7,11 @@ this file is the deliberate workaround.)
 
 ## Open
 
+- [ ] **Lane map doc (branch-model Phase 5)** — write the parallel-session lane map as its own
+      doc: `src/modules/{auth,banner,customers,invoices,users}` + docs + isolated chores are
+      parallel-safe lanes; `src/shared/**` + `src/server/**` are the single-thread kernel (never
+      parallel-edit). Map existing BACKLOG items onto lanes. The remaining piece of the
+      develop/promote migration. Detail: memory `project_branch_model_migration`.
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
       override automation + grouped dep updates (Dependabot can't do those). Replaces
       Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of
@@ -40,6 +45,15 @@ this file is the deliberate workaround.)
 
 Terse log — newest first. Full detail lives in the `project_*` memory files.
 
+- [x] **Two-tier branch model: `develop` → `main`** _(2026-06-23)_ — reworked the git strategy for
+      parallel multi-session work: `develop` is now the **default** branch (integration), `main` is
+      promote-only (production). GitHub rulesets gate `develop` (`Lint & type-check`) and `main`
+      (`+ E2E (Cypress)`); `ci.yml` split so the slow E2E runs only for main-targeting PRs (#89);
+      branch model + Mermaid diagram documented (#90); Vercel verified (main=production,
+      develop=free staging URL); added the `/promote` command + updated CLAUDE.md/AGENTS.md
+      git-safety wording. Remaining: the lane map (see Open). ⚠️ Rulesets pin required-status-check
+      contexts to the CI job **names** (`Lint & type-check`, `E2E (Cypress)`) — rename a job and
+      merges silently block. Detail: memory `project_branch_model_migration`.
 - [x] **Worktree/branch cleanup tooling** _(2026-06-23, #88)_ — added a `/clean-worktrees`
       command (`.claude/commands/clean-worktrees.md`): fetch → classify `[gone]`/merged/empty
       lanes (verified via `gh` PR state or `ahead=0`) → auto-remove only **clean** worktrees

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,11 +7,6 @@ this file is the deliberate workaround.)
 
 ## Open
 
-- [ ] **Lane map doc (branch-model Phase 5)** — write the parallel-session lane map as its own
-      doc: `src/modules/{auth,banner,customers,invoices,users}` + docs + isolated chores are
-      parallel-safe lanes; `src/shared/**` + `src/server/**` are the single-thread kernel (never
-      parallel-edit). Map existing BACKLOG items onto lanes. The remaining piece of the
-      develop/promote migration. Detail: memory `project_branch_model_migration`.
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
       override automation + grouped dep updates (Dependabot can't do those). Replaces
       Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of
@@ -51,7 +46,7 @@ Terse log — newest first. Full detail lives in the `project_*` memory files.
       (`+ E2E (Cypress)`); `ci.yml` split so the slow E2E runs only for main-targeting PRs (#89);
       branch model + Mermaid diagram documented (#90); Vercel verified (main=production,
       develop=free staging URL); added the `/promote` command + updated CLAUDE.md/AGENTS.md
-      git-safety wording. Remaining: the lane map (see Open). ⚠️ Rulesets pin required-status-check
+      git-safety wording; the lane map landed (`docs/lane-map.md` + diagram). ⚠️ Rulesets pin required-status-check
       contexts to the CI job **names** (`Lint & type-check`, `E2E (Cypress)`) — rename a job and
       merges silently block. Detail: memory `project_branch_model_migration`.
 - [x] **Worktree/branch cleanup tooling** _(2026-06-23, #88)_ — added a `/clean-worktrees`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,11 @@ After completing any backlog item or fix: run the full test suite + typecheck, v
 
 ## Git Safety
 
-Never delete branches/worktrees or run destructive DB/git commands without explicit confirmation. When merging stacked PRs, warn before deleting any branch so changes aren't lost. Always confirm you are operating in a worktree, never directly on main.
+Never delete branches/worktrees or run destructive DB/git commands without explicit confirmation. When merging stacked PRs, warn before deleting any branch so changes aren't lost. Always work from a worktree feature branch — never commit directly to `develop` (the default, integration branch) or `main` (production). Both are protected; code reaches them only through a PR, and `main` only via a deliberate `develop → main` promote (`/promote`).
 
 ## Worktrees
 
-This project runs in git worktrees under `.claude/worktrees/`, not a single checkout — work committed there lives on a separate branch and does not touch `main` until a PR merges. Expect **multiple worktrees at once**: today usually one per Claude Code session, with the intended direction being branch-per-architecture lanes for running several sessions in parallel. Reason about branches, env files, and isolation with that in mind. (Shell/OS specifics live in `AGENTS.md` → "Shell environment".)
+This project runs in git worktrees under `.claude/worktrees/`, not a single checkout — work committed there lives on a separate branch (cut from `develop`, the default) and does not touch the shared `develop`/`main` branches until a PR merges. Expect **multiple worktrees at once**: today usually one per Claude Code session, with the intended direction being branch-per-architecture lanes for running several sessions in parallel. Reason about branches, env files, and isolation with that in mind. The full branch/CI/release model is in [`docs/branching-and-releases.md`](docs/branching-and-releases.md). (Shell/OS specifics live in `AGENTS.md` → "Shell environment".)
 
 ## Claude-specific context
 
@@ -21,18 +21,19 @@ This project runs in git worktrees under `.claude/worktrees/`, not a single chec
 
 Project-level slash commands are defined in `.claude/commands/`:
 
-| Command       | Runs                                                                                         |
-| ------------- | -------------------------------------------------------------------------------------------- |
-| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                |
-| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)        |
-| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)             |
-| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                 |
-| `/test`       | `pnpm test` — unit tests only (report-only)                                                  |
-| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                            |
-| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                     |
-| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI |
+| Command       | Runs                                                                                                 |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                        |
+| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)                |
+| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)                     |
+| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                         |
+| `/test`       | `pnpm test` — unit tests only (report-only)                                                          |
+| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                                    |
+| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                             |
+| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI         |
+| `/promote`    | open the `develop → main` release PR, run the full gate (check + E2E), watch CI, hand the merge back |
 
-Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit). `/ship` is the one command that writes git history — it commits, pushes, and opens a PR, and only ever runs from a worktree branch, never `main`.
+Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit). `/ship` commits, pushes, and opens a PR into `develop` from a worktree feature branch (never `develop`/`main` directly); `/promote` opens the `develop → main` release PR and watches the full gate but never merges `main` itself — that stays a human decision.
 
 ### Markdown tooling
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,12 @@ folder is for the cross-cutting, project-wide docs.
 | ------------------------ | ----------------------------------------------------------------------------- |
 | [testing.md](testing.md) | "How do I run the unit (Vitest) and E2E (Cypress) suites, locally and in CI?" |
 
+## Branching, CI & releases
+
+| Doc                                                    | The question it answers                                                                         |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| [branching-and-releases.md](branching-and-releases.md) | "Which branch do I work on, how does a change reach production, and what CI runs at each step?" |
+
 ## Build tooling & configuration
 
 | Doc                                                            | The question it answers                                                                                         |

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,9 +27,10 @@ folder is for the cross-cutting, project-wide docs.
 
 ## Branching, CI & releases
 
-| Doc                                                    | The question it answers                                                                         |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| [branching-and-releases.md](branching-and-releases.md) | "Which branch do I work on, how does a change reach production, and what CI runs at each step?" |
+| Doc                                                    | The question it answers                                                                            |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| [branching-and-releases.md](branching-and-releases.md) | "Which branch do I work on, how does a change reach production, and what CI runs at each step?"    |
+| [lane-map.md](lane-map.md)                             | "If I want to run several Claude sessions at once, how do I split the work so they don't collide?" |
 
 ## Build tooling & configuration
 

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -84,14 +84,15 @@ The point of `develop` is to let multiple branches integrate cheaply. Two sessio
 collide only when they edit the same files, so parallel-safe "lanes" are slices with
 disjoint footprints:
 
-- **Parallel-safe:** the feature modules
-  `src/modules/{auth,banner,customers,invoices,users}`, docs/diagrams, and isolated
-  chores (deps, tsconfig, fonts).
-- **Single-thread — never parallel-edit:** the shared kernel `src/shared/**` and
-  `src/server/**`. Almost everything imports these, so two sessions touching them
-  will conflict.
+- **Parallel-safe:** the feature modules — `auth`+`users` move together (they import each
+  other), then `customers`, `invoices` (downstream), and `banner` — plus docs/diagrams and
+  isolated chores (deps, tsconfig, fonts).
+- **Single-thread — never parallel-edit:** the shared kernel `src/shared/**`, `src/ui/**`,
+  `src/server/**`, and the centralized `database/schema/**`. Almost everything imports these,
+  so two sessions touching them will conflict.
 
-A fuller lane map is planned as its own doc.
+See [lane-map.md](lane-map.md) for the full lane map — the verified module-coupling graph and
+today's BACKLOG mapped onto lanes.
 
 ## Keeping this honest
 

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -50,7 +50,8 @@ When `develop` is in a coherent state you want live:
    `E2E (Cypress)` suite. Both are required on `main`.
 3. Merge → `main` advances → Vercel builds a **production** deploy.
 
-A `/promote` command to script this step is planned; until then it's the manual
+The `/promote` command scripts this step — it opens the `develop → main` PR, runs the full gate,
+watches CI, and hands you the merge (it never merges `main` itself). The manual equivalent is the
 `gh pr create --base main` above.
 
 ## What runs where
@@ -72,6 +73,10 @@ The required-check policy itself lives in GitHub **rulesets** (`Protect Importan
 Branches` → `main`; `Protect develop (integration)` → `develop`), not in this repo.
 If you rename a CI job, update the ruleset's required-status-check contexts or merges
 will silently block.
+
+`develop` also has a persistent **staging URL** you can share or test against —
+`https://nextjs-dashboard-git-develop-andrew-petersons-projects-15cc2fda.vercel.app` — which Vercel
+auto-updates on every push to `develop`.
 
 ## Working in parallel (lanes)
 

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -1,0 +1,95 @@
+# Branching & releases
+
+> The question this answers: _"Which branch do I work on, how does a change reach
+> production, and what CI runs at each step?"_ The visual companion is
+> [diagrams/branch-and-ci-flow.md](diagrams/branch-and-ci-flow.md).
+
+## Why this shape
+
+This repo uses a two-tier branch model — `feature → develop → main` — for three
+reasons:
+
+1. **Parallel work.** Several Claude sessions (or you, across tasks) can each work
+   on their own branch and integrate through `develop` without every merge touching
+   production.
+2. **A clean production face.** `main` is the portfolio/production branch. Half-done
+   work never lands there — it accumulates on `develop` until a deliberate release.
+3. **Cheaper feedback.** The slow end-to-end suite and the Vercel production deploy
+   happen once per _release_, not on every merge.
+
+## The branches
+
+| Branch           | Role                             | How code lands                                  |
+| ---------------- | -------------------------------- | ----------------------------------------------- |
+| `feature` / lane | one unit of work, one session    | its own branch → PR into `develop`              |
+| `develop`        | **default** branch · integration | only through a PR                               |
+| `main`           | production · promote-only        | never directly — only via a `develop → main` PR |
+
+`develop` is the repository's **default branch**, so new clones, new worktrees, and
+`gh pr create` all target it automatically.
+
+## Everyday flow — shipping to `develop`
+
+1. Branch off `develop` (a worktree per session is the norm — see the Worktrees
+   section in [../CLAUDE.md](../CLAUDE.md)).
+2. Make your change.
+3. Open a PR into `develop`. The `/ship` command runs this end-to-end and targets
+   `develop` automatically now that it's the default branch.
+4. The fast **`Lint & type-check`** gate runs (~1 min) — the only required check on
+   `develop`. Green → merge.
+
+No end-to-end suite runs here, by design, so lane work stays fast.
+
+## Release flow — promoting `develop → main`
+
+When `develop` is in a coherent state you want live:
+
+1. Open a PR with **base `main`, head `develop`**:
+   `gh pr create --base main --head develop`.
+2. This PR runs the **full gate**: `Lint & type-check` **and** the slow
+   `E2E (Cypress)` suite. Both are required on `main`.
+3. Merge → `main` advances → Vercel builds a **production** deploy.
+
+A `/promote` command to script this step is planned; until then it's the manual
+`gh pr create --base main` above.
+
+## What runs where
+
+CI is one workflow, [`../.github/workflows/ci.yml`](../.github/workflows/ci.yml),
+with two jobs and a per-branch gate:
+
+| Branch    | `Lint & type-check` (fast) | `E2E (Cypress)` (slow) | Vercel            |
+| --------- | -------------------------- | ---------------------- | ----------------- |
+| `develop` | ✅ required                | ⏭ skipped              | preview URL       |
+| `main`    | ✅ required                | ✅ required            | production deploy |
+
+The E2E job is gated in the workflow with
+`if: github.base_ref == 'main' || github.ref == 'refs/heads/main'`. It is required
+on `main` only — never on `develop`, because a _required_ check that gets skipped
+would block the merge.
+
+The required-check policy itself lives in GitHub **rulesets** (`Protect Important
+Branches` → `main`; `Protect develop (integration)` → `develop`), not in this repo.
+If you rename a CI job, update the ruleset's required-status-check contexts or merges
+will silently block.
+
+## Working in parallel (lanes)
+
+The point of `develop` is to let multiple branches integrate cheaply. Two sessions
+collide only when they edit the same files, so parallel-safe "lanes" are slices with
+disjoint footprints:
+
+- **Parallel-safe:** the feature modules
+  `src/modules/{auth,banner,customers,invoices,users}`, docs/diagrams, and isolated
+  chores (deps, tsconfig, fonts).
+- **Single-thread — never parallel-edit:** the shared kernel `src/shared/**` and
+  `src/server/**`. Almost everything imports these, so two sessions touching them
+  will conflict.
+
+A fuller lane map is planned as its own doc.
+
+## Keeping this honest
+
+Like every doc here, this is a **snapshot**. If you change the branch model, a CI
+trigger, or a ruleset, update this file and
+[diagrams/branch-and-ci-flow.md](diagrams/branch-and-ci-flow.md) in the same PR.

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -24,6 +24,7 @@ in a PR, and sitting right next to the code it describes.
 | [session-lifecycle.md](session-lifecycle.md)               | "What states can a session be in, and what moves it between them?"                            | State machine                        |
 | [dependency-injection.md](dependency-injection.md)         | "How do application contracts and infrastructure implementations actually get connected?"     | Component graph                      |
 | [branch-and-ci-flow.md](branch-and-ci-flow.md)             | "Which branch do I work on, how does a change reach production, and what CI gate runs where?" | Flowchart                            |
+| [lane-map.md](lane-map.md)                                 | "Which slices can be edited in parallel sessions, and which must stay single-threaded?"       | Flowchart                            |
 
 ## Pick the question first
 

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -12,17 +12,18 @@ in a PR, and sitting right next to the code it describes.
 
 ## The diagrams
 
-| File                                                       | The question it answers                                                                   | Diagram type                         |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------ |
-| [c4-architecture.md](c4-architecture.md)                   | "How is the whole system carved into pieces?"                                             | C4 (context → container → component) |
-| [database-erd.md](database-erd.md)                         | "What tables exist and how do they relate?"                                               | Entity-relationship                  |
-| [module-layers.md](module-layers.md)                       | "How is a module layered, and which way do dependencies point?"                           | Layered flowchart                    |
-| [auth-login-flow.md](auth-login-flow.md)                   | "Step by step, what happens when someone logs in?"                                        | Sequence                             |
-| [request-flow-update-user.md](request-flow-update-user.md) | "How does a form submission travel through the layers?"                                   | Sequence                             |
-| [error-handling-flow.md](error-handling-flow.md)           | "How does a failure travel from the database to a red field error — without a `throw`?"   | Sequence + type map                  |
-| [route-authorization.md](route-authorization.md)           | "Before a page renders, what decides whether I'm allowed in?"                             | Sequence + decision                  |
-| [session-lifecycle.md](session-lifecycle.md)               | "What states can a session be in, and what moves it between them?"                        | State machine                        |
-| [dependency-injection.md](dependency-injection.md)         | "How do application contracts and infrastructure implementations actually get connected?" | Component graph                      |
+| File                                                       | The question it answers                                                                       | Diagram type                         |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------ |
+| [c4-architecture.md](c4-architecture.md)                   | "How is the whole system carved into pieces?"                                                 | C4 (context → container → component) |
+| [database-erd.md](database-erd.md)                         | "What tables exist and how do they relate?"                                                   | Entity-relationship                  |
+| [module-layers.md](module-layers.md)                       | "How is a module layered, and which way do dependencies point?"                               | Layered flowchart                    |
+| [auth-login-flow.md](auth-login-flow.md)                   | "Step by step, what happens when someone logs in?"                                            | Sequence                             |
+| [request-flow-update-user.md](request-flow-update-user.md) | "How does a form submission travel through the layers?"                                       | Sequence                             |
+| [error-handling-flow.md](error-handling-flow.md)           | "How does a failure travel from the database to a red field error — without a `throw`?"       | Sequence + type map                  |
+| [route-authorization.md](route-authorization.md)           | "Before a page renders, what decides whether I'm allowed in?"                                 | Sequence + decision                  |
+| [session-lifecycle.md](session-lifecycle.md)               | "What states can a session be in, and what moves it between them?"                            | State machine                        |
+| [dependency-injection.md](dependency-injection.md)         | "How do application contracts and infrastructure implementations actually get connected?"     | Component graph                      |
+| [branch-and-ci-flow.md](branch-and-ci-flow.md)             | "Which branch do I work on, how does a change reach production, and what CI gate runs where?" | Flowchart                            |
 
 ## Pick the question first
 

--- a/docs/diagrams/branch-and-ci-flow.md
+++ b/docs/diagrams/branch-and-ci-flow.md
@@ -1,0 +1,51 @@
+# Branch & CI flow — from a lane branch to production
+
+> The question this answers: _"Which branch do I work on, how does a change reach
+> production, and what CI gate runs at each step?"_ The prose companion is
+> [../branching-and-releases.md](../branching-and-releases.md).
+
+## The two-tier flow
+
+```mermaid
+flowchart LR
+    F["feature / lane branch<br/>(one per session)"]
+    DEV["develop<br/>(default, integration)"]
+    MAIN["main<br/>(production)"]
+    PROD["Vercel production"]
+    PREV["Vercel preview URL"]
+
+    F -->|"open PR — gate: fast check (~1 min)"| DEV
+    DEV -->|"promote PR — gate: fast check + E2E"| MAIN
+    MAIN ==>|"merge, then deploy"| PROD
+    F -.->|"push: preview"| PREV
+    DEV -.->|"push: preview"| PREV
+```
+
+## How to read it
+
+- **`develop` is the default branch** — your day-to-day base. Every feature or
+  lane branch opens a PR into `develop`, gated only by the fast
+  `Lint & type-check` job (Biome + Markdown + type-check + typegen + drift + the
+  DB-free unit lane). Feedback is ~1 minute.
+- **`main` is production, and promote-only.** Code reaches it through a single
+  `develop → main` "promote" PR, which runs the full gate — the fast check **and**
+  the slow `E2E (Cypress)` suite — so the end-to-end tests run once per release
+  instead of on every merge.
+- **Vercel** builds a throwaway **preview** for every branch push (your live WIP
+  URL) and a **production** deploy only when `main` advances. Production redeploys
+  at release cadence, not on every change.
+
+## Where the gates are enforced
+
+The two CI jobs live in [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml);
+which ones are _required_ to merge is enforced by GitHub rulesets:
+
+| Branch    | Required to merge                     | Vercel            |
+| --------- | ------------------------------------- | ----------------- |
+| `develop` | `Lint & type-check`                   | preview URL       |
+| `main`    | `Lint & type-check` + `E2E (Cypress)` | production deploy |
+
+The slow `E2E (Cypress)` job is gated in the workflow with
+`if: github.base_ref == 'main' || github.ref == 'refs/heads/main'`, so it runs only
+for main-targeting work. It is a _required_ check on `main` only — never on
+`develop`, because a required check that gets skipped would block the merge.

--- a/docs/diagrams/lane-map.md
+++ b/docs/diagrams/lane-map.md
@@ -1,0 +1,45 @@
+# Lane map — what can run in parallel
+
+> The question this answers: _"Which slices of the codebase can be edited in separate sessions at the
+> same time, and which must stay single-threaded?"_ The prose companion (per-lane table + BACKLOG
+> mapping) is [../lane-map.md](../lane-map.md).
+
+## Lanes vs. the single-thread kernel
+
+```mermaid
+flowchart TD
+    subgraph LANES["Parallel-safe lanes — each its own session + worktree"]
+        direction LR
+        AU["auth ⇄ users<br/>(coupled → ONE lane)"]
+        CU["customers"]
+        INV["invoices"]
+        BAN["banner"]
+        DOC["docs / diagrams"]
+        CHO["isolated chores"]
+    end
+
+    subgraph KERNEL["Single-thread zone — at most ONE session at a time"]
+        direction LR
+        SH["src/shared"]
+        UI["src/ui"]
+        SRV["src/server"]
+        DB["database/schema"]
+    end
+
+    INV -.->|consumes| AU
+    INV -.->|consumes| CU
+    LANES ==>|"every lane imports the kernel —<br/>editing it ripples into all of them"| KERNEL
+```
+
+## How to read it
+
+- **Top box = parallel-safe lanes.** Each can be a separate worktree + session because their _edit_
+  footprints don't overlap. `auth` and `users` import each other, so they collapse into one lane;
+  `invoices` reads `auth`/`customers` but edits only itself (downstream).
+- **Bottom box = the kernel.** `shared`, the `ui` design system, `server`, and the centralized
+  `database/schema` are imported by everything, so a change here ripples up into every lane. Edit it in
+  **one** session at a time, and don't run a kernel refactor next to a module lane it will break.
+- **The rule:** lanes collide on shared _edits_, not shared _imports_. Two lanes importing the same
+  kernel file is fine — until both try to change it.
+
+See [../lane-map.md](../lane-map.md) for the per-lane table and today's BACKLOG mapped onto lanes.

--- a/docs/lane-map.md
+++ b/docs/lane-map.md
@@ -1,0 +1,94 @@
+# Lane map — running sessions in parallel
+
+> The question this answers: _"If I want to run several Claude sessions (or tasks) at once, how do I
+> split the work so they don't collide?"_ The visual companion is
+> [diagrams/lane-map.md](diagrams/lane-map.md); the branch mechanics are in
+> [branching-and-releases.md](branching-and-releases.md).
+
+## The one rule
+
+Two sessions collide only when they **edit the same files** — not when they import the same files. A
+"lane" is a slice of work whose **edit footprint** doesn't overlap another lane's. Two lanes can both
+_depend on_ `src/shared/core`; they conflict only if both _change_ it. So parallelizing safely is mostly
+about picking work whose edits land in different places.
+
+## The dependency reality (verified, not assumed)
+
+The codebase has three tiers — the documented rule is `shared/ui → modules → shell → app` (see
+[project-structure.md](project-structure.md)):
+
+- **Shared kernel** — `src/shared/**`, `src/ui/**`, `src/server/**`, and the centralized
+  `database/schema/**`. Almost everything imports these, so an edit here ripples into every lane.
+- **Feature modules** — `src/modules/*`, the domain slices. These are the parallel lanes — but they are
+  **not all independent**:
+
+  | Module      | Coupling (verified via imports)     | Lane                       |
+  | ----------- | ----------------------------------- | -------------------------- |
+  | `auth`      | imports `users` (mutual)            | **one lane with `users`**  |
+  | `users`     | imports `auth` (mutual)             | (same lane as `auth`)      |
+  | `customers` | none                                | standalone lane            |
+  | `banner`    | none                                | standalone lane            |
+  | `invoices`  | reads `auth`, `customers` (one-way) | own lane, but _downstream_ |
+
+  `auth` and `users` import each other, so they must move together as a single lane. `invoices` _reads_
+  `auth` and `customers` but doesn't edit them — it's its own edit footprint, just downstream: fine to
+  run beside the others, with the caveat that if an upstream lane changes a contract `invoices` uses,
+  `invoices` may need a follow-up (CI's type-check catches it at integration).
+
+- **Composition** — `src/app/**`, `src/shell/**`. Thin, route-specific glue at the top of the stack.
+
+## The lanes
+
+| Lane                | Edit footprint                                                      | Parallel?                   |
+| ------------------- | ------------------------------------------------------------------- | --------------------------- |
+| **auth + users**    | `src/modules/auth`, `src/modules/users`                             | ✅ (one lane, both modules) |
+| **customers**       | `src/modules/customers`                                             | ✅                          |
+| **invoices**        | `src/modules/invoices`                                              | ✅ (downstream — see above) |
+| **banner**          | `src/modules/banner`                                                | ✅                          |
+| **docs**            | `docs/**` (stable areas not under active code change)               | ✅                          |
+| **chore**           | one isolated file/config (a dep, `tsconfig`, a font)                | ✅ (if footprints disjoint) |
+| **kernel / schema** | `src/shared/**`, `src/ui/**`, `src/server/**`, `database/schema/**` | ⛔ **single-thread**        |
+
+The kernel row is the exception: cross-cutting changes to shared code, the design system, infra, or the
+DB schema should be **one session at a time**, because everything depends on them. Don't run two kernel
+refactors at once, and don't run a kernel refactor next to a module lane it will break.
+
+## How many at once
+
+The realistic ceiling isn't the kernel or your tokens — it's **your steering bandwidth**. Two or three
+sessions you can actually review and unblock beats five you can't. Start with 2, grow toward ~4 once the
+rhythm is comfortable. Each lane is its own worktree + branch off `develop`, opening its own PR.
+
+## Today's BACKLOG, mapped onto lanes
+
+Most open items are tooling/docs/config rather than feature work, which makes them _very_
+parallel-friendly:
+
+| BACKLOG item                  | Lane                       | Edit footprint                 |
+| ----------------------------- | -------------------------- | ------------------------------ |
+| docs/ consolidation           | docs                       | `docs/standards/**`, `docs/**` |
+| Font experiment (finish/drop) | chore (UI)                 | `src/ui/styles/fonts.ts`       |
+| TSConfig modernization        | chore (config)             | `tsconfig*.json`               |
+| Renovate adoption             | chore (CI/config)          | CI + workspace config          |
+| Integration lane in CI        | chore (CI)                 | `.github/workflows/ci.yml`     |
+| Skills exploration            | research (no code)         | none                           |
+| **Forms taxonomy flattening** | **kernel — single-thread** | `src/shared/forms/**`          |
+
+A clean four-session day right now could be **docs consolidation** + **font experiment** + **TSConfig
+modernization** + **skills exploration** — four near-disjoint footprints. **Forms taxonomy flattening**
+is the one to keep solo: it lives in the shared kernel, so don't pair it with another kernel task.
+
+## The protocol
+
+1. Pick lanes with disjoint edit footprints (use the tables above).
+2. Give each its own worktree + branch off `develop`.
+3. Let each open its own PR into `develop`; the fast `Lint & type-check` gate runs per PR.
+4. If a task must touch the **kernel / schema**, run it **solo** — pause module lanes it could break.
+5. Promote `develop → main` with `/promote` once the integrated set is coherent.
+
+## Keeping this honest
+
+This maps the dependency graph as of now (`auth`⇄`users` coupled; `invoices` downstream of `auth` +
+`customers`; schema centralized in `database/schema/`). If you split a module, add a cross-module
+import, or move the schema, re-derive the coupling — `grep -rho '@/modules/[a-z-]*' src/modules/<m>`
+shows what a module imports.


### PR DESCRIPTION
## Release: two-tier branch model → production

Promotes `develop` into `main`. This is the production release of the complete two-tier
branch-model migration (Phases 1–5) plus the parallel-session lane map.

### Commits being promoted

- #92 — docs: add the lane map for parallel sessions (branch-model Phase 5)
- #91 — feat(claude): add `/promote` command + align git-safety docs with the develop model
- #90 — docs: document the develop/promote branch model + CI split
- #89 — ci: split CI gate by branch — fast `check` on develop, E2E on main only

### Completes

- The **Two-tier branch model: `develop` → `main`** backlog item: `develop` is now the default
  integration branch, `main` is promote-only production, GitHub rulesets gate both, CI is split
  by base branch, the `/promote` command exists, and the lane map (`docs/lane-map.md`) has landed.

This is the first production promote under the new model. On merge, `main` advances and Vercel
builds the production deploy.
