### PR TITLE
release: promote develop → main — docs drift reconciliation across all modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,17 +21,17 @@ This project runs in git worktrees under `.claude/worktrees/`, not a single chec
 
 Project-level slash commands are defined in `.claude/commands/`:
 
-| Command       | Runs                                                                                                 |
-| ------------- | ---------------------------------------------------------------------------------------------------- |
-| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                        |
-| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, unit tests, e2e (report-only)                |
-| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)                     |
-| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                         |
-| `/test`       | `pnpm test` — unit tests only (report-only)                                                          |
-| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                                    |
-| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                             |
-| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI         |
-| `/promote`    | open the `develop → main` release PR, run the full gate (check + E2E), watch CI, hand the merge back |
+| Command       | Runs                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------ |
+| `/check`      | `pnpm check:fast` — Biome + Markdown lint + typecheck + typegen (report-only)                                |
+| `/check-full` | `pnpm check` — full suite: Biome + Markdown, typecheck, typegen, unit + integration tests, e2e (report-only) |
+| `/lint`       | `pnpm biome:lint + biome:format:check + md:lint + md:format:check` (report-only)                             |
+| `/fix`        | auto-fix Biome (`biome:lint:fix`) + Markdown (`md:fix`), then report residue                                 |
+| `/test`       | `pnpm test` — unit tests only (report-only)                                                                  |
+| `/coverage`   | `pnpm test:coverage` — vitest unit coverage summary (report-only)                                            |
+| `/e2e`        | `pnpm cy:e2e` — Cypress e2e suite; needs `.env.test.local` (report-only)                                     |
+| `/ship`       | review, reconcile BACKLOG/docs, gate on `pnpm check:fast`, commit, push, open a PR, watch CI                 |
+| `/promote`    | open the `develop → main` release PR, run the full gate (check + E2E), watch CI, hand the merge back         |
 
 Report-only commands carry `disallowed-tools: Edit, Write, NotebookEdit`, so they structurally cannot modify files. `/fix` delegates writes to Biome, markdownlint-cli2, and dprint (it does not hand-edit). `/ship` commits, pushes, and opens a PR into `develop` from a worktree feature branch (never `develop`/`main` directly); `/promote` opens the `develop → main` release PR and watches the full gate but never merges `main` itself — that stays a human decision.
 

--- a/README.md
+++ b/README.md
@@ -12,39 +12,40 @@ authentication, middleware-based route protection, database migrations/seeding, 
 ## Tech Stack
 
 - Next.js 16 (App Router, Server/Client Components)
-- React 19 + TypeScript 5 (strict)
+- React 19 + TypeScript 6 (strict)
 - Drizzle ORM (PostgreSQL)
 - Tailwind CSS v4
 - Cypress for E2E testing (with @testing-library/cypress and cypress-axe)
-- Biome and Prettier for formatting and checks
+- Biome for JS/TS/JSON; dprint + markdownlint-cli2 for Markdown
 - Turbopack for dev/build
 
-Note: ESLint is not used in this project, by design.
+Note: ESLint and Prettier are not used in this project, by design.
 
 ## Project Structure
 
 ```text
 nextjs-dashboard/
 ├── cypress/                # E2E specs and support
+├── database/               # Drizzle schema (source of truth)
 ├── docs/                   # Additional documentation and guides
-├── drizzle/                # Generated SQL, migrations, meta
+├── drizzle/                # Generated SQL migrations, one set per env (dev/test/prod)
 ├── devtools/               # cli, config, seed-support, tasks
 ├── public/                 # Static assets
 ├── src/                    # Application source
 │   ├── app/                # App router
-│   ├── modules/            # auth, customers, invoices, revenues, users
-│   ├── server/             # config, db, events
-│   ├── shared/             # branding, config, errors, forms, http,  logging, result, routes, utilities
-│   ├── shell/              # dashboard-wide components/screens/
-│   ├── ui/                 # atoms, brand, feedback, forms, molecules, navigation, styles
-│   ├── proxy.ts       # Route protection
+│   ├── modules/            # auth, banner, customers, invoices, users (each internally layered)
+│   ├── server/             # cookies, crypto, db (shared server infra)
+│   ├── shared/             # core, forms, http, policies, primitives, routing, telemetry, time
+│   ├── shell/              # dashboard composition
+│   ├── ui/                 # atoms, brand, forms, hooks, molecules, navigation, skeletons, styles, utils, wrappers
+│   ├── proxy.ts            # Route protection (Next.js middleware)
 └── ...
 ```
 
 ## Requirements
 
-- Node >= 24
-- PNPM >= 10.12
+- Node >= 26 (pinned in `.nvmrc`)
+- pnpm >= 11 (pinned via the `packageManager` field in `package.json`)
 - PostgreSQL (local or remote)
 
 ## Getting Started

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,18 +21,20 @@ All environments need these. Validation lives in
 `src/shared/core/config/` — the server **fails fast at startup** if any are
 missing or malformed, so set them all.
 
-| Variable                  | Example                               | Notes                                     |
-| ------------------------- | ------------------------------------- | ----------------------------------------- |
-| `DATABASE_URL`            | `postgresql://user:pass@host:5432/db` | Neon: append `?sslmode=require`           |
-| `SESSION_SECRET`          | (long random string)                  | generate with `openssl rand -base64 48`   |
-| `AUTH_BCRYPT_SALT_ROUNDS` | `12`                                  | positive integer                          |
-| `SESSION_ISSUER`          | `my-app`                              | fixed value                               |
-| `SESSION_AUDIENCE`        | `web`                                 | fixed value                               |
-| `NODE_ENV`                | `production`                          |                                           |
-| `DATABASE_ENV`            | `production`                          | selects the migration scope               |
-| `LOG_LEVEL`               | `info`                                | `trace`\|`debug`\|`info`\|`warn`\|`error` |
-| `NEXT_PUBLIC_NODE_ENV`    | `production`                          | inlined into the client bundle at build   |
-| `NEXT_PUBLIC_LOG_LEVEL`   | `info`                                | inlined into the client bundle at build   |
+| Variable                  | Example                               | Notes                                                       |
+| ------------------------- | ------------------------------------- | ----------------------------------------------------------- |
+| `DATABASE_URL`            | `postgresql://user:pass@host:5432/db` | Neon: append `?sslmode=require`                             |
+| `SESSION_SECRET`          | (long random string)                  | generate with `openssl rand -base64 48`                     |
+| `AUTH_BCRYPT_SALT_ROUNDS` | `12`                                  | positive integer                                            |
+| `NODE_ENV`                | `production`                          | `development` \| `test` \| `production`                     |
+| `DATABASE_ENV`            | `production`                          | selects the migration scope                                 |
+| `NEXT_PUBLIC_NODE_ENV`    | `production`                          | inlined into the client bundle at build                     |
+| `NEXT_PUBLIC_LOG_LEVEL`   | `info`                                | `trace`\|`debug`\|`info`\|`warn`\|`error`; inlined at build |
+
+The server validates `DATABASE_URL`, `SESSION_SECRET`, and `AUTH_BCRYPT_SALT_ROUNDS` (plus `NODE_ENV` /
+`DATABASE_ENV`) and fails fast at startup if any are missing or malformed. The JWT `issuer` / `audience`
+are compile-time **constants** (`my-app` / `web`), not env vars — see
+`src/modules/auth/infrastructure/session/config/session-jwt.constants.ts`.
 
 **Demo logins** (created by the seed):
 

--- a/docs/diagrams/auth-login-flow.md
+++ b/docs/diagrams/auth-login-flow.md
@@ -74,14 +74,14 @@ Same shape as login, with one extra step **first**: create the user.
 
 ## The files behind the boxes
 
