### PR TITLE
docs: fix cross-cutting documentation drift against the codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,17 +21,17 @@ This project runs in git worktrees under `.claude/worktrees/`, not a single chec
 
 Project-level slash commands are defined in `.claude/commands/`:
 
-| Command       | Runs                                                                                                 |
-| ------------- | ---------------------------------------------------------------------------------------------------- |
-| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                        |
-| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)                |
-| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)                     |
-| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                         |
-| `/test`       | `pnpm test` — unit tests only (report-only)                                                          |
-| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                                    |
-| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                             |
-| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI         |
-| `/promote`    | open the `develop → main` release PR, run the full gate (check + E2E), watch CI, hand the merge back |
+| Command       | Runs                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------ |
+| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                                |
+| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, typegen, unit + integration tests, e2e (report-only) |
+| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)                             |
+| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                                 |
+| `/test`       | `pnpm test` — unit tests only (report-only)                                                                  |
+| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                                            |
+| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                                     |
+| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI                 |
+| `/promote`    | open the `develop → main` release PR, run the full gate (check + E2E), watch CI, hand the merge back         |
 
 Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit). `/ship` commits, pushes, and opens a PR into `develop` from a worktree feature branch (never `develop`/`main` directly); `/promote` opens the `develop → main` release PR and watches the full gate but never merges `main` itself — that stays a human decision.
 

--- a/README.md
+++ b/README.md
@@ -12,39 +12,40 @@ authentication, middleware-based route protection, database migrations/seeding, 
 ## Tech Stack
 
 - Next.js 16 (App Router, Server/Client Components)
-- React 19 + TypeScript 5 (strict)
+- React 19 + TypeScript 6 (strict)
 - Drizzle ORM (PostgreSQL)
 - Tailwind CSS v4
 - Cypress for E2E testing (with @testing-library/cypress and cypress-axe)
-- Biome and Prettier for formatting and checks
+- Biome for JS/TS/JSON; dprint + markdownlint-cli2 for Markdown
 - Turbopack for dev/build
 
-Note: ESLint is not used in this project, by design.
+Note: ESLint and Prettier are not used in this project, by design.
 
 ## Project Structure
 
 ```text
 nextjs-dashboard/
 ├── cypress/                # E2E specs and support
+├── database/               # Drizzle schema (source of truth)
 ├── docs/                   # Additional documentation and guides
-├── drizzle/                # Generated SQL, migrations, meta
+├── drizzle/                # Generated SQL migrations, one set per env (dev/test/prod)
 ├── devtools/               # cli, config, seed-support, tasks
 ├── public/                 # Static assets
 ├── src/                    # Application source
 │   ├── app/                # App router
-│   ├── modules/            # auth, customers, invoices, revenues, users
-│   ├── server/             # config, db, events
-│   ├── shared/             # branding, config, errors, forms, http,  logging, result, routes, utilities
-│   ├── shell/              # dashboard-wide components/screens/
-│   ├── ui/                 # atoms, brand, feedback, forms, molecules, navigation, styles
-│   ├── proxy.ts       # Route protection
+│   ├── modules/            # auth, banner, customers, invoices, users (each internally layered)
+│   ├── server/             # cookies, crypto, db (shared server infra)
+│   ├── shared/             # core, forms, http, policies, primitives, routing, telemetry, time
+│   ├── shell/              # dashboard composition
+│   ├── ui/                 # atoms, brand, forms, hooks, molecules, navigation, skeletons, styles, utils, wrappers
+│   ├── proxy.ts            # Route protection (Next.js middleware)
 └── ...
 ```
 
 ## Requirements
 
-- Node >= 24
-- PNPM >= 10.12
+- Node >= 26 (pinned in `.nvmrc`)
+- pnpm >= 11 (pinned via the `packageManager` field in `package.json`)
 - PostgreSQL (local or remote)
 
 ## Getting Started

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,18 +21,20 @@ All environments need these. Validation lives in
 `src/shared/core/config/` — the server **fails fast at startup** if any are
 missing or malformed, so set them all.
 
