### PR TITLE
docs: reconcile remaining md drift + reprioritize backlog for job hunt

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,6 +7,46 @@ this file is the deliberate workaround.)
 
 ## Open
 
+> **Priority focus — set 2026-06-25 (active job hunt, ~1–2 week window).** Shifted the
+> emphasis from infrastructure/tooling to the **demo surface a hiring manager actually
+> experiences in 60 seconds**: kill demo dead-ends → first impression → one memorable
+> feature. The infra-polish items still matter but drop to "Later" below. Full rationale
+> in memory (`project_job_hunt_priority_shift`). If week 2 runs long, ship the week-1
+> polish on its own — a clean demo beats a half-built feature.
+
+### Now — job-hunt focus (demo-first, ~2 weeks)
+
+1. **Kill the demo dead-ends** (fast, high honesty-per-hour)
+   - [ ] **`forgot-password` is a live stub** — `src/app/auth/forgot-password/page.tsx`
+         renders a bare placeholder yet is linked from the login screen
+         (`.../components/shared/forgot-password-link.tsx`). Build a minimal request-reset
+         form returning a generic "if an account exists, we've sent a link" confirmation
+         (no email provider needed for the demo). This **demonstrates ADR-006**
+         (prevent credential enumeration) in the product, not just the docs.
+   - [ ] **Stub/empty module READMEs (~12)** — empty (0 bytes) or literal
+         `# [Capability Name]` templates: auth `application/**` sub-layers,
+         `src/shared/{http,primitives,routing,time}`, `forms/notes`. Fill the meaningful
+         ones, delete the dead templates. (Surfaced by the 2026-06-25 docs-drift audit.)
+   - [ ] **Font experiment — finish or drop** — wire `doto`/`merienda`
+         (`src/ui/styles/fonts.ts`, `--font-experiment` CSS var) into the UI or delete the
+         exports + the var. Tracked scaffolding from the 2026-06-14 dead-code triage; stays
+         visible in `pnpm knip` until decided.
+2. **First impression** — the live link is what recruiters click first.
+   - [ ] Real landing page (`src/app/page.tsx`) explaining the project + a one-click
+         "Try the demo" login.
+   - [ ] Surface the `docs/diagrams/` architecture diagrams on the README (strong, and
+         currently buried).
+3. **One memorable feature — invoice status lifecycle** (the interview story).
+   - [ ] Status enum + guarded transitions (pending → paid → overdue/void), status badges,
+         a status filter on the invoices list, and tests. Domain-native (invoice
+         schema/DAL/list already exist), bounded to ~a week, whiteboard-able end to end.
+         No specific tech to show off (confirmed 2026-06-25) → build it the straightforward
+         server-action way matching the existing architecture.
+4. **(Optional, alongside) a11y + Lighthouse pass** — `cypress-axe` + `axe-core` are
+   already installed; run a real sweep, fix findings, write up before/after.
+
+### Later — lower priority during the job hunt (infra/tooling polish)
+
 - [ ] **Renovate adoption** — for pnpm-version / node-version / `pnpm-workspace.yaml`
       override automation + grouped dep updates (Dependabot can't do those). Replaces
       Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of
@@ -18,13 +58,6 @@ this file is the deliberate workaround.)
       (the rest of the shrink → lock → decide → reshape roadmap completed 2026-06-13; see
       Done). Unscheduled. Core layering is sound, so don't migrate internals to DTOs.
       Full context in memory (`project_forms_error_refactor`).
-- [ ] **Font experiment — finish or drop** — `doto` + `merienda` in `src/ui/styles/fonts.ts`
-      are loaded via `next/font/google` and a `--font-experiment` CSS variable is defined,
-      but the fonts are never applied to any element (the class silently falls back to
-      sans-serif). Decide: wire them in (apply `doto.variable`/`merienda.variable`) or delete
-      the exports + the CSS var. Left deliberately as tracked scaffolding (the only
-      intended-but-unbuilt code surfaced by the 2026-06-14 dead-code triage); both stay
-      visible in `pnpm knip` until decided.
 - [ ] **Skills exploration** — evaluate reputable-source skills (e.g. Vercel's
       `vercel-react-best-practices`) against `docs/standards/` before adopting.
 - [ ] **TSConfig modernization for TypeScript 6.0** — TS **6.0.3** is already installed
@@ -35,11 +68,33 @@ this file is the deliberate workaround.)
 - [ ] **Integration lane in CI (optional)** — the e2e job's Postgres-service-container
       pattern (2026-06-23) could also run the integration vitest lane in CI; today only
       the DB-free unit lane runs there. Unscheduled.