-| Box                                 | File                                                                                                                                                          |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| login.action / signup.action        | [`presentation/authn/actions/`](../../src/modules/auth/presentation/authn/actions)                                                                            |
-| verifySessionOptimistic             | [`presentation/session/actions/verify-session-optimistic.action.ts`](../../src/modules/auth/presentation/session/actions/verify-session-optimistic.action.ts) |
-| auth.composition                    | [`infrastructure/composition/auth.composition.ts`](../../src/modules/auth/infrastructure/composition/auth.composition.ts)                                     |
-| login.workflow / LoginUseCase       | [`application/auth-user/`](../../src/modules/auth/application/auth-user)                                                                                      |
-| SessionService / ReadSessionUseCase | [`application/session/`](../../src/modules/auth/application/session) + [`infrastructure/session/`](../../src/modules/auth/infrastructure/session)             |
-| Bcrypt service                      | [`infrastructure/crypto/services/bcrypt-password.service.ts`](../../src/modules/auth/infrastructure/crypto/services/bcrypt-password.service.ts)               |
+| Box                                 | File                                                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| login.action / signup.action        | [`presentation/authn/actions/`](../../src/modules/auth/presentation/authn/actions)                                                                |
+| verifySessionOptimistic             | [`presentation/session/verify-session-optimistic.action.ts`](../../src/modules/auth/presentation/session/verify-session-optimistic.action.ts)     |
+| auth.composition                    | [`infrastructure/composition/auth.composition.ts`](../../src/modules/auth/infrastructure/composition/auth.composition.ts)                         |
+| login.workflow / LoginUseCase       | [`application/auth-user/`](../../src/modules/auth/application/auth-user)                                                                          |
+| SessionService / ReadSessionUseCase | [`application/session/`](../../src/modules/auth/application/session) + [`infrastructure/session/`](../../src/modules/auth/infrastructure/session) |
+| Bcrypt service                      | [`infrastructure/crypto/services/bcrypt-password.service.ts`](../../src/modules/auth/infrastructure/crypto/services/bcrypt-password.service.ts)   |
 
 ## The "why" lives in the ADRs
 

--- a/docs/diagrams/route-authorization.md
+++ b/docs/diagrams/route-authorization.md
@@ -114,7 +114,7 @@ But Next.js Server Actions are independently invocable RPC endpoints: a crafted
 request can call an action without ever loading the page that hosts it, so the
 gate alone doesn't protect them. Each sensitive action therefore enforces its own
 authorization as a second layer (defense in depth), via two guards in