-| Variable                  | Example                               | Notes                                     |
-| ------------------------- | ------------------------------------- | ----------------------------------------- |
-| `DATABASE_URL`            | `postgresql://user:pass@host:5432/db` | Neon: append `?sslmode=require`           |
-| `SESSION_SECRET`          | (long random string)                  | generate with `openssl rand -base64 48`   |
-| `AUTH_BCRYPT_SALT_ROUNDS` | `12`                                  | positive integer                          |
-| `SESSION_ISSUER`          | `my-app`                              | fixed value                               |
-| `SESSION_AUDIENCE`        | `web`                                 | fixed value                               |
-| `NODE_ENV`                | `production`                          |                                           |
-| `DATABASE_ENV`            | `production`                          | selects the migration scope               |
-| `LOG_LEVEL`               | `info`                                | `trace`\|`debug`\|`info`\|`warn`\|`error` |
-| `NEXT_PUBLIC_NODE_ENV`    | `production`                          | inlined into the client bundle at build   |
-| `NEXT_PUBLIC_LOG_LEVEL`   | `info`                                | inlined into the client bundle at build   |
+| Variable                  | Example                               | Notes                                                       |
+| ------------------------- | ------------------------------------- | ----------------------------------------------------------- |
+| `DATABASE_URL`            | `postgresql://user:pass@host:5432/db` | Neon: append `?sslmode=require`                             |
+| `SESSION_SECRET`          | (long random string)                  | generate with `openssl rand -base64 48`                     |
+| `AUTH_BCRYPT_SALT_ROUNDS` | `12`                                  | positive integer                                            |
+| `NODE_ENV`                | `production`                          | `development` \| `test` \| `production`                     |
+| `DATABASE_ENV`            | `production`                          | selects the migration scope                                 |
+| `NEXT_PUBLIC_NODE_ENV`    | `production`                          | inlined into the client bundle at build                     |
+| `NEXT_PUBLIC_LOG_LEVEL`   | `info`                                | `trace`\|`debug`\|`info`\|`warn`\|`error`; inlined at build |
+
+The server validates `DATABASE_URL`, `SESSION_SECRET`, and `AUTH_BCRYPT_SALT_ROUNDS` (plus `NODE_ENV` /
+`DATABASE_ENV`) and fails fast at startup if any are missing or malformed. The JWT `issuer` / `audience`
+are compile-time **constants** (`my-app` / `web`), not env vars — see
+`src/modules/auth/infrastructure/session/config/session-jwt.constants.ts`.
 
 **Demo logins** (created by the seed):
 

--- a/docs/drizzle.md
+++ b/docs/drizzle.md
@@ -5,10 +5,11 @@ TypeScript CLI scripts in `devtools/`.
 
 ## Key Locations
 
-- `drizzle/` — generated SQL, migrations, and meta
-- `drizzle.config.ts` — Drizzle Kit configuration
-- `devtools/cli/*.ts` — reset and seed helpers
-- `src/server/**` — server-side DB access (repositories/services)
+- `database/schema/` — the Drizzle table schema (the source migrations are generated from)
+- `drizzle/migrations/{dev,test,prod}/` — generated SQL migrations, one set per environment
+- `drizzle.config.ts` — Drizzle Kit config (`schema` → `database/schema`, `out` → the per-env migration dir)
+- `devtools/cli/*.ts` + `devtools/seed/**` — reset and seed helpers
+- `src/server/db/` — the shared database connection; per-module repositories live in each module's `infrastructure/persistence/`
 
 ## Common Commands
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,8 +4,8 @@ This guide helps you set up, run, and develop the Next.js Dashboard locally.
 
 ## Prerequisites
 
-- Node >= 24
-- PNPM >= 10.12
+- Node >= 26 (pinned in [`.nvmrc`](../.nvmrc); CI reads the version from it)
+- pnpm >= 11 (pinned via the `packageManager` field in [`package.json`](../package.json))
 - PostgreSQL (local or remote)
 
 ## 1. Install Dependencies

