### PR TITLE
docs(customers,banner): reconcile module READMEs with code

### DIFF
--- a/src/modules/banner/README.md
+++ b/src/modules/banner/README.md
@@ -36,12 +36,15 @@ User clicks Dismiss ─▶ dismissBannerAction()  ─▶ dismissBanner() sets co
 ```
 
 - **Gating is the caller's job.** `<OneTimeBanner>` always renders when mounted;
-  the server code that includes it should check `isBannerDismissed()` first and
-  skip mounting it when the cookie is set. The component owns only the dismiss
+  the server code that includes it must check `isBannerDismissed()` first and skip
+  mounting it when the cookie is set. The one real caller is the root layout
+  (`app/layout.tsx`), which awaits `isBannerDismissed()` and renders
+  `{!dismissed && <OneTimeBanner/>}`. The component owns only the dismiss
   interaction (optimistic `useState` + `useTransition`).
 - **The adapter** (`BannerCookieAdapter`) wraps the shared cookie service
-  (`@/server/cookies`) and centralizes the cookie options; `banner-cookie.ts` is a
-  two-function facade so callers don't construct the adapter themselves.
+  (`createCookieService()` from `@/server/cookies/cookie.factory`) and centralizes
+  the cookie options; `banner-cookie.ts` is a two-function facade so callers don't
+  construct the adapter themselves.
 
 ---
 
@@ -74,8 +77,8 @@ flags like this one.
 ## Related documentation
 
 - [project-structure.md](../../../docs/project-structure.md) — where code belongs across the repo.
-- Cookie service: `@/server/cookies` (the shared adapter this module builds on).
+- Cookie service: `@/server/cookies/cookie.factory` (`createCookieService()` — the shared service this module builds on).
 
 ---
 
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-24

--- a/src/modules/customers/README.md
+++ b/src/modules/customers/README.md
@@ -64,9 +64,13 @@ customers/
 │   ├── repository/dal/                  #   fetch-filtered-customers, fetch-customers-select, fetch-total-count
 │   └── adapters/customer.mapper.ts      #   raw row → server DTO (brand id, normalize sums)
 │
-└── presentation/                        # Next.js server actions + React UI
-    ├── actions/                         #   read-filtered-customers, read-customers, read-total-customers-count
-    └── components/                      #   customers-table (+ desktop / mobile / row variants)
+├── presentation/                        # Next.js server actions + React UI
+│   ├── actions/                         #   read-filtered-customers, read-customers, read-total-customers-count
+│   └── components/                      #   customers-table (+ desktop / mobile / row variants)
+│
+└── __tests__/unit/                      # Vitest unit tests (domain mappers + infra adapter)
+    ├── domain/                          #   customer-id.mappers, mappers (toFormattedCustomersTableRow)
+    └── infrastructure/adapters/         #   customer.mapper (raw → DTO, null→0)
 ```
 
 There is intentionally no `application/` layer — without writes or business rules
@@ -121,15 +125,20 @@ All three actions follow the same read-only shape — for example the table:
 
 ## Error handling
 
-The DAL **throws** `makeAppError(APP_ERROR_KEYS.database, …)` on a query failure
-(using `CUSTOMER_SERVER_ERROR_MESSAGES`); the error propagates up to the action /
-page. This is the same throw-based model as the `invoices` DAL — note it differs
-from `users`, which returns `Result` end-to-end. See
+The two query DALs (`fetch-filtered-customers`, `fetch-customers-select`) wrap
+their query in `try/catch` and **throw** `makeAppError(APP_ERROR_KEYS.database, …)`
+on failure (using `CUSTOMER_SERVER_ERROR_MESSAGES`); the error propagates up to the
+action / page. `fetch-total-count` is the exception: it does not catch query errors
+(so a DB failure propagates raw) and only throws — with the `validation` key — when
+the count comes back missing. This is the same throw-based model as the `invoices`
+DAL — note it differs from `users`, which returns `Result` end-to-end. See
 [when-to-use-app-error.md](../../../docs/when-to-use-app-error.md).
 