-[`session-access.guard.ts`](../../src/modules/auth/presentation/session/guards/session-access.guard.ts):
+[`session-access.guard.ts`](../../src/modules/auth/presentation/session/session-access.guard.ts):
 
 - **`requireSession()`** — any valid session; used by the invoice mutations.
 - **`requireAdmin()`** — an admin session; used by every user action (the

--- a/docs/drizzle.md
+++ b/docs/drizzle.md
@@ -5,10 +5,11 @@ TypeScript CLI scripts in `devtools/`.
 
 ## Key Locations
 
-- `drizzle/` — generated SQL, migrations, and meta
-- `drizzle.config.ts` — Drizzle Kit configuration
-- `devtools/cli/*.ts` — reset and seed helpers
-- `src/server/**` — server-side DB access (repositories/services)
+- `database/schema/` — the Drizzle table schema (the source migrations are generated from)
+- `drizzle/migrations/{dev,test,prod}/` — generated SQL migrations, one set per environment
+- `drizzle.config.ts` — Drizzle Kit config (`schema` → `database/schema`, `out` → the per-env migration dir)
+- `devtools/cli/*.ts` + `devtools/seed/**` — reset and seed helpers
+- `src/server/db/` — the shared database connection; per-module repositories live in each module's `infrastructure/persistence/`
 
 ## Common Commands
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,8 +4,8 @@ This guide helps you set up, run, and develop the Next.js Dashboard locally.
 
 ## Prerequisites
 
-- Node >= 24
-- PNPM >= 10.12
+- Node >= 26 (pinned in [`.nvmrc`](../.nvmrc); CI reads the version from it)
+- pnpm >= 11 (pinned via the `packageManager` field in [`package.json`](../package.json))
 - PostgreSQL (local or remote)
 
 ## 1. Install Dependencies

--- a/docs/package-json-scripts-guide.md
+++ b/docs/package-json-scripts-guide.md
@@ -45,7 +45,7 @@ Markdown is linted by markdownlint-cli2 and formatted by dprint (Biome's Markdow
 Build and run the app.
 
 - `pnpm next:dev` — start Next.js in development mode (Turbopack).
-- `pnpm next:dev:test` — start Next.js in development mode on port 3001 with the test environment.
+- `pnpm next:dev:test` — start Next.js in development mode with the test environment (port from `PORT` in `.env.test.local`).
 - `pnpm next:build` — create a production build.
 - `pnpm next:build:test` — build the app using the test environment.
 - `pnpm next:build:standalone` — clean and build a standalone production bundle.
@@ -66,6 +66,9 @@ End-to-end testing.
 - `pnpm cy:e2e:ci` — alias for `cy:e2e`.
 - `pnpm cy:e2e:open` — open the Cypress interactive runner.
 - `pnpm cy:e2e:run` — run Cypress E2E in headless mode.
+- `pnpm cy:open:with-server` — boot the test-env dev server, then open the interactive runner.
+- `pnpm cy:server` — start the test-env dev server only (alias for `next:dev:test`).
+- `pnpm cy:preflight` — run the `/api/health` identity preflight (asserts the test env/DB).
 - `pnpm cy:open` — open Cypress (general).
 - `pnpm cy:run` — run Cypress (general).
 - `pnpm cy:clean` — remove generated Cypress config artifacts.
@@ -87,6 +90,7 @@ Migrations, seeding, and resets per environment.
 - `pnpm db:reset:prod` — drop, recreate, and seed the production database.
 - `pnpm db:studio:dev` — open Drizzle Studio against the development database.
 - `pnpm db:studio:test` — open Drizzle Studio against the test database.
+- `pnpm db:drift` — assert the dev/test/prod migration sets describe the same schema (the CI drift gate; no database needed).
 
 ---
 
@@ -110,17 +114,21 @@ Load a specific `.env.*.local` file before running a command.
 - `pnpm clean:deps` — remove `node_modules`.
 - `pnpm clean:generated` — remove generated `.js`, `.map`, and `.tsbuildinfo` files.
 - `pnpm knip` — find unused exports, files, and dependencies.
-- `pnpm check` — run lint, typecheck, typegen, tests, and E2E.
-- `pnpm check:fast` — run lint, typecheck, and typegen only.
-- `pnpm check:repo` — run full check plus knip.
-- `pnpm test` — run unit/integration tests (Vitest) with the test environment.
-- `pnpm test:coverage` — run tests with coverage using the test environment.
-- `pnpm test:ui` — open Vitest UI with the test environment.
-- `pnpm test:watch` — run Vitest in watch mode with the test environment.
+- `pnpm check` — run Biome lint, Markdown check, typecheck, typegen, unit + integration tests, and E2E.
+- `pnpm check:fast` — run Biome lint, Markdown check, typecheck, typegen, and the migration-drift gate (no tests/E2E).
+- `pnpm check:repo` — run full `check` plus knip.
+- `pnpm test` — run the unit lane (alias for `test:unit`; `vitest run --project unit`). DB-free; no test env needed.
+- `pnpm test:unit` — run the unit lane once (pure/mocked, no database).
+- `pnpm test:integration` — run the integration lane against the real `test_db` (loads `.env.test.local` via `env:test`).
+- `pnpm test:all` — run the unit and integration lanes together.
+- `pnpm test:coverage` — run the unit lane with coverage (enforces the floors in `vitest.config.ts`). No test env needed.
+- `pnpm test:ui` — open the Vitest UI.
+- `pnpm test:watch` — run the unit lane in watch mode.
 
-Vitest environment variables are loaded by the `test:*` scripts via `env:test`; `vitest.setup.ts` only registers global
-test mocks. If DB-backed integration tests continue to run in the same `pnpm test` command as unit tests, revisit Vitest
-`coverage`, `pool`/isolation, and explicit integration-test behavior so the default test command remains predictable.
+The unit lane is database-free: it runs against a schema-valid dummy env baked into `vitest.config.ts`, so it needs
+neither `.env.test.local` nor a live database. Only the integration lane (`test:integration`, and the integration half
+of `test:all`) loads `.env.test.local` via `env:test` and talks to the real `test_db`. `vitest.setup.ts` registers the
+global server-API mocks shared by both lanes.
 
 ---
 
@@ -160,4 +168,4 @@ pnpm next:dev
 
 ---
 
-_Last updated: 2026-04-02_
+_Last updated: 2026-06-24_

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -2,6 +2,16 @@
 
 Use this guide to decide where code belongs and how layers interact.
 
+> **The model in one line:** each feature is a self-contained vertical slice under
+> `src/modules/<feature>/`, internally organized into clean-architecture layers
+> (`presentation/`, `application/`, `domain/`, `infrastructure/`) — so a module owns
+> its own UI, domain rules, use cases, **and** its data access (repositories, DB
+> queries) and server actions. `src/server` is _not_ where feature repositories or
+> actions live; it holds only the small set of **shared, cross-cutting** server-only
+> pieces (the Drizzle connection, cookies, crypto). For the per-module layering and
+> dependency direction, see [diagrams/module-layers.md](diagrams/module-layers.md)
+> and [standards/clean-architecture-standards.md](standards/clean-architecture-standards.md).
+
 ## 1) Identify the concern: domain capability vs. page/layout composition
 
 - Domain capability: A cohesive business area with its own models, rules, and reusable UI (e.g., auth, invoices,
@@ -50,23 +60,26 @@ Use this guide to decide where code belongs and how layers interact.
 
 - shared: May only import from shared. Lowest-level utilities, tokens, and primitives.
 - ui: Base, reusable UI primitives and patterns (atoms/molecules). May import from shared.
-- modules: A domain slice. May import from modules (itself/peers) and shared/ui. Must not import from shell.
+- modules: A domain slice, internally layered (presentation/application/domain/infrastructure). May import from modules (itself/peers) and shared/ui. Must not import from shell.
 - shell: App composition/orchestration. May import from modules, shared, ui. Should not be imported by modules.
-- server: Infrastructure, actions, services, repositories. No import restrictions (but keep server code server-only).
-- app (Next.js): Routes and server components. Should delegate domain logic to server/modules and composition to shell.
+- server: **Shared, cross-cutting** server-only infrastructure (the DB connection, cookies, crypto) — not feature repositories or actions, which live inside each module. Keep server code server-only.
+- app (Next.js): Routes and server components. Should delegate domain logic to modules (and shared server infra) and composition to shell.
 
 One-way dependency rule of thumb:
 shared/ui -> modules -> shell -> app
-server is usable from modules/shell/app as needed.
+the shared `server` infra is usable from modules/shell/app as needed.
 
 ---
 
 ## Purpose of the `src` folder's children
 
-1. `modules` — Domain-centric slices (auth, invoices, customers, users, etc.). Each slice exposes:
-   - Domain types, schemas, and view-model mappers
-   - Reusable, module-scoped UI
-   - Light adapters that are module-specific (no DB or external I/O)
+1. `modules` — Domain-centric vertical slices (auth, invoices, customers, users, banner). Each slice is internally layered (`presentation/`, `application/`, `domain/`, `infrastructure/`) and owns:
+   - Domain entities, value objects, and policies (`domain/`)
+   - Use cases, contracts, schemas, and mappers (`application/`)
+   - Its own data access — repositories, DAL, row↔entity mappers (`infrastructure/`)
+   - Server actions and module-scoped UI (`presentation/`)
+
+   Not every module needs every layer — thin CRUD slices (`customers`, `banner`) skip `application/`. See [diagrams/module-layers.md](diagrams/module-layers.md) for the per-module map.
 
 2. `shared` — Cross-cutting, module-agnostic utilities and tokens:
    - Pure helpers, constants, types
@@ -86,10 +99,10 @@ server is usable from modules/shell/app as needed.
      - Data access or external API calls (keep in server)
      - Generic utilities (keep in shared)
 
-4. `server` — Infrastructure and backend-facing code:
-   - Database access, repositories, migrations
-   - Services and server actions
-   - Integration with external systems (OAuth, queues, webhooks)
+4. `server` — Shared, cross-cutting server-only infrastructure (the small stuff many modules need):
+   - The Drizzle database **connection** (`server/db/`)
+   - Cookie handling (`server/cookies/`) and crypto/hashing (`server/crypto/`)
+   - Note: feature **repositories** and **server actions** do _not_ live here — they live in each module's `infrastructure/` and `presentation/`. Drizzle schema and migrations live in `database/schema` and `drizzle/migrations/` (see [drizzle.md](drizzle.md)).
 
 5. `ui` — Base UI primitives intended for reuse and extension:
    - Atoms/molecules (buttons, inputs, wrappers)
@@ -101,15 +114,14 @@ server is usable from modules/shell/app as needed.
 
 1. Is it app chrome or cross-module composition (layouts, nav, role gates, dashboard composition)?
    - Yes → Place in `shell`.
-2. Is it a domain capability with reusable UI and types (auth, invoices, customers)?
-   - Yes → Place in `modules/<module>`.
-3. Is it infrastructure (DB, services, actions, external APIs)?
+2. Is it a domain capability — a repository, use case, server action, domain rule, or module UI for one feature?
+   - Yes → Place in the right layer of `modules/<module>` (`infrastructure/`, `application/`, `presentation/`, `domain/`).
+3. Is it shared, cross-cutting server-only infrastructure used by many modules (the DB connection, cookies, crypto)?
    - Yes → Place in `server`.
 4. Is it a generic utility, token, or primitive UI with no domain knowledge?
    - Yes → `shared` (utilities/tokens) or `ui` (primitive components).
 5. Route files and data fetching for pages?
-   - Prefer `src/app` server components that call into `server` (for data) and render `shell` (for composition) and
-     `modules` (for module UI).
+   - Prefer `src/app` server components that call into `modules` (for data and module UI) and render `shell` (for composition).
 
 ---
 
@@ -128,8 +140,8 @@ server is usable from modules/shell/app as needed.
   - Don't: Import from modules or shell.
 
 - server
-  - Do: Encapsulate data access and integrations; expose actions/services.
-  - Don't: Contain client UI.
+  - Do: Hold shared, cross-cutting server-only infrastructure (DB connection, cookies, crypto).
+  - Don't: Contain client UI, or feature-specific repositories/actions (those belong in the module).
 
 ---
 
@@ -140,8 +152,9 @@ server is usable from modules/shell/app as needed.
   - Underlying widgets provided by their respective `modules/*`
 
 - Authentication:
-  - Forms, schemas, roles, and client helpers in `modules/auth`
-  - Server actions and provider integrations in `server/auth`
+  - Domain rules, use cases, schemas, repositories, server actions, and module UI all live in `modules/auth` (across its
+    `domain`/`application`/`infrastructure`/`presentation` layers)
+  - It reuses shared server infra from `server` (the DB connection, cookies, crypto) rather than reimplementing it
   - If the sidebar needs a logout button or role-aware links, the sidebar lives in `shell`, consuming `modules/auth`
     UI or actions.
 
@@ -152,4 +165,4 @@ boundaries, and simplify testing and scaling of both the UI and the backend.
 
 ---
 
-_Last updated: 2026-03-03_
+_Last updated: 2026-06-24_

--- a/docs/standards/clean-architecture-standards.md
+++ b/docs/standards/clean-architecture-standards.md
@@ -35,7 +35,7 @@ drivers.
 
 - **Allowed Imports**:
   - Primitives and TypeScript utilities
-  - Shared domain types (`@/shared/domain/`)
+  - Shared value types and branded primitives (`@/shared/primitives/`, `@/shared/core/branding/`)
 - **Forbidden Imports**:
   - Application layer (DTOs, schemas, use cases, contracts)
   - Infrastructure implementations

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,26 +1,34 @@
 # Testing
 
-The dashboard has two layers of tests, and both run under the **test environment**
-(`.env.test.local`):
+The dashboard has three test lanes. The **unit** lane is database-free and runs
+anywhere; the **integration** and **E2E** lanes talk to the real `test_db` under
+the **test environment** (`.env.test.local`):
 
-| Layer              | Tool    | Command       | What it covers                                                    |
-| ------------------ | ------- | ------------- | ----------------------------------------------------------------- |
-| Unit + integration | Vitest  | `pnpm test`   | Logic, mappers, services, and full-stack flows through the layers |
-| End-to-end (E2E)   | Cypress | `pnpm cy:e2e` | The running app in a real browser, including accessibility        |
+| Lane        | Tool    | Command                 | What it covers                                                | Needs `test_db`? |
+| ----------- | ------- | ----------------------- | ------------------------------------------------------------- | ---------------- |
+| Unit        | Vitest  | `pnpm test`             | Pure logic, mappers, services — dependencies mocked           | No               |
+| Integration | Vitest  | `pnpm test:integration` | Full-stack flows through the layers against the real database | Yes              |
+| End-to-end  | Cypress | `pnpm cy:e2e`           | The running app in a real browser, including accessibility    | Yes              |
 
-Before running either, make sure the **test database** exists and is migrated — see
-[database-setup.md](database-setup.md). The integration tests and all E2E specs
-talk to `test_db`.
+`pnpm test` is an alias for `pnpm test:unit` (unit only); `pnpm test:all` runs the
+unit and integration lanes together.
+
+Before running the integration or E2E lanes, make sure the **test database** exists
+and is migrated — see [database-setup.md](database-setup.md). The unit lane needs
+neither a database nor `.env.test.local`: it runs against a schema-valid dummy env
+baked into [`vitest.config.ts`](../vitest.config.ts).
 
 ## Unit & integration tests (Vitest)
 
 Config: [`vitest.config.ts`](../vitest.config.ts) · setup: [`vitest.setup.ts`](../vitest.setup.ts)
 
 ```sh
-pnpm test            # run once (test env)
-pnpm test:watch      # re-run on change
-pnpm test:ui         # Vitest UI
-pnpm test:coverage   # run once with coverage
+pnpm test             # unit lane, run once (no database needed)
+pnpm test:watch       # unit lane, re-run on change
+pnpm test:ui          # Vitest UI
+pnpm test:coverage    # unit lane once, with coverage (enforces the floors)
+pnpm test:integration # integration lane against the real test_db
+pnpm test:all         # unit + integration
 ```
 
 **Where tests live** — beside the code they cover, in `__tests__/` folders:
@@ -28,7 +36,8 @@ pnpm test:coverage   # run once with coverage
 - `__tests__/unit/…` — pure logic with dependencies mocked. No database needed.
 - `__tests__/integration/…` — exercise multiple layers together (presentation →
   application → infrastructure → DB). **These connect to the real `test_db`**, so
-  Postgres must be running and migrated (`pnpm db:push:test`) before `pnpm test`.
+  Postgres must be running and migrated (`pnpm db:push:test`) before
+  `pnpm test:integration` (or `pnpm test:all`).
 
 **Conventions:**
 
@@ -90,15 +99,23 @@ cy.checkA11y()
 
 ## CI
 
-- Unit / integration: `pnpm test` (needs the migrated `test_db`).
-- E2E headless: `pnpm cy:e2e` (alias `pnpm cy:e2e:ci`) — it boots the server itself.
+The CI gate is two-tier, matching the branch model — see
+[branching-and-releases.md](branching-and-releases.md).
+
+- **`check` job (every push/PR to `develop` and `main`):** runs `pnpm test:coverage`,
+  the DB-free unit lane, which also enforces the coverage floors in
+  `vitest.config.ts`. The integration lane is **not** run in CI — it needs a live
+  database — so run it locally before opening a PR.
+- **`e2e` job (main-targeting work only):** `pnpm cy:e2e` (alias `pnpm cy:e2e:ci`) —
+  it boots the server itself against an ephemeral Postgres service container.
 - Cypress records no video by default (`video: false` in `cypress.config.ts`).
 
 ## Troubleshooting
 
-- **`pnpm test` can't connect / hangs** — the integration tests need `test_db`.
-  Confirm Postgres is up, `pnpm db:push:test` has run, and `.env.test.local`'s
-  `DATABASE_URL` is reachable.
+- **`pnpm test:integration` can't connect / hangs** — the integration tests need
+  `test_db`. Confirm Postgres is up, `pnpm db:push:test` has run, and
+  `.env.test.local`'s `DATABASE_URL` is reachable. (The plain `pnpm test` unit lane
+  is database-free, so it should never need a connection.)
 - **Cypress can't reach the app** — confirm the server is running and that `PORT`
   and `CYPRESS_BASE_URL` in `.env.test.local` agree (the auto-server path derives
   its wait-URL from `PORT`).

--- a/docs/tsconfig.md
+++ b/docs/tsconfig.md
@@ -43,7 +43,7 @@ later layers win:
 | `next`                      | Next.js: DOM libs, `module: esnext`, `moduleResolution: bundler`, `jsx: preserve`, `plugins: [next]`, `noEmit` |
 
 On top of the presets, the root then sets `target: esnext` and `jsx: react-jsx`, declares the path aliases (`@/*`,
-`@cypress/*`, `@database/*`, `@devtools/*`) and explicit `types`, and relaxes three `strictest` flags
+`@cypress/*`, `@database/*`, `@devtools/*`, `@test-support/*`) and explicit `types`, and relaxes three `strictest` flags
 (`exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`, `noUnusedLocals`).
 
 For the exact contents of each preset, read them in `@tsconfig/bases` — a copy pasted here would drift the moment the

--- a/docs/ui-refactor-strategy.md
+++ b/docs/ui-refactor-strategy.md
@@ -146,7 +146,7 @@ Use the current codebase as the reference for what should stay where.
   - Keep in auth presentation because it is a feature-local page template, not app-wide shell.
 - `src/shell/dashboard/components/dashboard-sidebar.tsx`
   - Keep in `src/shell` because it composes branding, navigation, and auth logout into dashboard chrome.
-- `src/ui/molecules/page-header.tsx`
+- `src/ui/molecules/page-header.molecule.tsx`
   - Keep in `src/ui` as long as it stays feature-neutral and does not absorb auth-specific behavior.
 
 ### Signals that a file is in the wrong layer

--- a/docs/weekly-maintenance-routine.md
+++ b/docs/weekly-maintenance-routine.md
@@ -1,9 +1,10 @@
-# Weekly maintenance routine (drafted)
+# Weekly maintenance routine
 
 A scheduled Claude Code cloud agent that keeps the repo current with a single,
-reviewable PR each week. Drafted from the `BACKLOG.md` "Weekly codemod routine"
-item, with extra scope recommended below. **Not yet live** — create it with
-`/schedule` once you're happy with the scope.
+reviewable PR each week. Grown from the `BACKLOG.md` "Weekly codemod routine"
+item, with extra scope recommended below. **Live** — it runs as the
+`weekly-maintenance` `/schedule` cloud agent (cron `0 9 * * 1`, Mondays). This doc
+records its scope and rationale; use `/schedule` to list, adjust, or disable it.
 
 ## Schedule
 

--- a/src/modules/auth/application/README.md
+++ b/src/modules/auth/application/README.md
@@ -86,37 +86,34 @@ Promise < Result < AuthenticatedUserDto, AppError >> {
 ```text
 application/
 ├── auth-user/                      # Auth user subdomain
-│   ├── commands/                   # Write operations (login, signup)
+│   ├── auth-error.factory.ts       # Auth error factory (flat file — no errors/ folder)
+│   ├── commands/                   # Write operations (login, signup, create-demo-user)
 │   ├── contracts/                  # Interfaces for infrastructure
 │   │   ├── repositories/           # Repository contracts
-│   │   └── services/               # Service contracts (password hashing, etc.)
+│   │   └── services/               # Service contracts (password hashing, generation)
 │   ├── dtos/                       # Data Transfer Objects
 │   │   ├── requests/               # Input DTOs
 │   │   └── responses/              # Output DTOs
-│   ├── errors/                     # Error factories
-│   ├── schemas/                    # Input validation schemas (Zod)
-│   ├── validators/                 # Domain entity validators
+│   ├── validators/                 # Input / entity validators
 │   └── workflows/                  # Multi-use-case orchestration
 │
 ├── session/                        # Session subdomain
+│   ├── builders/                   # Complex DTO builders
 │   ├── commands/                   # Write operations (establish, rotate, terminate)
-│   ├── queries/                    # Read operations (read, require)
 │   ├── contracts/                  # Session service contracts
 │   ├── dtos/                       # Session DTOs
 │   │   ├── requests/               # Input DTOs
 │   │   └── responses/              # Output DTOs
-│   ├── builders/                   # Complex DTO builders
 │   ├── mappers/                    # Session-specific mappers
-│   ├── schemas/                    # Session validation schemas
+│   ├── queries/                    # Read operations (read, require)
 │   └── workflows/                  # Session workflows
 │
 └── shared/                         # Shared application concerns
-    ├── helpers/                    # Utility functions
+    ├── helpers/                    # Cookie / authorization / session-cleanup helpers
     ├── logging/                    # Logging utilities
     └── mappers/                    # Cross-subdomain mappers
         └── flows/                  # Mappers organized by flow
-            ├── login/              # Login flow mappers
-            └── signup/             # Signup flow mappers
+            └── login/              # Login flow mappers (to-authenticated-user, to-session-principal)
 ```
 
 ---
@@ -217,7 +214,7 @@ Cross-cutting concerns:
 
 - **Helpers**: Cookie operations, authorization, session cleanup
 - **Logging**: Auth-specific logging utilities
-- **Mappers**: Organized by flow (login, signup) for easy navigation
+- **Mappers**: Organized by flow under `flows/` — currently `login/` (signup reuses these)
 
 ---
 
@@ -408,5 +405,5 @@ Changes to contracts or DTOs are breaking changes. Coordinate with:
 
 ---
 
-**Last Updated**: 2026-02-01\
+**Last Updated**: 2026-06-24\
 **Maintainer**: Auth Module Team

--- a/src/modules/auth/domain/README.md
+++ b/src/modules/auth/domain/README.md
@@ -50,12 +50,21 @@ The domain layer does **not**:
 
 ## Directory Structure
 
-This layer is intentionally small. Typical contents include:
+The domain is organized by subdomain (`auth-user`, `session`) plus a `shared/`
+constants area:
 
 ```text
 domain/
-├── entities/          # Domain entities (rich data + invariants)
-├── types/             # Branded types and enums (e.g., UserId, UserRole)
+├── auth-user/
+│   ├── entities/        # AuthUserEntity
+│   └── policies/        # password.policy.ts, registration.policy.ts
+├── session/
+│   ├── entities/        # session.entity.ts
+│   ├── policies/        # session-lifecycle + authorization/ route policies
+│   ├── value-objects/   # auth-brands.value.ts (branded types), time.value.ts
+│   └── auth-request-authorization.output.ts
+├── shared/
+│   └── constants/       # session-config, session-lifecycle, route, request, policy, demo-identity
 └── README.md
 ```
 
@@ -81,10 +90,10 @@ When data crosses the domain → application boundary, sensitive fields should b
 - **Infrastructure → Domain**: database rows are mapped into domain entities (e.g., `UserRow → AuthUserEntity`).
 - **Domain → Application**: passwords are stripped when mapping to DTOs (e.g., `AuthUserEntity → AuthenticatedUserDto`).
 
-For the full chain, see:
+For the boundary mappers, see:
 
-- `src/modules/auth/application/shared/mappers/mapper-chains.ts`
-- `src/modules/auth/application/shared/mappers/mapper-registry.ts`
+- `src/modules/auth/application/shared/mappers/flows/login/to-authenticated-user.mapper.ts` — strips the password hash
+- `src/modules/auth/application/shared/mappers/flows/login/to-session-principal.mapper.ts` — narrows to the session principal
 
 ---
 

--- a/src/modules/auth/infrastructure/README.md
+++ b/src/modules/auth/infrastructure/README.md
@@ -118,12 +118,15 @@ export class AuthUserRepository {
 
 ```text
 infrastructure/
+├── auth-transaction.logger.ts      # Transaction-scoped logger (flat — no logging/ folder)
+│
 ├── composition/                    # Dependency Injection
 │   ├── auth.composition.ts         # Main composition root
 │   └── factories/                  # Factory functions
 │       ├── auth-user/              # Auth user factories
 │       │   ├── auth-tx-deps.factory.ts
 │       │   ├── auth-unit-of-work.factory.ts
+│       │   ├── demo-user-use-case.factory.ts
 │       │   ├── login-use-case.factory.ts
 │       │   └── signup-use-case.factory.ts
 │       ├── crypto/                 # Crypto service factories
@@ -136,19 +139,15 @@ infrastructure/
 │           └── session-token-service.factory.ts
 │
 ├── crypto/                         # Cryptography implementations
-│   ├── adapters/
-│   │   └── password-hasher.adapter.ts
-│   ├── config/
-│   │   └── auth-crypto.config.ts
+│   ├── auth-crypto.config.ts       #   (flat — no config/ folder)
+│   ├── password-hasher.adapter.ts  #   (flat — no adapters/ folder)
 │   └── services/
 │       ├── bcrypt-password.service.ts
 │       └── password-generator.service.ts
 │
-├── logging/                        # Infrastructure logging
-│   └── auth-transaction.logger.ts
-│
 ├── persistence/                    # Database access
 │   └── auth-user/
+│       ├── auth-user.repository.ts # Repository impl (flat — no repositories/ folder)
 │       ├── adapters/               # Repository adapters
 │       │   ├── auth-unit-of-work.adapter.ts
 │       │   └── auth-user-repository.adapter.ts
@@ -156,29 +155,26 @@ infrastructure/
 │       │   ├── get-user-by-email.dal.ts
 │       │   ├── increment-demo-user-counter.dal.ts
 │       │   └── insert-user.dal.ts
-│       ├── mappers/                # Database row → Domain entity
-│       │   └── to-auth-user-entity.mapper.ts
-│       └── repositories/           # Repository implementations
-│           └── auth-user.repository.ts
+│       └── mappers/                # Database row → Domain entity
+│           ├── pg-unique-violation-to-signup-conflict-error.mapper.ts
+│           └── to-auth-user-entity.mapper.ts
 │
 └── session/                        # Session infrastructure
+    ├── jwt-to-session-token-claims-dto.mapper.ts   # JWT → DTO (flat — no mappers/ folder)
+    ├── session-jwt-crypto.strategy.ts              # JWT strategy (flat — no strategies/ folder)
+    ├── session-token-claims.schema.ts              # Zod schema for the JWT claims
+    ├── to-session-cookie-max-age-seconds.helper.ts # cookie max-age helper (flat — no helpers/ folder)
+    ├── adapters/                   # Session adapters
+    │   ├── session-cookie-store.adapter.ts
+    │   └── session-token-codec.adapter.ts
     ├── config/                     # Session configuration
     │   ├── session-cookie-options.config.ts
     │   ├── session-jwt.constants.ts
     │   └── session-token.constants.ts
-    ├── adapters/                   # Session adapters
-    │   ├── session-cookie-store.adapter.ts
-    │   └── session-token-codec.adapter.ts
     ├── services/                   # Session services
-    │   ├── session.service.ts
+    │   ├── jose-session-jwt-crypto.service.ts
     │   ├── session-token.service.ts
-    │   └── jose-session-jwt-crypto.service.ts
-    ├── strategies/                 # JWT strategies
-    │   └── session-jwt-crypto.strategy.ts
-    ├── mappers/                    # JWT → DTO mappers
-    │   └── jwt-to-session-token-claims-dto.mapper.ts
-    ├── helpers/                    # Session helpers
-    │   └── to-session-cookie-max-age-seconds.helper.ts
+    │   └── session.service.ts
     └── types/                      # Infrastructure types
         ├── session-cookie.constants.ts
         ├── session-jwt-claims.transport.ts
@@ -280,7 +276,7 @@ Facade over session use cases. Delegates to:
 
 Handles token issuance and validation:
 
-- Issues JWT with claims (userId, role, exp, iat, nbf)
+- Issues JWT with claims (`sub` (user id), `role`, `sid`, `jti`, `iat`, `exp`, `nbf`)
 - Validates token signature and claims
 - Enforces semantic checks (exp > iat, nbf <= iat, etc.)
 
@@ -421,7 +417,7 @@ export function toAuthUserEntity(row: UserRow): AuthUserEntity {
 
 Concrete implementation using bcrypt:
 
-- Hash passwords with salt rounds (10)
+- Hash passwords with env-configured salt rounds (`AUTH_BCRYPT_SALT_ROUNDS`)
 - Compare plaintext with hash
 - Returns `Result<boolean, AppError>`
 
@@ -439,16 +435,16 @@ Implements `PasswordHasherContract`:
 Concrete JWT implementation:
 
 - Algorithm: HS256 (HMAC with SHA-256)
-- Secret: From environment variable
-- Claims: userId, role, exp, iat, nbf
-- Expiration: 7 days (configurable)
+- Secret: From environment variable `SESSION_SECRET`
+- Claims: `sub` (user id), `role`, `sid`, `jti`, `iat`, `exp`, `nbf`
+- Expiration: 15 minutes per token, slid forward by rotation (see below)
 
 **Security Features:**
 
 - HTTP-only cookies (prevents XSS)
 - Secure flag (HTTPS only in production)
 - SameSite=Strict (CSRF protection; current default)
-- Short expiration (7 days)
+- Short-lived tokens (15 minutes), rotated up to a 30-day absolute ceiling
 - Signature verification on every request
 
 ---
@@ -458,8 +454,11 @@ Concrete JWT implementation:
 ### **Environment Variables**
 
 ```bash
-# Session JWT secret (required)
-SESSION_JWT_SECRET=your-secret-key-here
+# Session JWT signing secret (required)
+SESSION_SECRET=your-secret-key-here
+
+# Bcrypt cost factor (required — schema enforces a positive int, no default)
+AUTH_BCRYPT_SALT_ROUNDS=10
 
 # Database connection (required)
 DATABASE_URL=postgresql://...
@@ -467,9 +466,14 @@ DATABASE_URL=postgresql://...
 
 ### **Constants**
 
-- **Session duration**: 7 days (`SESSION_DURATION_SEC`)
+- **Session duration**: 15 minutes (`SESSION_DURATION_SEC` = 900s) — lifetime of a freshly issued token
+- **Refresh threshold**: 2 minutes (`SESSION_REFRESH_THRESHOLD_SEC`) — the "approaching expiry" rotation window
+- **Max absolute lifetime**: 30 days (`MAX_ABSOLUTE_SESSION_SEC`) — hard ceiling on age via `iat`, even with rotation
 - **Clock tolerance**: 5 seconds (`SESSION_TOKEN_CLOCK_TOLERANCE_SEC`)
-- **Bcrypt rounds**: 10 (`BCRYPT_SALT_ROUNDS`)
+- **Bcrypt rounds**: env-configured via `AUTH_BCRYPT_SALT_ROUNDS` (required; e.g. 10)
+
+> The full session state machine and these numbers are in the
+> [session-lifecycle diagram](../../../../docs/diagrams/session-lifecycle.md).
 
 ---
 
@@ -651,5 +655,5 @@ Changes to adapters or services that implement application contracts are breakin
 
 ---
 
-**Last Updated**: 2026-02-01\
+**Last Updated**: 2026-06-24\
 **Maintainer**: Auth Module Team

--- a/src/modules/auth/notes/adr/005-use-jwt-for-session-tokens.md
+++ b/src/modules/auth/notes/adr/005-use-jwt-for-session-tokens.md
@@ -17,7 +17,7 @@ We will use JSON Web Tokens (JWT) stored in secure, HTTP-only cookies for sessio
 - **Storage**: Tokens are stored in a cookie named `session` (or similar).
 - **Security**: Cookies must be `HttpOnly`, `Secure`, and use `SameSite: Strict` (current default; consider `Lax` only
   if you introduce cross-site auth flows and add CSRF protections as needed).
-- **Payload**: Minimal data should be stored in the JWT (e.g., `userId`, `role`, `sid`).
+- **Payload**: Minimal data should be stored in the JWT (e.g., `sub` (the user id), `role`, `sid`).
 - **Signing**: Use a strong cryptographic algorithm (e.g., HS256 with a sufficiently long secret).
 - **Rotation**: Sessions should support rotation (refreshing the expiration) to keep users logged in during active use
   while maintaining security.

--- a/src/modules/auth/notes/adr/007-enforce-action-level-authorization.md
+++ b/src/modules/auth/notes/adr/007-enforce-action-level-authorization.md
@@ -22,7 +22,7 @@ escalate privileges — or read user PII directly.
 
 Each sensitive server action enforces its own authorization, as a second layer
 beneath the route gate (defense in depth). Two guards live in
-[`session/guards/session-access.guard.ts`](../../presentation/session/guards/session-access.guard.ts):
+[`session/session-access.guard.ts`](../../presentation/session/session-access.guard.ts):
 
 - **`requireSession()`** — requires any valid session; redirects to login when
   none exists. Used by the invoice mutations (create / update / delete).

--- a/src/modules/auth/presentation/README.md
+++ b/src/modules/auth/presentation/README.md
@@ -101,10 +101,13 @@ export type LoginFormResult = FormResult<LoginField>;
 presentation/
 ├── authn/                          # Authentication UI
 │   ├── actions/                    # Server Actions
-│   │   ├── demo-user.action.ts     # Create demo user
+│   │   ├── demo-user.action.ts     # demoUserAction + demoAdminAction
 │   │   ├── login.action.ts         # User login
 │   │   ├── logout.action.ts        # User logout
 │   │   └── signup.action.ts        # User registration
+│   ├── adapters/                   # FormData → command adapters
+│   │   ├── to-login-command.adapter.ts
+│   │   └── to-signup-command.adapter.ts
 │   ├── components/                 # React components
 │   │   ├── cards/                  # Page-level components
 │   │   │   ├── login-card.tsx
@@ -114,32 +117,35 @@ presentation/
 │   │   │   ├── login-form.tsx
 │   │   │   ├── logout-form.tsx
 │   │   │   └── signup-form.tsx
-│   │   └── shared/                 # Reusable UI components
-│   │       ├── auth-actions-row.tsx
-│   │       ├── auth-form-demo-section.tsx
+│   │   └── shared/                 # Reusable UI (grouped by type)
 │   │       ├── auth-form-feedback.tsx
-│   │       ├── auth-form-social-section.tsx
-│   │       ├── auth-page-wrapper.tsx
 │   │       ├── forgot-password-link.tsx
-│   │       ├── form-row.wrapper.tsx
-│   │       ├── icons.tsx
 │   │       ├── remember-me-checkbox.tsx
-│   │       └── social-login-button.tsx
+│   │       ├── sections/
+│   │       │   ├── auth-form-demo-section.tsx
+│   │       │   └── auth-form-social-section.tsx
+│   │       ├── ui/
+│   │       │   ├── icons.tsx
+│   │       │   └── social-login-button.tsx
+│   │       └── wrappers/
+│   │           ├── auth-actions-row.tsx
+│   │           ├── auth-page-template.tsx
+│   │           └── form-row.wrapper.tsx
 │   ├── mappers/                    # Error mappers
-│   │   └── auth-form-error.mapper.ts
-│   └── transports/                 # Type definitions
+│   │   ├── map-generic-auth.error.ts
+│   │   ├── to-login-form-result.mapper.ts
+│   │   └── to-signup-form-result.mapper.ts
+│   └── transports/                 # Type definitions + form schemas
 │       ├── auth-action-props.transport.ts
+│       ├── login.form.schema.ts
 │       ├── login.transport.ts
+│       ├── signup.form.schema.ts
 │       └── signup.transport.ts
 │
-├── session/                        # Session UI + authorization guards
-│   ├── actions/
-│   │   └── verify-session-optimistic.action.ts
-│   ├── guards/                     # Server-action authorization
-│   │   └── session-access.guard.ts # requireSession() / requireAdmin()
-│   ├── components/                 # (Empty - future session UI)
-│   └── features/
-│       └── session-refresh.tsx
+├── session/                        # Session UI + authorization guards (flat files)
+│   ├── session-access.guard.ts     # requireSession() / requireAdmin()
+│   ├── session-refresh.tsx         # client session-refresh feature
+│   └── verify-session-optimistic.action.ts  # canonical optimistic session check
 │
 └── constants/                      # UI constants
     ├── auth-ui.constants.ts
@@ -234,7 +240,7 @@ Terminates current session.
 Server Actions are independently invocable RPC endpoints — a crafted request can
 reach an action without going through the page that hosts it — so the route
 checks in `proxy.ts` (middleware) are not sufficient on their own. The guards in
-[`session/guards/session-access.guard.ts`](session/guards/session-access.guard.ts)
+[`session/session-access.guard.ts`](session/session-access.guard.ts)
 make each sensitive action enforce its own authorization (defense in depth).
 
 | Guard              | Requires             | Redirects when denied                     | Used by                                                                   |
@@ -280,9 +286,9 @@ Page-level containers that wrap forms:
 ```typescript
 export function LoginCard() {
     return (
-        <AuthPageWrapper title = "Sign In" >
+        <AuthPageTemplate title = "Sign In" >
             <LoginForm / >
-            </AuthPageWrapper>
+            </AuthPageTemplate>
     );
 }
 ```
@@ -310,15 +316,15 @@ export function LoginForm() {
 
 #### **Shared Components** (`components/shared/`)
 
-Reusable UI elements:
+Reusable UI elements (grouped into `sections/`, `ui/`, and `wrappers/`):
 
-- **Layout**: `AuthPageWrapper`, `FormRowWrapper`
+- **Layout** (`wrappers/`): `AuthPageTemplate`, `AuthActionsRow`, `FormRowWrapper`
 - **Feedback**: `AuthFormFeedback` (displays errors)
 - **Controls**: `RememberMeCheckbox`
-- **Sections**: `AuthFormDemoSection`, `AuthFormSocialSection`
+- **Sections** (`sections/`): `AuthFormDemoSection`, `AuthFormSocialSection`
 - **Links**: `ForgotPasswordLink`
-- **Buttons**: `SocialLoginButton`
-- **Icons**: `Icons` (auth-related icons)
+- **Buttons** (`ui/`): `SocialLoginButton`
+- **Icons** (`ui/`): `Icons` (auth-related icons)
 
 ---
 
@@ -390,17 +396,18 @@ FormResult<LoginField> (presentation layer)
 User-friendly error message (UI)
 ```
 
-### **Error Mapper** (`mappers/auth-form-error.mapper.ts`)
+### **Error Mapper** (`mappers/to-login-form-result.mapper.ts`)
 
-Converts application errors to form errors:
+Converts application errors to form errors (the generic fallback lives in
+`map-generic-auth.error.ts`):
 
 ```typescript
 export function toLoginFormResult(
   error: AppError,
-  input: LoginRequestDto,
+  formData: LoginFormData,
 ): FormResult<never> {
-  // Map specific error codes to user-friendly messages
-  if (error.code === "invalid_credentials") {
+  // Map specific error keys to user-friendly messages
+  if (error.key === "invalid_credentials") {
     return {
       ok: false,
       error: {
@@ -652,14 +659,16 @@ Changes to Server Action signatures or form field names are breaking changes. Co
 
 ### **Suggested Enhancements**
 
-1. **Reorganize `components/shared/`**: Group by type (controls, feedback, layout, links, sections, ui)
-2. **Add client-side hooks**: `useAuthForm`, `useLoginState` for client components
-3. **Add session UI components**: Session status indicator, logout button
-4. **Add loading skeletons**: Better loading states for forms
-5. **Add animations**: Smooth transitions for error messages
-6. **Add toast notifications**: Success/error toasts instead of redirects
+> `components/shared/` has since been regrouped by type (`sections/`, `ui/`,
+> `wrappers/`), so that earlier suggestion is done.
+
+1. **Add client-side hooks**: `useAuthForm`, `useLoginState` for client components
+2. **Add session UI components**: Session status indicator
+3. **Add loading skeletons**: Better loading states for forms
+4. **Add animations**: Smooth transitions for error messages
+5. **Add toast notifications**: Success/error toasts instead of redirects
 
 ---
 
-**Last Updated**: 2026-06-09\
+**Last Updated**: 2026-06-24\
 **Maintainer**: Auth Module Team

--- a/src/modules/banner/README.md
+++ b/src/modules/banner/README.md
@@ -36,12 +36,15 @@ User clicks Dismiss ─▶ dismissBannerAction()  ─▶ dismissBanner() sets co
 ```
 
 - **Gating is the caller's job.** `<OneTimeBanner>` always renders when mounted;
-  the server code that includes it should check `isBannerDismissed()` first and
-  skip mounting it when the cookie is set. The component owns only the dismiss
+  the server code that includes it must check `isBannerDismissed()` first and skip
+  mounting it when the cookie is set. The one real caller is the root layout
+  (`app/layout.tsx`), which awaits `isBannerDismissed()` and renders
+  `{!dismissed && <OneTimeBanner/>}`. The component owns only the dismiss
   interaction (optimistic `useState` + `useTransition`).
 - **The adapter** (`BannerCookieAdapter`) wraps the shared cookie service
-  (`@/server/cookies`) and centralizes the cookie options; `banner-cookie.ts` is a
-  two-function facade so callers don't construct the adapter themselves.
+  (`createCookieService()` from `@/server/cookies/cookie.factory`) and centralizes
+  the cookie options; `banner-cookie.ts` is a two-function facade so callers don't
+  construct the adapter themselves.
 
 ---
 
@@ -74,8 +77,8 @@ flags like this one.
 ## Related documentation
 
 - [project-structure.md](../../../docs/project-structure.md) — where code belongs across the repo.
-- Cookie service: `@/server/cookies` (the shared adapter this module builds on).
+- Cookie service: `@/server/cookies/cookie.factory` (`createCookieService()` — the shared service this module builds on).
 
 ---
 
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-24

--- a/src/modules/customers/README.md
+++ b/src/modules/customers/README.md
@@ -64,9 +64,13 @@ customers/
 │   ├── repository/dal/                  #   fetch-filtered-customers, fetch-customers-select, fetch-total-count
 │   └── adapters/customer.mapper.ts      #   raw row → server DTO (brand id, normalize sums)
 │
-└── presentation/                        # Next.js server actions + React UI
-    ├── actions/                         #   read-filtered-customers, read-customers, read-total-customers-count
-    └── components/                      #   customers-table (+ desktop / mobile / row variants)
+├── presentation/                        # Next.js server actions + React UI
+│   ├── actions/                         #   read-filtered-customers, read-customers, read-total-customers-count
+│   └── components/                      #   customers-table (+ desktop / mobile / row variants)
+│
+└── __tests__/unit/                      # Vitest unit tests (domain mappers + infra adapter)
+    ├── domain/                          #   customer-id.mappers, mappers (toFormattedCustomersTableRow)
+    └── infrastructure/adapters/         #   customer.mapper (raw → DTO, null→0)
 ```
 
 There is intentionally no `application/` layer — without writes or business rules
@@ -121,15 +125,20 @@ All three actions follow the same read-only shape — for example the table:
 
 ## Error handling
 
-The DAL **throws** `makeAppError(APP_ERROR_KEYS.database, …)` on a query failure
-(using `CUSTOMER_SERVER_ERROR_MESSAGES`); the error propagates up to the action /
-page. This is the same throw-based model as the `invoices` DAL — note it differs
-from `users`, which returns `Result` end-to-end. See
+The two query DALs (`fetch-filtered-customers`, `fetch-customers-select`) wrap
+their query in `try/catch` and **throw** `makeAppError(APP_ERROR_KEYS.database, …)`
+on failure (using `CUSTOMER_SERVER_ERROR_MESSAGES`); the error propagates up to the
+action / page. `fetch-total-count` is the exception: it does not catch query errors
+(so a DB failure propagates raw) and only throws — with the `validation` key — when
+the count comes back missing. This is the same throw-based model as the `invoices`
+DAL — note it differs from `users`, which returns `Result` end-to-end. See
 [when-to-use-app-error.md](../../../docs/when-to-use-app-error.md).
 
-> No automated tests yet. The mappers (`mapCustomerAggregatesRawToDto`'s null→0
-> normalization) and the filtered-aggregate query are the highest-value things to
-> cover first.
+> **Tests:** unit suites cover the domain mappers (`toFormattedCustomersTableRow`
+> currency formatting, `CustomerId` create/throw) and the infra adapter
+> (`mapCustomerAggregatesRawToDto`'s null→0 normalization, id branding). The
+> filtered-aggregate DAL query is still uncovered — it needs a DB and is the
+> highest-value thing to add next.
 
 ---
 
@@ -142,4 +151,4 @@ from `users`, which returns `Result` end-to-end. See
 
 ---
 
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-24

--- a/src/modules/invoices/README.md
+++ b/src/modules/invoices/README.md
@@ -57,7 +57,9 @@ Server Action ─▶ InvoiceService ─▶ InvoiceRepository ─▶ DAL ─▶ P
 
 Both commands (create / read-by-id / update / delete) and list/aggregate
 reads (filtered list, page count, latest, totals/summary) take this path; each
-action builds `new InvoiceService(new InvoiceRepository(getAppDb()))` inline.
+action builds `new InvoiceService(new InvoiceRepository(getAppDb()))` inline. The
+one exception is `deleteInvoiceFormAction`, a thin `FormData` wrapper that delegates
+to `deleteInvoiceAction` rather than building its own service.
 
 How invoices differs from the `auth` module — worth knowing up front:
 
@@ -105,11 +107,15 @@ invoices/
 │       ├── invoice.repository.ts        #   InvoiceRepository — CRUD + reads; throws AppError
 │       └── dal/                         #   one function per query (4 CRUD + 6 dashboard reads)
 │
-└── presentation/                        # Next.js server actions + React UI
-    ├── actions/                         #   9 server actions (commands + reads)
-    ├── components/                      #   tables (desktop/mobile/status), latest, skeletons, links
-    ├── forms/                           #   create/edit forms + field inputs
-    └── constants/invoice-form.constants.ts
+├── presentation/                        # Next.js server actions + React UI
+│   ├── actions/                         #   9 server actions (8 build the service inline; delete-invoice-form wraps delete)
+│   ├── components/                      #   tables (desktop/mobile/status), latest, skeletons, links
+│   ├── forms/                           #   create/edit forms + field inputs
+│   └── constants/invoice-form.constants.ts
+│
+└── __tests__/unit/                      # Vitest unit tests — domain + infra (service & actions still uncovered)
+    ├── domain/                          #   id mappers, status validator, codecs, date-utils
+    └── infrastructure/                  #   adapter codecs + mapper, 2 read DAL queries (filtered, pages)
 ```
 
 ---
@@ -152,10 +158,13 @@ won't type-check where an ID is expected. Convert at the boundary with
 
 ### Validation, forms, and i18n
 
-- Input is validated with a Zod schema (`CreateInvoiceSchema` +
-  `CREATE_INVOICE_FIELDS_LIST`) in `domain/schema/invoice.schema.ts`.
-- Actions return a `FormResult` (`makeFormOk` / `makeFormError` from
-  `@/shared/forms`), with Zod issues mapped to per-field errors.
+- Input is validated with Zod schemas in `domain/schema/invoice.schema.ts`:
+  `CreateInvoiceSchema` (+ `CREATE_INVOICE_FIELDS_LIST`) for create, and its partial
+  form `UpdateInvoiceSchema` (+ `UPDATE_INVOICE_FIELDS_LIST`) for update.
+- The create and update actions return a `FormResult` (`makeFormOk` / `makeFormError`
+  from `@/shared/forms`), with Zod issues mapped to per-field errors.
+  (`deleteInvoiceAction` returns a `Result<InvoiceDto, AppError>` instead — see
+  [Request flows](#request-flows).)
 - User-facing strings come from `INVOICE_MSG` and are rendered through
   `translator()` (`domain/i18n/`); domain/infra errors are mapped to a message via
   `toInvoiceErrorMessage()`.
@@ -192,14 +201,22 @@ and [ADR-007](../auth/notes/adr/007-enforce-action-level-authorization.md).
 
 ### Create / update / delete (command path)
 
-1. The action parses `FormData` and validates it with the Zod schema.
-2. It constructs `new InvoiceService(new InvoiceRepository(getAppDb()))`.
+1. **create / update** parse `FormData` and validate it through the shared
+   `validateForm` funnel with the matching Zod schema (`CreateInvoiceSchema`, or the
+   partial `UpdateInvoiceSchema`). **delete** takes a string id and only checks that
+   it is present.
+2. The action constructs `new InvoiceService(new InvoiceRepository(getAppDb()))`.
 3. `InvoiceService` applies business rules (dollars→cents, date format), runs the
    codec/mapper chain, and calls the repository.
 4. `InvoiceRepository` calls the matching DAL function and maps the row back to an
    `InvoiceDto`.
-5. The action `revalidatePath(ROUTES.dashboard.invoices)` and returns a
-   `FormResult`.
+5. On success the action revalidates and returns:
+   - **create** → `revalidatePath(ROUTES.dashboard.invoices)`, returns a `FormResult`.
+   - **update** → `revalidatePath(ROUTES.dashboard.root)`, returns a `FormResult`.
+   - **delete** (`deleteInvoiceAction`) → `revalidatePath(ROUTES.dashboard.root)`,
+     returns a `Result<InvoiceDto, AppError>` (not a `FormResult`). The form-bound
+     `deleteInvoiceFormAction` wraps it: read the id from `FormData`, call
+     `deleteInvoiceAction`, then `revalidatePath` + `redirect` to the invoices list.
 
 ### Lists & aggregates (read path)
 
@@ -220,9 +237,12 @@ This module uses two styles, and you'll see both in a single action:
 
 - **The service returns `Result`** — its own validation failures come back as
   `Err(AppError)` and are turned into field-level `FormResult` errors.
-- **The repository and DAL throw `AppError`** — those propagate up as exceptions
-  and are caught by the action's `try/catch`, then mapped with
-  `toInvoiceErrorMessage()` and logged.
+- **The repository and DAL throw `AppError`** — those propagate up as exceptions.
+  The command actions (and the by-id / pages reads) catch them in a `try/catch`,
+  then map with `toInvoiceErrorMessage()` and log. The plain list/aggregate reads
+  (`readFilteredInvoicesAction`, `readLatestInvoicesAction`,
+  `readInvoicesSummaryAction`) have no `try/catch` and rethrow, letting the invoices
+  route error boundary (`error.tsx`) handle it.
 
 For when something should be an `AppError` versus a domain outcome, see
 [when-to-use-app-error.md](../../../docs/when-to-use-app-error.md) and the
@@ -234,10 +254,12 @@ For when something should be an `AppError` versus a domain outcome, see
 
 Kept honest on purpose — a doc that hides the warts isn't worth much.
 
-- **No automated tests yet.** Unlike `auth` and `users`, this module has no
-  `__tests__/`. The service's business rules (cents conversion, date validation,
-  partial-update assembly) and the DAL queries are the highest-value things to
-  cover first.
+- **Test coverage is partial.** A `__tests__/unit/` suite covers the domain (id
+  mappers, status validator, codecs, date-utils) and parts of infrastructure
+  (adapter codecs + mapper, the filtered-list and pages-count DAL queries). Still
+  uncovered, and the highest-value gaps: `InvoiceService`'s business rules (cents
+  conversion, date validation, partial-update assembly), the CRUD and remaining read
+  DAL queries, and the server actions.
 - **Composition is inline.** Actions `new` up the service and repository directly
   rather than resolving them from a composition root (as `auth` does). Fine while
   the graph is small; revisit if wiring grows.
@@ -257,4 +279,4 @@ Kept honest on purpose — a doc that hides the warts isn't worth much.
 
 ---
 
-**Last updated:** 2026-06-09
+**Last updated:** 2026-06-24

--- a/src/modules/users/README.md
+++ b/src/modules/users/README.md
@@ -127,7 +127,7 @@ users/
     ├── forms/                           #   create / edit / delete-button
     └── constants/user-form.constants.ts
 
-__tests__/                               # Vitest unit tests (service); see also the co-located schema/action tests
+__tests__/unit/                          # Vitest unit tests, centralized by layer (service / schema / actions)
 ```
 
 ---
@@ -263,18 +263,22 @@ For when something should be an `AppError`, see
 
 ## Testing
 
-This module **has tests** (Vitest) — the most-covered of the feature modules:
+This module **has tests** (Vitest) — the most-covered of the feature modules.
+They live under a centralized `__tests__/unit/` tree (mirroring the source
+layers), not co-located next to the source:
 
 - `__tests__/unit/application/services/user.service.test.ts` — `UserService` with a
   fully mocked `UserRepositoryContract`, `HashingService`, and logger; covers
   `readUserById` (found / null / repo-error) and `createUser` (ok / repo-error).
-- `domain/schemas/__tests__/user.schema.test.ts` — form-schema validation.
-- `presentation/actions/__tests__/create-user.action.test.ts` — the create action.
+- `__tests__/unit/domain/schemas/user.schema.test.ts` — form-schema validation.
+- `__tests__/unit/presentation/actions/create-user.action.test.ts` — the create action.
+- `__tests__/unit/presentation/actions/delete-user.action.test.ts` — the delete action,
+  including the success redirect, not-found, unexpected-error, and admin-authorization paths.
 
 Run them with `pnpm test` (see [testing.md](../../../docs/testing.md)).
 
 **Coverage gaps worth filling:** `updateUser` / `deleteUser` / `readFilteredUsers`
-in the service, the DAL functions, and the update/delete actions are not yet unit-tested.
+in the service, the DAL functions, and the **update** action are not yet unit-tested.
 
 ---
 
@@ -289,4 +293,4 @@ in the service, the DAL functions, and the update/delete actions are not yet uni
 
 ---
 
-**Last updated:** 2026-06-09
+**Last updated:** 2026-06-24


### PR DESCRIPTION
## Release: develop → main

Promotes the four documentation-reconciliation PRs landed on `develop` (produced by a four-session parallel-lane run, each lane scoped to non-overlapping docs). Content is **docs-only** — no code, schema, or config changes.

### Promoted commits
- bb827e47 — docs: fix cross-cutting documentation drift against the codebase (#100) — shared/governance docs (CLAUDE.md, README, docs/standards, project-structure, testing, deployment…)
- 9bf32bcb — docs(auth,users): reconcile module docs with code (#99) — flat-file reorg, JWT claims (`sub/sid/jti`), 15-min sessions, `SESSION_SECRET`, guard path
- 5ca32543 — docs(invoices): reconcile module README with current code (#98) — delete-action split, partial update schema, test coverage state
- c46e8003 — docs(customers,banner): reconcile module READMEs with code (#97) — cookie-factory path, error-handling specifics, test dirs

### Scope / risk
- 24 files, +349/-249, all markdown.
- Each lane's claims were spot-checked against the actual code before merge into `develop`.
- No `BACKLOG.md` changes (reconciliation pending separately).

### Merge instructions
Merge as a **merge commit** (`gh pr merge --merge` / "Create a merge commit") — never squash — to keep `develop`'s commits as ancestors of `main`.