--- a/docs/package-json-scripts-guide.md
+++ b/docs/package-json-scripts-guide.md
@@ -45,7 +45,7 @@ Markdown is linted by markdownlint-cli2 and formatted by dprint (Biome's Markdow
 Build and run the app.
 
 - `pnpm next:dev` — start Next.js in development mode (Turbopack).
-- `pnpm next:dev:test` — start Next.js in development mode on port 3001 with the test environment.
+- `pnpm next:dev:test` — start Next.js in development mode with the test environment (port from `PORT` in `.env.test.local`).
 - `pnpm next:build` — create a production build.
 - `pnpm next:build:test` — build the app using the test environment.
 - `pnpm next:build:standalone` — clean and build a standalone production bundle.
@@ -66,6 +66,9 @@ End-to-end testing.
 - `pnpm cy:e2e:ci` — alias for `cy:e2e`.
 - `pnpm cy:e2e:open` — open the Cypress interactive runner.
 - `pnpm cy:e2e:run` — run Cypress E2E in headless mode.
+- `pnpm cy:open:with-server` — boot the test-env dev server, then open the interactive runner.
+- `pnpm cy:server` — start the test-env dev server only (alias for `next:dev:test`).
+- `pnpm cy:preflight` — run the `/api/health` identity preflight (asserts the test env/DB).
 - `pnpm cy:open` — open Cypress (general).
 - `pnpm cy:run` — run Cypress (general).
 - `pnpm cy:clean` — remove generated Cypress config artifacts.
@@ -87,6 +90,7 @@ Migrations, seeding, and resets per environment.
 - `pnpm db:reset:prod` — drop, recreate, and seed the production database.
 - `pnpm db:studio:dev` — open Drizzle Studio against the development database.
 - `pnpm db:studio:test` — open Drizzle Studio against the test database.
+- `pnpm db:drift` — assert the dev/test/prod migration sets describe the same schema (the CI drift gate; no database needed).
 
 ---
 
@@ -110,17 +114,21 @@ Load a specific `.env.*.local` file before running a command.
 - `pnpm clean:deps` — remove `node_modules`.
 - `pnpm clean:generated` — remove generated `.js`, `.map`, and `.tsbuildinfo` files.
 - `pnpm knip` — find unused exports, files, and dependencies.
-- `pnpm check` — run lint, typecheck, typegen, tests, and E2E.
-- `pnpm check:fast` — run lint, typecheck, and typegen only.
-- `pnpm check:repo` — run full check plus knip.
-- `pnpm test` — run unit/integration tests (Vitest) with the test environment.
-- `pnpm test:coverage` — run tests with coverage using the test environment.
-- `pnpm test:ui` — open Vitest UI with the test environment.
-- `pnpm test:watch` — run Vitest in watch mode with the test environment.
+- `pnpm check` — run Biome lint, Markdown check, typecheck, typegen, unit + integration tests, and E2E.
+- `pnpm check:fast` — run Biome lint, Markdown check, typecheck, typegen, and the migration-drift gate (no tests/E2E).
+- `pnpm check:repo` — run full `check` plus knip.
+- `pnpm test` — run the unit lane (alias for `test:unit`; `vitest run --project unit`). DB-free; no test env needed.
+- `pnpm test:unit` — run the unit lane once (pure/mocked, no database).
+- `pnpm test:integration` — run the integration lane against the real `test_db` (loads `.env.test.local` via `env:test`).
+- `pnpm test:all` — run the unit and integration lanes together.
+- `pnpm test:coverage` — run the unit lane with coverage (enforces the floors in `vitest.config.ts`). No test env needed.
+- `pnpm test:ui` — open the Vitest UI.
+- `pnpm test:watch` — run the unit lane in watch mode.
 
-Vitest environment variables are loaded by the `test:*` scripts via `env:test`; `vitest.setup.ts` only registers global
-test mocks. If DB-backed integration tests continue to run in the same `pnpm test` command as unit tests, revisit Vitest
-`coverage`, `pool`/isolation, and explicit integration-test behavior so the default test command remains predictable.
+The unit lane is database-free: it runs against a schema-valid dummy env baked into `vitest.config.ts`, so it needs
+neither `.env.test.local` nor a live database. Only the integration lane (`test:integration`, and the integration half
+of `test:all`) loads `.env.test.local` via `env:test` and talks to the real `test_db`. `vitest.setup.ts` registers the
+global server-API mocks shared by both lanes.
 
 ---
 
@@ -160,4 +168,4 @@ pnpm next:dev
 
 ---
 
-_Last updated: 2026-04-02_
+_Last updated: 2026-06-24_

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -2,6 +2,16 @@
 
 Use this guide to decide where code belongs and how layers interact.
 
+> **The model in one line:** each feature is a self-contained vertical slice under
+> `src/modules/<feature>/`, internally organized into clean-architecture layers
+> (`presentation/`, `application/`, `domain/`, `infrastructure/`) — so a module owns
+> its own UI, domain rules, use cases, **and** its data access (repositories, DB
+> queries) and server actions. `src/server` is _not_ where feature repositories or
+> actions live; it holds only the small set of **shared, cross-cutting** server-only
+> pieces (the Drizzle connection, cookies, crypto). For the per-module layering and
+> dependency direction, see [diagrams/module-layers.md](diagrams/module-layers.md)
+> and [standards/clean-architecture-standards.md](standards/clean-architecture-standards.md).
+
 ## 1) Identify the concern: domain capability vs. page/layout composition
 
 - Domain capability: A cohesive business area with its own models, rules, and reusable UI (e.g., auth, invoices,
@@ -50,23 +60,26 @@ Use this guide to decide where code belongs and how layers interact.
 
 - shared: May only import from shared. Lowest-level utilities, tokens, and primitives.
 - ui: Base, reusable UI primitives and patterns (atoms/molecules). May import from shared.
-- modules: A domain slice. May import from modules (itself/peers) and shared/ui. Must not import from shell.
+- modules: A domain slice, internally layered (presentation/application/domain/infrastructure). May import from modules (itself/peers) and shared/ui. Must not import from shell.
 - shell: App composition/orchestration. May import from modules, shared, ui. Should not be imported by modules.
-- server: Infrastructure, actions, services, repositories. No import restrictions (but keep server code server-only).
-- app (Next.js): Routes and server components. Should delegate domain logic to server/modules and composition to shell.
+- server: **Shared, cross-cutting** server-only infrastructure (the DB connection, cookies, crypto) — not feature repositories or actions, which live inside each module. Keep server code server-only.
+- app (Next.js): Routes and server components. Should delegate domain logic to modules (and shared server infra) and composition to shell.
 
 One-way dependency rule of thumb:
 shared/ui -> modules -> shell -> app
-server is usable from modules/shell/app as needed.
+the shared `server` infra is usable from modules/shell/app as needed.
 
 ---
 
 ## Purpose of the `src` folder's children
 
-1. `modules` — Domain-centric slices (auth, invoices, customers, users, etc.). Each slice exposes:
-   - Domain types, schemas, and view-model mappers
-   - Reusable, module-scoped UI
-   - Light adapters that are module-specific (no DB or external I/O)
+1. `modules` — Domain-centric vertical slices (auth, invoices, customers, users, banner). Each slice is internally layered (`presentation/`, `application/`, `domain/`, `infrastructure/`) and owns:
+   - Domain entities, value objects, and policies (`domain/`)
+   - Use cases, contracts, schemas, and mappers (`application/`)
+   - Its own data access — repositories, DAL, row↔entity mappers (`infrastructure/`)
+   - Server actions and module-scoped UI (`presentation/`)
+
+   Not every module needs every layer — thin CRUD slices (`customers`, `banner`) skip `application/`. See [diagrams/module-layers.md](diagrams/module-layers.md) for the per-module map.
 
 2. `shared` — Cross-cutting, module-agnostic utilities and tokens:
    - Pure helpers, constants, types
@@ -86,10 +99,10 @@ server is usable from modules/shell/app as needed.
      - Data access or external API calls (keep in server)
      - Generic utilities (keep in shared)
 
-4. `server` — Infrastructure and backend-facing code:
-   - Database access, repositories, migrations
-   - Services and server actions
-   - Integration with external systems (OAuth, queues, webhooks)
+4. `server` — Shared, cross-cutting server-only infrastructure (the small stuff many modules need):
+   - The Drizzle database **connection** (`server/db/`)
+   - Cookie handling (`server/cookies/`) and crypto/hashing (`server/crypto/`)
+   - Note: feature **repositories** and **server actions** do _not_ live here — they live in each module's `infrastructure/` and `presentation/`. Drizzle schema and migrations live in `database/schema` and `drizzle/migrations/` (see [drizzle.md](drizzle.md)).
 
 5. `ui` — Base UI primitives intended for reuse and extension:
    - Atoms/molecules (buttons, inputs, wrappers)
@@ -101,15 +114,14 @@ server is usable from modules/shell/app as needed.
 
 1. Is it app chrome or cross-module composition (layouts, nav, role gates, dashboard composition)?
    - Yes → Place in `shell`.
-2. Is it a domain capability with reusable UI and types (auth, invoices, customers)?
-   - Yes → Place in `modules/<module>`.
-3. Is it infrastructure (DB, services, actions, external APIs)?
+2. Is it a domain capability — a repository, use case, server action, domain rule, or module UI for one feature?
+   - Yes → Place in the right layer of `modules/<module>` (`infrastructure/`, `application/`, `presentation/`, `domain/`).
+3. Is it shared, cross-cutting server-only infrastructure used by many modules (the DB connection, cookies, crypto)?
    - Yes → Place in `server`.
 4. Is it a generic utility, token, or primitive UI with no domain knowledge?
    - Yes → `shared` (utilities/tokens) or `ui` (primitive components).
 5. Route files and data fetching for pages?
-   - Prefer `src/app` server components that call into `server` (for data) and render `shell` (for composition) and
-     `modules` (for module UI).
+   - Prefer `src/app` server components that call into `modules` (for data and module UI) and render `shell` (for composition).
 
 ---
 
@@ -128,8 +140,8 @@ server is usable from modules/shell/app as needed.
   - Don't: Import from modules or shell.
 
 - server
-  - Do: Encapsulate data access and integrations; expose actions/services.
-  - Don't: Contain client UI.
+  - Do: Hold shared, cross-cutting server-only infrastructure (DB connection, cookies, crypto).
+  - Don't: Contain client UI, or feature-specific repositories/actions (those belong in the module).
 
 ---
 
@@ -140,8 +152,9 @@ server is usable from modules/shell/app as needed.
   - Underlying widgets provided by their respective `modules/*`
 
 - Authentication:
-  - Forms, schemas, roles, and client helpers in `modules/auth`
-  - Server actions and provider integrations in `server/auth`
+  - Domain rules, use cases, schemas, repositories, server actions, and module UI all live in `modules/auth` (across its
+    `domain`/`application`/`infrastructure`/`presentation` layers)
+  - It reuses shared server infra from `server` (the DB connection, cookies, crypto) rather than reimplementing it
   - If the sidebar needs a logout button or role-aware links, the sidebar lives in `shell`, consuming `modules/auth`
     UI or actions.
 
@@ -152,4 +165,4 @@ boundaries, and simplify testing and scaling of both the UI and the backend.
 
 ---
 
-_Last updated: 2026-03-03_
+_Last updated: 2026-06-24_

--- a/docs/standards/clean-architecture-standards.md
+++ b/docs/standards/clean-architecture-standards.md
@@ -35,7 +35,7 @@ drivers.
 
 - **Allowed Imports**:
   - Primitives and TypeScript utilities
-  - Shared domain types (`@/shared/domain/`)
+  - Shared value types and branded primitives (`@/shared/primitives/`, `@/shared/core/branding/`)
 - **Forbidden Imports**:
   - Application layer (DTOs, schemas, use cases, contracts)
   - Infrastructure implementations

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,26 +1,34 @@
 # Testing
 
-The dashboard has two layers of tests, and both run under the **test environment**
-(`.env.test.local`):
+The dashboard has three test lanes. The **unit** lane is database-free and runs
+anywhere; the **integration** and **E2E** lanes talk to the real `test_db` under
+the **test environment** (`.env.test.local`):
 
-| Layer              | Tool    | Command       | What it covers                                                    |
-| ------------------ | ------- | ------------- | ----------------------------------------------------------------- |
-| Unit + integration | Vitest  | `pnpm test`   | Logic, mappers, services, and full-stack flows through the layers |
-| End-to-end (E2E)   | Cypress | `pnpm cy:e2e` | The running app in a real browser, including accessibility        |
+| Lane        | Tool    | Command                 | What it covers                                                | Needs `test_db`? |
+| ----------- | ------- | ----------------------- | ------------------------------------------------------------- | ---------------- |
+| Unit        | Vitest  | `pnpm test`             | Pure logic, mappers, services — dependencies mocked           | No               |
+| Integration | Vitest  | `pnpm test:integration` | Full-stack flows through the layers against the real database | Yes              |
+| End-to-end  | Cypress | `pnpm cy:e2e`           | The running app in a real browser, including accessibility    | Yes              |
 
-Before running either, make sure the **test database** exists and is migrated — see
-[database-setup.md](database-setup.md). The integration tests and all E2E specs
-talk to `test_db`.
+`pnpm test` is an alias for `pnpm test:unit` (unit only); `pnpm test:all` runs the
+unit and integration lanes together.
+
+Before running the integration or E2E lanes, make sure the **test database** exists
+and is migrated — see [database-setup.md](database-setup.md). The unit lane needs
+neither a database nor `.env.test.local`: it runs against a schema-valid dummy env
+baked into [`vitest.config.ts`](../vitest.config.ts).
 
 ## Unit & integration tests (Vitest)
 
 Config: [`vitest.config.ts`](../vitest.config.ts) · setup: [`vitest.setup.ts`](../vitest.setup.ts)
 
 ```sh
-pnpm test            # run once (test env)
-pnpm test:watch      # re-run on change
-pnpm test:ui         # Vitest UI
-pnpm test:coverage   # run once with coverage
+pnpm test             # unit lane, run once (no database needed)
+pnpm test:watch       # unit lane, re-run on change
+pnpm test:ui          # Vitest UI
+pnpm test:coverage    # unit lane once, with coverage (enforces the floors)
+pnpm test:integration # integration lane against the real test_db
+pnpm test:all         # unit + integration
 ```
 
 **Where tests live** — beside the code they cover, in `__tests__/` folders:
@@ -28,7 +36,8 @@ pnpm test:coverage   # run once with coverage
 - `__tests__/unit/…` — pure logic with dependencies mocked. No database needed.
 - `__tests__/integration/…` — exercise multiple layers together (presentation →
   application → infrastructure → DB). **These connect to the real `test_db`**, so
-  Postgres must be running and migrated (`pnpm db:push:test`) before `pnpm test`.
+  Postgres must be running and migrated (`pnpm db:push:test`) before
+  `pnpm test:integration` (or `pnpm test:all`).
 
 **Conventions:**
 
@@ -90,15 +99,23 @@ cy.checkA11y()
 
 ## CI
 
-- Unit / integration: `pnpm test` (needs the migrated `test_db`).
-- E2E headless: `pnpm cy:e2e` (alias `pnpm cy:e2e:ci`) — it boots the server itself.
+The CI gate is two-tier, matching the branch model — see
+[branching-and-releases.md](branching-and-releases.md).
+
+- **`check` job (every push/PR to `develop` and `main`):** runs `pnpm test:coverage`,
+  the DB-free unit lane, which also enforces the coverage floors in
+  `vitest.config.ts`. The integration lane is **not** run in CI — it needs a live
+  database — so run it locally before opening a PR.
+- **`e2e` job (main-targeting work only):** `pnpm cy:e2e` (alias `pnpm cy:e2e:ci`) —
+  it boots the server itself against an ephemeral Postgres service container.
 - Cypress records no video by default (`video: false` in `cypress.config.ts`).
 
 ## Troubleshooting
 
-- **`pnpm test` can't connect / hangs** — the integration tests need `test_db`.
-  Confirm Postgres is up, `pnpm db:push:test` has run, and `.env.test.local`'s
-  `DATABASE_URL` is reachable.
+- **`pnpm test:integration` can't connect / hangs** — the integration tests need
+  `test_db`. Confirm Postgres is up, `pnpm db:push:test` has run, and
+  `.env.test.local`'s `DATABASE_URL` is reachable. (The plain `pnpm test` unit lane
+  is database-free, so it should never need a connection.)
 - **Cypress can't reach the app** — confirm the server is running and that `PORT`
   and `CYPRESS_BASE_URL` in `.env.test.local` agree (the auto-server path derives
   its wait-URL from `PORT`).

--- a/docs/tsconfig.md
+++ b/docs/tsconfig.md
@@ -43,7 +43,7 @@ later layers win:
 | `next`                      | Next.js: DOM libs, `module: esnext`, `moduleResolution: bundler`, `jsx: preserve`, `plugins: [next]`, `noEmit` |
 
 On top of the presets, the root then sets `target: esnext` and `jsx: react-jsx`, declares the path aliases (`@/*`,
-`@cypress/*`, `@database/*`, `@devtools/*`) and explicit `types`, and relaxes three `strictest` flags
+`@cypress/*`, `@database/*`, `@devtools/*`, `@test-support/*`) and explicit `types`, and relaxes three `strictest` flags
 (`exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`, `noUnusedLocals`).
 
 For the exact contents of each preset, read them in `@tsconfig/bases` — a copy pasted here would drift the moment the

