### PR TITLE
docs(auth,users): reconcile module docs with code (drift fixes)

### DIFF
--- a/docs/diagrams/auth-login-flow.md
+++ b/docs/diagrams/auth-login-flow.md
@@ -74,14 +74,14 @@ Same shape as login, with one extra step **first**: create the user.
 
 ## The files behind the boxes
 
-| Box                                 | File                                                                                                                                                          |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| login.action / signup.action        | [`presentation/authn/actions/`](../../src/modules/auth/presentation/authn/actions)                                                                            |
-| verifySessionOptimistic             | [`presentation/session/actions/verify-session-optimistic.action.ts`](../../src/modules/auth/presentation/session/actions/verify-session-optimistic.action.ts) |
-| auth.composition                    | [`infrastructure/composition/auth.composition.ts`](../../src/modules/auth/infrastructure/composition/auth.composition.ts)                                     |
-| login.workflow / LoginUseCase       | [`application/auth-user/`](../../src/modules/auth/application/auth-user)                                                                                      |
-| SessionService / ReadSessionUseCase | [`application/session/`](../../src/modules/auth/application/session) + [`infrastructure/session/`](../../src/modules/auth/infrastructure/session)             |
-| Bcrypt service                      | [`infrastructure/crypto/services/bcrypt-password.service.ts`](../../src/modules/auth/infrastructure/crypto/services/bcrypt-password.service.ts)               |
+| Box                                 | File                                                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| login.action / signup.action        | [`presentation/authn/actions/`](../../src/modules/auth/presentation/authn/actions)                                                                |
+| verifySessionOptimistic             | [`presentation/session/verify-session-optimistic.action.ts`](../../src/modules/auth/presentation/session/verify-session-optimistic.action.ts)     |
+| auth.composition                    | [`infrastructure/composition/auth.composition.ts`](../../src/modules/auth/infrastructure/composition/auth.composition.ts)                         |
+| login.workflow / LoginUseCase       | [`application/auth-user/`](../../src/modules/auth/application/auth-user)                                                                          |
+| SessionService / ReadSessionUseCase | [`application/session/`](../../src/modules/auth/application/session) + [`infrastructure/session/`](../../src/modules/auth/infrastructure/session) |
+| Bcrypt service                      | [`infrastructure/crypto/services/bcrypt-password.service.ts`](../../src/modules/auth/infrastructure/crypto/services/bcrypt-password.service.ts)   |
 
 ## The "why" lives in the ADRs
 

--- a/docs/diagrams/route-authorization.md
+++ b/docs/diagrams/route-authorization.md
@@ -114,7 +114,7 @@ But Next.js Server Actions are independently invocable RPC endpoints: a crafted
 request can call an action without ever loading the page that hosts it, so the
 gate alone doesn't protect them. Each sensitive action therefore enforces its own
 authorization as a second layer (defense in depth), via two guards in