+- [ ] **Issue tracking: GitHub Issues/Projects vs. BACKLOG.md** _(revisit Mon 2026-06-29)_ —
+      consider a **hybrid**, not a switch: keep `BACKLOG.md` as the worktree-friendly planning
+      doc the AI sessions drive, but file the _narratable_ units (e.g. the invoice-status
+      feature, the forgot-password fix) as GitHub Issues that PRs close (`Closes #N`), plus a
+      small Projects board. Rationale = portfolio signal: makes the repo _look_ as
+      professionally run as it already is. Not now — only worth it once the demo polish lands.
+      Curiosity-driven (2026-06-25 chat).
 
 ## Done
 
 Terse log — newest first. Full detail lives in the `project_*` memory files.
 
+- [x] **Docs-drift audit — remaining md files** _(2026-06-25)_ — drift-checked the ~53 prose
+      markdown files yesterday's sweep didn't touch (ADRs excluded) via 7 read-only audit lanes;
+      48 clean, **5 fixed**: `docs/knip.md` (`ignoreDependencies`), error-handling standard
+      (`normalizeUnknownError`), `src/shared/README.md` (real dir list),
+      `src/shared/core/config/README.md` (real env exports), `cypress/README.md` (now in CI / no
+      skips). Surfaced a separate gap — ~12 empty/template module READMEs — now tracked under "Now".
+- [x] **Docs-drift reconciliation sweep** _(2026-06-24, #97–#100 → develop, promoted #101)_ — the
+      first real **parallel-lane run**: four worktrees, each scoped to non-overlapping docs —
+      customers/banner (#97), invoices (#98), auth/users (#99), shared/cross-cutting (#100) — re-verified
+      each module's README/standards against the current code and corrected the drift (24 files,
+      +349/-249, docs-only). Promoted `develop → main` as a merge commit (#101): the first **clean**
+      promote after the #96 divergence heal — both file diff and commit list showed only the four real
+      docs commits. Validated the lane workflow end-to-end; the cross-module type-contract safeguards
+      weren't exercised (docs touch no types). Detail: memory `project_docs_consolidation`,
+      `project_branch_per_architecture_idea`.
 - [x] **Two-tier branch model: `develop` → `main`** _(2026-06-23)_ — reworked the git strategy for
       parallel multi-session work: `develop` is now the **default** branch (integration), `main` is
       promote-only (production). GitHub rulesets gate `develop` (`Lint & type-check`) and `main`

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -293,14 +293,12 @@ Conventions worth following:
 
 Kept honest on purpose — a doc that hides the warts isn't worth much.
 
-- **Two tests are skipped, pending an app fix.** `update-form` (invalid amount)
-  and `auth-actions` (invalid credentials) are `it.skip`-ped because form **error**
-  results are non-serializable `AppError` class instances, so error banners never
-  render across the server-action boundary. Both have a `biome-ignore` comment
-  explaining why; re-enable them once form errors are returned as plain objects.
-- **Not in CI yet.** The suite runs locally only — `.github/workflows` has no
-  Cypress job. Wiring it in (against a service-container Postgres) is the highest-
-  value next step.
+- **Runs in CI.** The suite runs as the `E2E (Cypress)` job in
+  `.github/workflows/ci.yml` (against a service-container Postgres) and is a required
+  check on `main`; it also runs locally via `pnpm cy:e2e`. The suite is green with no
+  skipped specs — form **error** results now cross the server-action boundary as plain
+  `AppErrorJsonDto` objects (not `AppError` class instances), so the previously skipped
+  `update-form` / `auth-actions` error-banner specs are active again.
 - **Secrets stay Node-side.** `DATABASE_URL` and `SESSION_SECRET` are never
   written into `config.env`, so they can't be read browser-side via
   `Cypress.env()` (and can't leak into the command log or screenshots). Specs

--- a/docs/knip.md
+++ b/docs/knip.md
@@ -50,8 +50,10 @@ Triage each finding — not everything reported should be deleted:
 - **Intentionally kept** → leave it. The repo uses a leading `_` to mark
   deliberately-unused symbols (e.g. `_NewInvoiceRow` insert types, `_isDev`); Knip does
   not honor that convention, so these show up as noise.
-- **Config-only / peer dependencies** → not real dead deps. `dotenv` and `tailwindcss`
-  are used via scripts/PostCSS config, and `@testing-library/dom` is a peer of
-  `@testing-library/cypress` — none are imported in code, so Knip lists them.
+- **Config-only / peer dependencies** → not real dead deps. `dotenv` (used via scripts),
+  `tailwindcss` (PostCSS config), and `@testing-library/dom` (a peer of
+  `@testing-library/cypress`) are never imported in code. `tailwindcss` and
+  `@testing-library/dom` are silenced via `ignoreDependencies` in `knip.json`, so they no
+  longer surface; `dotenv` is not ignored, so it can still appear — leave it.
 
 The running triage list lives in `BACKLOG.md` ("knip full-report triage").

--- a/docs/standards/error-handling-and-result-pattern.md
+++ b/docs/standards/error-handling-and-result-pattern.md
@@ -48,7 +48,7 @@ The `AppError` constructor automatically validates and sanitizes `metadata` agai
 - **`makeUnexpectedError`**: Preferred for wrapping technical exceptions in Infrastructure.
   - Wraps a trigger (the `error` parameter) into an `unexpected` key.
   - Automatically normalizes the trigger and attaches it as the `cause`.
-- **`normalizeUnknownToAppError`**: Converts any caught `unknown` into an `AppError`.
+- **`normalizeUnknownError`**: Converts any caught `unknown` into an `AppError`.
   - Use this when you need a generic fallback but don't want to explicitly mark it as "unexpected".
 
 ### Infrastructure Normalizers

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -8,8 +8,8 @@ isomorphic, tree-shakable, and side-effect free unless otherwise noted.
 - `core/`: Generic types, error/result modeling, validation, and branding utilities.
 - `forms/`: Shared form logic, errors, field types, and mapping.
 - `http/`: HTTP header utilities and types.
+- `policies/`: Reusable validation/business-rule policies for domain primitives (email, password, username, user-role).
 - `primitives/`: Primitive types and utilities.
-- `routes/`: Shared route definitions.
+- `routing/`: Shared route definitions.
+- `telemetry/`: Logging and telemetry utilities.
 - `time/`: Date and time utilities.
-- `utilities/`: Generic array, date, object, and string utilities.
-- `validation/`: Validation utilities and schemas.

--- a/src/shared/core/config/README.md
+++ b/src/shared/core/config/README.md
@@ -2,11 +2,11 @@
 
 ## 1️⃣ Shared Core (Universal)
 
-- File: `src/shared/config/env-shared.ts`
+- File: `src/shared/core/config/shared/env-shared.ts`
 - Defines canonical env types & schemas (NODE\*ENV, `DATABASE_ENV`, etc.)
 - Provides fallbacks + normalization (toLower, cache)
 - Safe for use in both server and client contexts
-- Exports helper flags: `IS_DEV` / `IS_TEST` / `IS_PROD`
+- Exports runtime helper functions: `getDatabaseEnv()`, `isProd()`, `isTestDatabaseEnvironment()`
 
 ---
 
@@ -23,6 +23,6 @@
   stable code constants in
   `src/modules/auth/infrastructure/session/config/session-jwt.constants.ts`
 - Caches + freezes values for immutability
-- Exports both constants and a `getServerEnv()` helper
+- Exports the validated constants `DATABASE_URL`, `SESSION_SECRET`, and `AUTH_BCRYPT_SALT_ROUNDS`
 
 ---


### PR DESCRIPTION
## Summary

Two related documentation/reconciliation changes — **no code**:

### 1. Drift audit of the remaining markdown
Continued the 2026-06-24 module sweep across the ~53 prose docs it didn't touch (ADRs excluded), via parallel read-only audit lanes. 48 were accurate; **5 fixed**:

- `docs/knip.md` — `tailwindcss` + `@testing-library/dom` are now silenced via `ignoreDependencies` in `knip.json`; only `dotenv` can still surface.
- `docs/standards/error-handling-and-result-pattern.md` — `normalizeUnknownToAppError` → real symbol `normalizeUnknownError`.
- `src/shared/README.md` — replaced a stale structure list (`routes/`, non-existent `utilities/`/`validation/`) with the 8 real dirs (incl. `policies/`, `routing/`, `telemetry/`).
- `src/shared/core/config/README.md` — corrected the `env-shared` path and real exports (functions `getDatabaseEnv()/isProd()/isTestDatabaseEnvironment()`, not `IS_DEV/IS_TEST/IS_PROD` flags; no `getServerEnv()`).
- `cypress/README.md` — two stale "rough edges" both resolved: the suite runs in CI (`E2E (Cypress)`, #80) with zero skipped specs.

### 2. Backlog reprioritized for the active job hunt
`BACKLOG.md` `Open` restructured into **Now / Later**: demo-first focus (kill dead-ends → first impression → invoice-status-lifecycle feature), with infra-polish items moved to Later. Added Done entries for the 2026-06-24/25 docs work and a **Mon 2026-06-29** note to consider GitHub Issues/Projects as a portfolio-signal complement to `BACKLOG.md`. Rationale persisted in memory (`project_job_hunt_priority_shift`).

## Validation
`pnpm check:fast` green — Biome, markdownlint + dprint, `tsc -b`, typegen, migration drift all pass.