--- a/docs/ui-refactor-strategy.md
+++ b/docs/ui-refactor-strategy.md
@@ -146,7 +146,7 @@ Use the current codebase as the reference for what should stay where.
   - Keep in auth presentation because it is a feature-local page template, not app-wide shell.
 - `src/shell/dashboard/components/dashboard-sidebar.tsx`
   - Keep in `src/shell` because it composes branding, navigation, and auth logout into dashboard chrome.
-- `src/ui/molecules/page-header.tsx`
+- `src/ui/molecules/page-header.molecule.tsx`
   - Keep in `src/ui` as long as it stays feature-neutral and does not absorb auth-specific behavior.
 
 ### Signals that a file is in the wrong layer

--- a/docs/weekly-maintenance-routine.md
+++ b/docs/weekly-maintenance-routine.md
@@ -1,9 +1,10 @@
-# Weekly maintenance routine (drafted)
+# Weekly maintenance routine
 
 A scheduled Claude Code cloud agent that keeps the repo current with a single,
-reviewable PR each week. Drafted from the `BACKLOG.md` "Weekly codemod routine"
-item, with extra scope recommended below. **Not yet live** — create it with
-`/schedule` once you're happy with the scope.
+reviewable PR each week. Grown from the `BACKLOG.md` "Weekly codemod routine"
+item, with extra scope recommended below. **Live** — it runs as the
+`weekly-maintenance` `/schedule` cloud agent (cron `0 9 * * 1`, Mondays). This doc
+records its scope and rationale; use `/schedule` to list, adjust, or disable it.
 
 ## Schedule
 