-[`session-access.guard.ts`](../../src/modules/auth/presentation/session/guards/session-access.guard.ts):
+[`session-access.guard.ts`](../../src/modules/auth/presentation/session/session-access.guard.ts):
 
 - **`requireSession()`** — any valid session; used by the invoice mutations.
 - **`requireAdmin()`** — an admin session; used by every user action (the

--- a/src/modules/auth/application/README.md
+++ b/src/modules/auth/application/README.md
@@ -86,37 +86,34 @@ Promise < Result < AuthenticatedUserDto, AppError >> {
 ```text
 application/
 ├── auth-user/                      # Auth user subdomain
-│   ├── commands/                   # Write operations (login, signup)
+│   ├── auth-error.factory.ts       # Auth error factory (flat file — no errors/ folder)
+│   ├── commands/                   # Write operations (login, signup, create-demo-user)
 │   ├── contracts/                  # Interfaces for infrastructure
 │   │   ├── repositories/           # Repository contracts
-│   │   └── services/               # Service contracts (password hashing, etc.)
+│   │   └── services/               # Service contracts (password hashing, generation)
 │   ├── dtos/                       # Data Transfer Objects
 │   │   ├── requests/               # Input DTOs
 │   │   └── responses/              # Output DTOs
-│   ├── errors/                     # Error factories
-│   ├── schemas/                    # Input validation schemas (Zod)
-│   ├── validators/                 # Domain entity validators
+│   ├── validators/                 # Input / entity validators
 │   └── workflows/                  # Multi-use-case orchestration
 │
 ├── session/                        # Session subdomain
+│   ├── builders/                   # Complex DTO builders
 │   ├── commands/                   # Write operations (establish, rotate, terminate)
-│   ├── queries/                    # Read operations (read, require)
 │   ├── contracts/                  # Session service contracts
 │   ├── dtos/                       # Session DTOs
 │   │   ├── requests/               # Input DTOs
 │   │   └── responses/              # Output DTOs
-│   ├── builders/                   # Complex DTO builders
 │   ├── mappers/                    # Session-specific mappers
-│   ├── schemas/                    # Session validation schemas
+│   ├── queries/                    # Read operations (read, require)
 │   └── workflows/                  # Session workflows
 │
 └── shared/                         # Shared application concerns
-    ├── helpers/                    # Utility functions
+    ├── helpers/                    # Cookie / authorization / session-cleanup helpers
     ├── logging/                    # Logging utilities
     └── mappers/                    # Cross-subdomain mappers
         └── flows/                  # Mappers organized by flow
-            ├── login/              # Login flow mappers
-            └── signup/             # Signup flow mappers
+            └── login/              # Login flow mappers (to-authenticated-user, to-session-principal)
 ```
 
 ---
@@ -217,7 +214,7 @@ Cross-cutting concerns:
 
 - **Helpers**: Cookie operations, authorization, session cleanup
 - **Logging**: Auth-specific logging utilities
-- **Mappers**: Organized by flow (login, signup) for easy navigation
+- **Mappers**: Organized by flow under `flows/` — currently `login/` (signup reuses these)
 
 ---
 
@@ -408,5 +405,5 @@ Changes to contracts or DTOs are breaking changes. Coordinate with:
 
 ---
 
-**Last Updated**: 2026-02-01\
+**Last Updated**: 2026-06-24\
 **Maintainer**: Auth Module Team

--- a/src/modules/auth/domain/README.md
+++ b/src/modules/auth/domain/README.md
@@ -50,12 +50,21 @@ The domain layer does **not**:
 
 ## Directory Structure
 
-This layer is intentionally small. Typical contents include:
+The domain is organized by subdomain (`auth-user`, `session`) plus a `shared/`
+constants area:
 
 ```text
 domain/
-├── entities/          # Domain entities (rich data + invariants)
-├── types/             # Branded types and enums (e.g., UserId, UserRole)
+├── auth-user/
+│   ├── entities/        # AuthUserEntity
+│   └── policies/        # password.policy.ts, registration.policy.ts
+├── session/
+│   ├── entities/        # session.entity.ts
+│   ├── policies/        # session-lifecycle + authorization/ route policies
+│   ├── value-objects/   # auth-brands.value.ts (branded types), time.value.ts
+│   └── auth-request-authorization.output.ts
+├── shared/
+│   └── constants/       # session-config, session-lifecycle, route, request, policy, demo-identity
 └── README.md
 ```
 
@@ -81,10 +90,10 @@ When data crosses the domain → application boundary, sensitive fields should b
 - **Infrastructure → Domain**: database rows are mapped into domain entities (e.g., `UserRow → AuthUserEntity`).
 - **Domain → Application**: passwords are stripped when mapping to DTOs (e.g., `AuthUserEntity → AuthenticatedUserDto`).
 
-For the full chain, see:
+For the boundary mappers, see:
 
-- `src/modules/auth/application/shared/mappers/mapper-chains.ts`
-- `src/modules/auth/application/shared/mappers/mapper-registry.ts`
+- `src/modules/auth/application/shared/mappers/flows/login/to-authenticated-user.mapper.ts` — strips the password hash
+- `src/modules/auth/application/shared/mappers/flows/login/to-session-principal.mapper.ts` — narrows to the session principal
 
 ---
 

--- a/src/modules/auth/infrastructure/README.md
+++ b/src/modules/auth/infrastructure/README.md
@@ -118,12 +118,15 @@ export class AuthUserRepository {
 
 ```text
 infrastructure/
+├── auth-transaction.logger.ts      # Transaction-scoped logger (flat — no logging/ folder)
+│
 ├── composition/                    # Dependency Injection
 │   ├── auth.composition.ts         # Main composition root
 │   └── factories/                  # Factory functions
 │       ├── auth-user/              # Auth user factories
 │       │   ├── auth-tx-deps.factory.ts
 │       │   ├── auth-unit-of-work.factory.ts
+│       │   ├── demo-user-use-case.factory.ts
 │       │   ├── login-use-case.factory.ts
 │       │   └── signup-use-case.factory.ts
 │       ├── crypto/                 # Crypto service factories
@@ -136,19 +139,15 @@ infrastructure/
 │           └── session-token-service.factory.ts
 │
 ├── crypto/                         # Cryptography implementations
-│   ├── adapters/
-│   │   └── password-hasher.adapter.ts
-│   ├── config/
-│   │   └── auth-crypto.config.ts
+│   ├── auth-crypto.config.ts       #   (flat — no config/ folder)
+│   ├── password-hasher.adapter.ts  #   (flat — no adapters/ folder)
 │   └── services/
 │       ├── bcrypt-password.service.ts
 │       └── password-generator.service.ts
 │
-├── logging/                        # Infrastructure logging
-│   └── auth-transaction.logger.ts
-│
 ├── persistence/                    # Database access
 │   └── auth-user/
+│       ├── auth-user.repository.ts # Repository impl (flat — no repositories/ folder)
 │       ├── adapters/               # Repository adapters
 │       │   ├── auth-unit-of-work.adapter.ts
 │       │   └── auth-user-repository.adapter.ts
@@ -156,29 +155,26 @@ infrastructure/
 │       │   ├── get-user-by-email.dal.ts
 │       │   ├── increment-demo-user-counter.dal.ts
 │       │   └── insert-user.dal.ts
-│       ├── mappers/                # Database row → Domain entity
-│       │   └── to-auth-user-entity.mapper.ts
-│       └── repositories/           # Repository implementations
-│           └── auth-user.repository.ts
+│       └── mappers/                # Database row → Domain entity
+│           ├── pg-unique-violation-to-signup-conflict-error.mapper.ts
+│           └── to-auth-user-entity.mapper.ts
 │
 └── session/                        # Session infrastructure
+    ├── jwt-to-session-token-claims-dto.mapper.ts   # JWT → DTO (flat — no mappers/ folder)
+    ├── session-jwt-crypto.strategy.ts              # JWT strategy (flat — no strategies/ folder)
+    ├── session-token-claims.schema.ts              # Zod schema for the JWT claims
+    ├── to-session-cookie-max-age-seconds.helper.ts # cookie max-age helper (flat — no helpers/ folder)
+    ├── adapters/                   # Session adapters
+    │   ├── session-cookie-store.adapter.ts
+    │   └── session-token-codec.adapter.ts
     ├── config/                     # Session configuration
     │   ├── session-cookie-options.config.ts
     │   ├── session-jwt.constants.ts
     │   └── session-token.constants.ts
-    ├── adapters/                   # Session adapters
-    │   ├── session-cookie-store.adapter.ts
-    │   └── session-token-codec.adapter.ts
     ├── services/                   # Session services
-    │   ├── session.service.ts
+    │   ├── jose-session-jwt-crypto.service.ts
     │   ├── session-token.service.ts
-    │   └── jose-session-jwt-crypto.service.ts
-    ├── strategies/                 # JWT strategies
-    │   └── session-jwt-crypto.strategy.ts
-    ├── mappers/                    # JWT → DTO mappers
-    │   └── jwt-to-session-token-claims-dto.mapper.ts
-    ├── helpers/                    # Session helpers
-    │   └── to-session-cookie-max-age-seconds.helper.ts
+    │   └── session.service.ts
     └── types/                      # Infrastructure types
         ├── session-cookie.constants.ts
         ├── session-jwt-claims.transport.ts
@@ -280,7 +276,7 @@ Facade over session use cases. Delegates to:
 
 Handles token issuance and validation:
 
-- Issues JWT with claims (userId, role, exp, iat, nbf)
+- Issues JWT with claims (`sub` (user id), `role`, `sid`, `jti`, `iat`, `exp`, `nbf`)
 - Validates token signature and claims
 - Enforces semantic checks (exp > iat, nbf <= iat, etc.)
 
@@ -421,7 +417,7 @@ export function toAuthUserEntity(row: UserRow): AuthUserEntity {
 
 Concrete implementation using bcrypt:
 
-- Hash passwords with salt rounds (10)
+- Hash passwords with env-configured salt rounds (`AUTH_BCRYPT_SALT_ROUNDS`)
 - Compare plaintext with hash
 - Returns `Result<boolean, AppError>`
 
@@ -439,16 +435,16 @@ Implements `PasswordHasherContract`:
 Concrete JWT implementation:
 
 - Algorithm: HS256 (HMAC with SHA-256)
-- Secret: From environment variable
-- Claims: userId, role, exp, iat, nbf
-- Expiration: 7 days (configurable)
+- Secret: From environment variable `SESSION_SECRET`
+- Claims: `sub` (user id), `role`, `sid`, `jti`, `iat`, `exp`, `nbf`
+- Expiration: 15 minutes per token, slid forward by rotation (see below)
 
 **Security Features:**
 
 - HTTP-only cookies (prevents XSS)
 - Secure flag (HTTPS only in production)
 - SameSite=Strict (CSRF protection; current default)
-- Short expiration (7 days)
+- Short-lived tokens (15 minutes), rotated up to a 30-day absolute ceiling
 - Signature verification on every request
 
 ---
@@ -458,8 +454,11 @@ Concrete JWT implementation:
 ### **Environment Variables**
 
 ```bash
-# Session JWT secret (required)
-SESSION_JWT_SECRET=your-secret-key-here
+# Session JWT signing secret (required)
+SESSION_SECRET=your-secret-key-here
+
+# Bcrypt cost factor (required — schema enforces a positive int, no default)
+AUTH_BCRYPT_SALT_ROUNDS=10
 
 # Database connection (required)
 DATABASE_URL=postgresql://...
@@ -467,9 +466,14 @@ DATABASE_URL=postgresql://...
 
 ### **Constants**
 
-- **Session duration**: 7 days (`SESSION_DURATION_SEC`)
+- **Session duration**: 15 minutes (`SESSION_DURATION_SEC` = 900s) — lifetime of a freshly issued token
+- **Refresh threshold**: 2 minutes (`SESSION_REFRESH_THRESHOLD_SEC`) — the "approaching expiry" rotation window
+- **Max absolute lifetime**: 30 days (`MAX_ABSOLUTE_SESSION_SEC`) — hard ceiling on age via `iat`, even with rotation
 - **Clock tolerance**: 5 seconds (`SESSION_TOKEN_CLOCK_TOLERANCE_SEC`)
-- **Bcrypt rounds**: 10 (`BCRYPT_SALT_ROUNDS`)
+- **Bcrypt rounds**: env-configured via `AUTH_BCRYPT_SALT_ROUNDS` (required; e.g. 10)
+
+> The full session state machine and these numbers are in the
+> [session-lifecycle diagram](../../../../docs/diagrams/session-lifecycle.md).
 
 ---
 
@@ -651,5 +655,5 @@ Changes to adapters or services that implement application contracts are breakin
 
 ---
 
-**Last Updated**: 2026-02-01\
+**Last Updated**: 2026-06-24\
 **Maintainer**: Auth Module Team

--- a/src/modules/auth/notes/adr/005-use-jwt-for-session-tokens.md
+++ b/src/modules/auth/notes/adr/005-use-jwt-for-session-tokens.md
@@ -17,7 +17,7 @@ We will use JSON Web Tokens (JWT) stored in secure, HTTP-only cookies for sessio
 - **Storage**: Tokens are stored in a cookie named `session` (or similar).
 - **Security**: Cookies must be `HttpOnly`, `Secure`, and use `SameSite: Strict` (current default; consider `Lax` only
   if you introduce cross-site auth flows and add CSRF protections as needed).
-- **Payload**: Minimal data should be stored in the JWT (e.g., `userId`, `role`, `sid`).
+- **Payload**: Minimal data should be stored in the JWT (e.g., `sub` (the user id), `role`, `sid`).
 - **Signing**: Use a strong cryptographic algorithm (e.g., HS256 with a sufficiently long secret).
 - **Rotation**: Sessions should support rotation (refreshing the expiration) to keep users logged in during active use
   while maintaining security.

--- a/src/modules/auth/notes/adr/007-enforce-action-level-authorization.md
+++ b/src/modules/auth/notes/adr/007-enforce-action-level-authorization.md
@@ -22,7 +22,7 @@ escalate privileges — or read user PII directly.
 
 Each sensitive server action enforces its own authorization, as a second layer
 beneath the route gate (defense in depth). Two guards live in
-[`session/guards/session-access.guard.ts`](../../presentation/session/guards/session-access.guard.ts):
+[`session/session-access.guard.ts`](../../presentation/session/session-access.guard.ts):
 
 - **`requireSession()`** — requires any valid session; redirects to login when
   none exists. Used by the invoice mutations (create / update / delete).

--- a/src/modules/auth/presentation/README.md
+++ b/src/modules/auth/presentation/README.md
@@ -101,10 +101,13 @@ export type LoginFormResult = FormResult<LoginField>;
 presentation/
 ├── authn/                          # Authentication UI
 │   ├── actions/                    # Server Actions
-│   │   ├── demo-user.action.ts     # Create demo user
+│   │   ├── demo-user.action.ts     # demoUserAction + demoAdminAction
 │   │   ├── login.action.ts         # User login
 │   │   ├── logout.action.ts        # User logout
 │   │   └── signup.action.ts        # User registration
+│   ├── adapters/                   # FormData → command adapters
+│   │   ├── to-login-command.adapter.ts
+│   │   └── to-signup-command.adapter.ts
 │   ├── components/                 # React components
 │   │   ├── cards/                  # Page-level components
 │   │   │   ├── login-card.tsx
@@ -114,32 +117,35 @@ presentation/
 │   │   │   ├── login-form.tsx
 │   │   │   ├── logout-form.tsx
 │   │   │   └── signup-form.tsx
-│   │   └── shared/                 # Reusable UI components
-│   │       ├── auth-actions-row.tsx
-│   │       ├── auth-form-demo-section.tsx
+│   │   └── shared/                 # Reusable UI (grouped by type)
 │   │       ├── auth-form-feedback.tsx
-│   │       ├── auth-form-social-section.tsx
-│   │       ├── auth-page-wrapper.tsx
 │   │       ├── forgot-password-link.tsx
-│   │       ├── form-row.wrapper.tsx
-│   │       ├── icons.tsx
 │   │       ├── remember-me-checkbox.tsx
-│   │       └── social-login-button.tsx
+│   │       ├── sections/
+│   │       │   ├── auth-form-demo-section.tsx
+│   │       │   └── auth-form-social-section.tsx
+│   │       ├── ui/
+│   │       │   ├── icons.tsx
+│   │       │   └── social-login-button.tsx
+│   │       └── wrappers/
+│   │           ├── auth-actions-row.tsx
+│   │           ├── auth-page-template.tsx
+│   │           └── form-row.wrapper.tsx
 │   ├── mappers/                    # Error mappers
-│   │   └── auth-form-error.mapper.ts
-│   └── transports/                 # Type definitions
+│   │   ├── map-generic-auth.error.ts
+│   │   ├── to-login-form-result.mapper.ts
+│   │   └── to-signup-form-result.mapper.ts
+│   └── transports/                 # Type definitions + form schemas
 │       ├── auth-action-props.transport.ts
+│       ├── login.form.schema.ts
 │       ├── login.transport.ts
+│       ├── signup.form.schema.ts
 │       └── signup.transport.ts
 │
-├── session/                        # Session UI + authorization guards
-│   ├── actions/
-│   │   └── verify-session-optimistic.action.ts
-│   ├── guards/                     # Server-action authorization
-│   │   └── session-access.guard.ts # requireSession() / requireAdmin()
-│   ├── components/                 # (Empty - future session UI)
-│   └── features/
-│       └── session-refresh.tsx
+├── session/                        # Session UI + authorization guards (flat files)
+│   ├── session-access.guard.ts     # requireSession() / requireAdmin()
+│   ├── session-refresh.tsx         # client session-refresh feature
+│   └── verify-session-optimistic.action.ts  # canonical optimistic session check
 │
 └── constants/                      # UI constants
     ├── auth-ui.constants.ts
@@ -234,7 +240,7 @@ Terminates current session.
 Server Actions are independently invocable RPC endpoints — a crafted request can
 reach an action without going through the page that hosts it — so the route
 checks in `proxy.ts` (middleware) are not sufficient on their own. The guards in
-[`session/guards/session-access.guard.ts`](session/guards/session-access.guard.ts)
+[`session/session-access.guard.ts`](session/session-access.guard.ts)
 make each sensitive action enforce its own authorization (defense in depth).
 
 | Guard              | Requires             | Redirects when denied                     | Used by                                                                   |
@@ -280,9 +286,9 @@ Page-level containers that wrap forms:
 ```typescript
 export function LoginCard() {
     return (
-        <AuthPageWrapper title = "Sign In" >
+        <AuthPageTemplate title = "Sign In" >
             <LoginForm / >
-            </AuthPageWrapper>
+            </AuthPageTemplate>
     );
 }
 ```
@@ -310,15 +316,15 @@ export function LoginForm() {
 
 #### **Shared Components** (`components/shared/`)
 
-Reusable UI elements:
+Reusable UI elements (grouped into `sections/`, `ui/`, and `wrappers/`):
 
-- **Layout**: `AuthPageWrapper`, `FormRowWrapper`
+- **Layout** (`wrappers/`): `AuthPageTemplate`, `AuthActionsRow`, `FormRowWrapper`
 - **Feedback**: `AuthFormFeedback` (displays errors)
 - **Controls**: `RememberMeCheckbox`
-- **Sections**: `AuthFormDemoSection`, `AuthFormSocialSection`
+- **Sections** (`sections/`): `AuthFormDemoSection`, `AuthFormSocialSection`
 - **Links**: `ForgotPasswordLink`
-- **Buttons**: `SocialLoginButton`
-- **Icons**: `Icons` (auth-related icons)
+- **Buttons** (`ui/`): `SocialLoginButton`
+- **Icons** (`ui/`): `Icons` (auth-related icons)
 
 ---
 
@@ -390,17 +396,18 @@ FormResult<LoginField> (presentation layer)
 User-friendly error message (UI)
 ```
 
-### **Error Mapper** (`mappers/auth-form-error.mapper.ts`)
+### **Error Mapper** (`mappers/to-login-form-result.mapper.ts`)
 
-Converts application errors to form errors:
+Converts application errors to form errors (the generic fallback lives in
+`map-generic-auth.error.ts`):
 
 ```typescript
 export function toLoginFormResult(
   error: AppError,
-  input: LoginRequestDto,
+  formData: LoginFormData,
 ): FormResult<never> {
-  // Map specific error codes to user-friendly messages
-  if (error.code === "invalid_credentials") {
+  // Map specific error keys to user-friendly messages
+  if (error.key === "invalid_credentials") {
     return {
       ok: false,
       error: {
@@ -652,14 +659,16 @@ Changes to Server Action signatures or form field names are breaking changes. Co
 
 ### **Suggested Enhancements**
 
-1. **Reorganize `components/shared/`**: Group by type (controls, feedback, layout, links, sections, ui)
-2. **Add client-side hooks**: `useAuthForm`, `useLoginState` for client components
-3. **Add session UI components**: Session status indicator, logout button
-4. **Add loading skeletons**: Better loading states for forms
-5. **Add animations**: Smooth transitions for error messages
-6. **Add toast notifications**: Success/error toasts instead of redirects
+> `components/shared/` has since been regrouped by type (`sections/`, `ui/`,
+> `wrappers/`), so that earlier suggestion is done.
+
+1. **Add client-side hooks**: `useAuthForm`, `useLoginState` for client components
+2. **Add session UI components**: Session status indicator
+3. **Add loading skeletons**: Better loading states for forms
+4. **Add animations**: Smooth transitions for error messages
+5. **Add toast notifications**: Success/error toasts instead of redirects
 
 ---
 
-**Last Updated**: 2026-06-09\
+**Last Updated**: 2026-06-24\
 **Maintainer**: Auth Module Team

--- a/src/modules/users/README.md
+++ b/src/modules/users/README.md
@@ -127,7 +127,7 @@ users/
     ├── forms/                           #   create / edit / delete-button
     └── constants/user-form.constants.ts
 
-__tests__/                               # Vitest unit tests (service); see also the co-located schema/action tests
+__tests__/unit/                          # Vitest unit tests, centralized by layer (service / schema / actions)
 ```
 
 ---
@@ -263,18 +263,22 @@ For when something should be an `AppError`, see
 
 ## Testing
 
-This module **has tests** (Vitest) — the most-covered of the feature modules:
+This module **has tests** (Vitest) — the most-covered of the feature modules.
+They live under a centralized `__tests__/unit/` tree (mirroring the source
+layers), not co-located next to the source:
 
 - `__tests__/unit/application/services/user.service.test.ts` — `UserService` with a
   fully mocked `UserRepositoryContract`, `HashingService`, and logger; covers
   `readUserById` (found / null / repo-error) and `createUser` (ok / repo-error).
-- `domain/schemas/__tests__/user.schema.test.ts` — form-schema validation.
-- `presentation/actions/__tests__/create-user.action.test.ts` — the create action.
+- `__tests__/unit/domain/schemas/user.schema.test.ts` — form-schema validation.
+- `__tests__/unit/presentation/actions/create-user.action.test.ts` — the create action.
+- `__tests__/unit/presentation/actions/delete-user.action.test.ts` — the delete action,
+  including the success redirect, not-found, unexpected-error, and admin-authorization paths.
 
 Run them with `pnpm test` (see [testing.md](../../../docs/testing.md)).
 
 **Coverage gaps worth filling:** `updateUser` / `deleteUser` / `readFilteredUsers`
-in the service, the DAL functions, and the update/delete actions are not yet unit-tested.
+in the service, the DAL functions, and the **update** action are not yet unit-tested.
 
 ---
 
@@ -289,4 +293,4 @@ in the service, the DAL functions, and the update/delete actions are not yet uni
 
 ---
 
-**Last updated:** 2026-06-09
+**Last updated:** 2026-06-24


### PR DESCRIPTION
## What & why

One of three parallel doc-review sessions. **Lane: auth + users module docs only.**
Verified every claim in the auth/users docs against the actual code (code = source
of truth) and applied tight corrections. No code, no `BACKLOG.md`, no docs index /
standards, no other module's docs were touched.

## Highest-impact drift fixed

| Doc | Claimed | Actual |
| --- | --- | --- |
| `auth/infrastructure/README.md` | Session expiration **"7 days"** | **15 min per token** (`SESSION_DURATION_SEC=900`), rotated up to a **30-day** absolute ceiling (`MAX_ABSOLUTE_SESSION_SEC`), 2-min refresh threshold |
| `auth/infrastructure/README.md` | Env `SESSION_JWT_SECRET`; const `BCRYPT_SALT_ROUNDS=10` | `SESSION_SECRET`; `AUTH_BCRYPT_SALT_ROUNDS` (required env var, **no default**) |
| `auth/infrastructure/README.md` | JWT claims `userId, role, exp, iat, nbf` | `sub, role, sid, jti, iat, exp, nbf` |
| `auth/presentation/README.md` + ADR-007 + 2 diagrams | guard at `session/guards/…`, verify at `session/actions/…` | both **flat** under `session/` |
| `users/README.md` | delete action "not yet unit-tested" | `delete-user.action.test.ts` exists (incl. admin-auth path) |

## All changes by file

- **`auth/infrastructure/README.md`** — session lifetime (7d → 15min/30d), env var names, JWT claim set, bcrypt rounds; rewrote the directory tree to match the **flattened** layout (`crypto/`, `persistence/auth-user/`, `session/` no longer nest under `adapters//config//repositories//strategies//mappers//helpers/`; `logging/` folder is gone — logger is flat); added `demo-user-use-case.factory.ts` and the pg-unique-violation mapper. Bumped Last-Updated.
- **`auth/presentation/README.md`** — `session/` is flat (3 files), not `actions//guards//components//features/`; fixed the guard link; `components/shared/` regrouped into `sections//ui//wrappers/`; `auth-page-wrapper.tsx` → `auth-page-template.tsx` / `AuthPageTemplate`; added `adapters/` + `*.form.schema` transports; error mapper is `to-login-form-result.mapper.ts` keyed on `error.key` (not `error.code`); removed the already-completed "regroup shared/" future-improvement.
- **`auth/application/README.md`** — removed non-existent `errors//schemas/` (auth-user) and `schemas/` (session); `flows/` has only `login/`; surfaced `auth-error.factory.ts`.
- **`auth/domain/README.md`** — replaced the stale "intentionally small" tree with the real `auth-user//session//shared` structure; fixed dead references to `mapper-chains.ts` / `mapper-registry.ts` (don't exist) → the real login-flow mappers.
- **`users/README.md`** — tests are centralized under `__tests__/unit/` (not co-located); added the delete-action test; corrected the coverage-gap line.
- **ADR-005** — payload example `userId` → `sub`. **ADR-007**, **`docs/diagrams/route-authorization.md`**, **`docs/diagrams/auth-login-flow.md`** — corrected the flattened `session/` paths.

`session-lifecycle.md` and `request-flow-update-user.md` were checked and needed **no** changes (the lifecycle diagram already documents the correct 15min/2min/30day numbers — it's what the infra README contradicted).

## Backlog-worthy (out of scope for this PR)

- **5 empty stub READMEs** carry no claims so weren't edited, but are worth filling or removing: `application/auth-user/README.md`, `application/session/README.md`, `application/auth-user/commands/README.md`, `infrastructure/persistence/README.md`, `infrastructure/session/README.md` (all 0 bytes). Two near-stubs: `application/shared/README.md`, `application/auth-user/workflows/README.md` (one line each).
- **No build-time guard** keeps these directory-structure trees honest — they drifted because the code was reorganized (flattened folders, regrouped shared components) without the docs following. A doc-lint or a generated tree would prevent recurrence.

## Verification

`pnpm check:fast` green: Biome (608 files), markdownlint (0 errors), dprint, `tsc -b`, next typegen, db:drift. Docs-only change — did not run the dev server / e2e (parallel sessions share the port; CI covers them).