-> No automated tests yet. The mappers (`mapCustomerAggregatesRawToDto`'s null→0
-> normalization) and the filtered-aggregate query are the highest-value things to
-> cover first.
+> **Tests:** unit suites cover the domain mappers (`toFormattedCustomersTableRow`
+> currency formatting, `CustomerId` create/throw) and the infra adapter
+> (`mapCustomerAggregatesRawToDto`'s null→0 normalization, id branding). The
+> filtered-aggregate DAL query is still uncovered — it needs a DB and is the
+> highest-value thing to add next.
 
 ---
 
@@ -142,4 +151,4 @@ from `users`, which returns `Result` end-to-end. See
 
 ---
 
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-24


### PR DESCRIPTION
## Scope

Documentation-only pass over the **customers** and **banner** module READMEs, run as one of three parallel doc-review sessions. Treated the **code as the source of truth** and reconciled each doc claim against `src/modules/customers/**` and `src/modules/banner/**`.

**Touched only:**
- `src/modules/customers/README.md`
- `src/modules/banner/README.md`

No code, no `BACKLOG.md`, no `docs/` index/standards, no other module's docs.

## Findings & fixes

### Customers (`src/modules/customers/README.md`)
- **Stale claim removed:** README said *"No automated tests yet."* Three Vitest unit suites now exist and cover exactly what the old note flagged as highest-value:
  - `__tests__/unit/domain/customer-id.mappers.test.ts` — `createCustomerId` (Result) + `toCustomerId` (throwing)
  - `__tests__/unit/domain/mappers.test.ts` — `toFormattedCustomersTableRow` currency formatting
  - `__tests__/unit/infrastructure/adapters/customer.mapper.test.ts` — `mapCustomerAggregatesRawToDto` null→0 normalization + id branding

  Reframed the note to state what's covered vs. what remains (the filtered-aggregate DAL query, which needs a DB).
- **Directory structure gap:** the tree omitted `__tests__/` entirely; added the `__tests__/unit/` subtree.
- **Error-handling over-generalized:** README claimed *"The DAL throws `makeAppError(APP_ERROR_KEYS.database, …)` on a query failure"* as a blanket statement. Verified against code: only the two query DALs (`fetch-filtered-customers`, `fetch-customers-select`) wrap their query in `try/catch` and throw a `database` AppError. `fetch-total-count` is the exception — no `try/catch` around the query (a DB failure propagates raw) and it throws a **`validation`** error only when the count is missing. Documented the distinction.

Verified accurate (left as-is): three-tier `Raw → ServerDto → Formatted` pipeline, read-only design, the `invoices` left-join aggregates, `CustomerId` ownership, request flow (`getAppDb()` → `createCustomersRepository` → `fetchFiltered` → `toFormattedCustomersTableRow`), and all five related-doc links.

### Banner (`src/modules/banner/README.md`)
- **Cookie-service path corrected:** doc referenced `@/server/cookies`, but there is no barrel at that path. The real dependency is `createCookieService()` from `@/server/cookies/cookie.factory`. Fixed both references (How-it-works note + Related docs).
- **Concrete gating caller named:** the doc abstractly said *"the server code that includes it should check `isBannerDismissed()`"*. There's exactly one caller — the root layout (`app/layout.tsx`, `{!dismissed && <OneTimeBanner/>}`). Named it.

Verified accurate (left as-is): cookie name `banner_dismissed_v1`, 180-day max-age, all five cookie options (`httpOnly:false`, `sameSite:lax`, `secure:isProd()`, `maxAge:15_552_000`, `path:/`), the facade (`isBannerDismissed`/`dismissBanner`), the dismiss action revalidating `/`, and the versioned-cookie re-show switch.

Both READMEs' "Last updated" bumped to 2026-06-24.

## Validation
`pnpm check:fast` — green: Biome clean, markdownlint 0 errors, dprint format check OK, `tsc` typecheck OK, Next typegen OK, db-drift OK.

## Backlog-worthy follow-up (not done here — out of lane)
- **Customers:** add coverage for the `fetch-filtered-customers` aggregate query (the one remaining untested DAL path; needs a DB-backed/integration test). Flagging only — `BACKLOG.md` intentionally untouched so the parallel sessions don't collide.