### PR DESCRIPTION
## What & why

The **shared, project-wide docs lane** (one of four parallel doc-review sessions). I verified every cross-cutting doc against the **actual code** (code = source of truth, not the doc) and fixed factual drift with minimal edits. Strictly stayed in lane: **no per-module READMEs/ADRs and no module-specific diagrams were touched** — those belong to the three live module sessions.

Gate: `pnpm check:fast` green (biome 608 files · markdownlint 0 · dprint clean · `tsc -b` · typegen · migration-drift OK).

## Fixed (drift confirmed against code)

| File | Drift → fix |
| --- | --- |
| `docs/testing.md` | `pnpm test` claimed to run unit **+ integration** w/ test env. Reality: `test` = `test:unit`, DB-free dummy env (`vitest.config.ts`). Documented the unit/integration/all split; CI runs only the DB-free unit lane (`test:coverage`), integration is **not** in CI. |
| `docs/package-json-scripts-guide.md` | Same `test`/`check`/`check:fast` description errors; added `test:unit`/`test:integration`/`test:all`/`db:drift`/`cy:*` entries; removed the stale "integration runs in `pnpm test`" paragraph; fixed `next:dev:test` port claim. |
| `docs/project-structure.md` | Superseded model ("all infra/repos/actions live in `src/server`; modules have no DB/IO"). Verified every `*.action.ts` lives in `modules/*/presentation` and every `*.repository.ts` in `modules/*/infrastructure`; `src/server` = shared infra (db/cookies/crypto) only. Rewrote the model note, import rules, decision tree, examples. |
| `docs/deployment.md` | Env contract listed 3 non-existent vars: `SESSION_ISSUER`/`SESSION_AUDIENCE` are hardcoded constants (`session-jwt.constants.ts`), `LOG_LEVEL` was removed (BACKLOG #67). Now matches the real fail-fast contract in `src/shared/core/config/`. |
| `README.md` | TypeScript **6** (not 5); Biome + dprint + markdownlint (no Prettier); fixed the `src/` tree — no `revenues` module (it's `banner`), corrected `server`/`shared`/`ui`, added `database/`. |
| `README.md` + `docs/getting-started.md` | Node **>= 26** (`.nvmrc`), pnpm **>= 11** (`packageManager`) — were `24` / `10.12`. |
| `docs/drizzle.md` | Key Locations: schema in `database/schema`, per-env migrations in `drizzle/migrations/{dev,test,prod}/`, repos in module `infrastructure/`. |
| `docs/tsconfig.md` | Added the `@test-support/*` path alias. |
| `docs/standards/clean-architecture-standards.md` | Domain allowed-import `@/shared/domain/` (doesn't exist) → `@/shared/primitives/`, `@/shared/core/branding/`. |
| `docs/ui-refactor-strategy.md` | `src/ui/molecules/page-header.tsx` → `page-header.molecule.tsx` (actual filename). |
| `docs/weekly-maintenance-routine.md` | Marked **live** — the `weekly-maintenance` `/schedule` agent exists (cron `0 9 * * 1`, last ran 2026-06-23). |
| `CLAUDE.md` | `/check-full` description: `pnpm check` runs `test:all` (unit **+ integration**) + typegen. *(Flagged below — governance file.)* |

## Verified accurate — no change needed

`docs/README.md`, `docs/branching-and-releases.md`, `docs/lane-map.md`, `docs/shared-architecture.md`, `docs/database-setup.md`, `docs/knip.md`, `docs/claude-code-command-guide.md`, `docs/when-to-use-app-error.md`, `docs/standards/{error-handling-and-result-pattern,global-standards,naming-conventions-and-organization,ui-design-standards}.md`, and all in-scope diagrams (`c4-architecture`, `module-layers`, `dependency-injection`, `database-erd`, `error-handling-flow`, `branch-and-ci-flow`, `lane-map`, `diagrams/README`). Module coupling for the lane map re-verified by import grep (auth⇄users mutual; invoices→auth+customers one-way; customers/banner standalone).

`AGENTS.md`, `SECURITY.md`, `BACKLOG.md`: accurate. BACKLOG's "Env hygiene (#67)" entry actually corroborates the deployment.md fix.

## ⚠️ For your review (governance / unverifiable)

- **`CLAUDE.md`** — I made one *factual* description fix (`/check-full` runs unit + integration). No rule/governance change. Revert if you'd rather keep that file untouched by doc sessions.
- **`AGENTS.md`** — left unchanged. Its "read Next docs in `node_modules/next/dist/docs/`" instruction couldn't be verified because `node_modules` isn't installed in the worktree; not flagging it as drift.
- **Module-doc drift:** none spotted that needs handing off — I didn't read into `src/modules/**/*.md` (off-limits), so nothing to forward to the module lanes from this pass.
