### PR TITLE
chore: weekly maintenance 2026-07-27

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -47,6 +47,16 @@ this file is the deliberate workaround.)
       Dependabot; needs the Mend Renovate GitHub App installed. _(Partially covered as of
       2026-06-13 by the `weekly-maintenance` routine, which reports/bumps the
       pnpm/node/override gap; Renovate would still automate grouped updates.)_
+- [ ] **Restore the `next` caret range** _(added 2026-07-27, weekly maintenance)_ — `next` is
+      temporarily pinned **exact** at `16.2.11` (the security patch) instead of `^16.2.11`, because
+      `16.2.12` was only 2 days old and the routine holds releases <3 days. Once `16.2.12`+ has aged,
+      restore `"next": "^16.2.x"` so Dependabot/caret updates work normally again.
+- [ ] **5 new `noUnnecessaryConditions` warnings** _(added 2026-07-27, weekly maintenance)_ — Biome
+      2.5.5 widened the rule and now flags redundant defensive guards on non-nullable params:
+      `invoice.service.ts:68`, `invoice.repository.ts:56`, and `if (!(db && id))` in the
+      delete/read/update invoice DALs. Warnings only (`check:fast` stays green). Deciding whether to
+      delete the guards is a real code change — they're runtime belt-and-braces against untyped
+      callers — so it was deliberately left out of the maintenance bump.
 - [ ] **docs/ consolidation** — reconcile `docs/standards/` overlap with the existing
       `project-structure.md`, `when-to-use-app-error.md`, and `ui-refactor-strategy.md`.
 - [ ] **Forms taxonomy flattening** — the last open piece of the forms/error cleanup

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
 	"assist": {
 		"actions": {
 			"preset": "recommended",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"date-fns": "^4.4.0",
 		"drizzle-orm": "^0.45.2",
 		"jose": "^6.2.3",
-		"next": "^16.2.10",
+		"next": "16.2.11",
 		"pg": "^8.22.0",
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",
@@ -17,7 +17,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.2",
+		"@biomejs/biome": "2.5.5",
 		"@tailwindcss/postcss": "^4.3.2",
 		"@testing-library/cypress": "^10.1.3",
 		"@testing-library/dom": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   js-yaml: ^4.3.0
   markdown-it: ^14.2.0
   linkify-it: ^5.0.2
-  brace-expansion: ^5.0.7
+  brace-expansion: ^5.0.8
   sharp: ^0.35.3
 
 importers:
@@ -37,8 +37,8 @@ importers:
         specifier: ^6.2.3
         version: 6.2.3
       next:
-        specifier: ^16.2.10
-        version: 16.2.10(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.2.11
+        version: 16.2.11(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -62,8 +62,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.5.2
-        version: 2.5.2
+        specifier: 2.5.5
+        version: 2.5.5
       '@tailwindcss/postcss':
         specifier: ^4.3.2
         version: 4.3.3
@@ -201,59 +201,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.2':
-    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
+  '@biomejs/biome@2.5.5':
+    resolution: {integrity: sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.2':
-    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    resolution: {integrity: sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.2':
-    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
+  '@biomejs/cli-darwin-x64@2.5.5':
+    resolution: {integrity: sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.2':
-    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    resolution: {integrity: sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.2':
-    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
+  '@biomejs/cli-linux-arm64@2.5.5':
+    resolution: {integrity: sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.2':
-    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    resolution: {integrity: sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.2':
-    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
+  '@biomejs/cli-linux-x64@2.5.5':
+    resolution: {integrity: sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.2':
-    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
+  '@biomejs/cli-win32-arm64@2.5.5':
+    resolution: {integrity: sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.2':
-    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
+  '@biomejs/cli-win32-x64@2.5.5':
+    resolution: {integrity: sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -792,57 +792,57 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.10':
-    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
+  '@next/env@16.2.11':
+    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
 
-  '@next/swc-darwin-arm64@16.2.10':
-    resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
+  '@next/swc-darwin-arm64@16.2.11':
+    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.10':
-    resolution: {integrity: sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==}
+  '@next/swc-darwin-x64@16.2.11':
+    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.10':
-    resolution: {integrity: sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==}
+  '@next/swc-linux-arm64-gnu@16.2.11':
+    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.10':
-    resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
+  '@next/swc-linux-arm64-musl@16.2.11':
+    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.10':
-    resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
+  '@next/swc-linux-x64-gnu@16.2.11':
+    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.10':
-    resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
+  '@next/swc-linux-x64-musl@16.2.11':
+    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.10':
-    resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
+  '@next/swc-win32-arm64-msvc@16.2.11':
+    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.10':
-    resolution: {integrity: sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==}
+  '@next/swc-win32-x64-msvc@16.2.11':
+    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1555,9 +1555,9 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2548,8 +2548,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  next@16.2.10:
-    resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
+  next@16.2.11:
+    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -3317,39 +3317,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.5.2':
+  '@biomejs/biome@2.5.5':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.2
-      '@biomejs/cli-darwin-x64': 2.5.2
-      '@biomejs/cli-linux-arm64': 2.5.2
-      '@biomejs/cli-linux-arm64-musl': 2.5.2
-      '@biomejs/cli-linux-x64': 2.5.2
-      '@biomejs/cli-linux-x64-musl': 2.5.2
-      '@biomejs/cli-win32-arm64': 2.5.2
-      '@biomejs/cli-win32-x64': 2.5.2
+      '@biomejs/cli-darwin-arm64': 2.5.5
+      '@biomejs/cli-darwin-x64': 2.5.5
+      '@biomejs/cli-linux-arm64': 2.5.5
+      '@biomejs/cli-linux-arm64-musl': 2.5.5
+      '@biomejs/cli-linux-x64': 2.5.5
+      '@biomejs/cli-linux-x64-musl': 2.5.5
+      '@biomejs/cli-win32-arm64': 2.5.5
+      '@biomejs/cli-win32-x64': 2.5.5
 
-  '@biomejs/cli-darwin-arm64@2.5.2':
+  '@biomejs/cli-darwin-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.2':
+  '@biomejs/cli-darwin-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.2':
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.2':
+  '@biomejs/cli-linux-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.2':
+  '@biomejs/cli-linux-x64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.2':
+  '@biomejs/cli-linux-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.2':
+  '@biomejs/cli-win32-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.2':
+  '@biomejs/cli-win32-x64@2.5.5':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -3745,30 +3745,30 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@next/env@16.2.10': {}
+  '@next/env@16.2.11': {}
 
-  '@next/swc-darwin-arm64@16.2.10':
+  '@next/swc-darwin-arm64@16.2.11':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.10':
+  '@next/swc-darwin-x64@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.10':
+  '@next/swc-linux-arm64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.10':
+  '@next/swc-linux-arm64-musl@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.10':
+  '@next/swc-linux-x64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.10':
+  '@next/swc-linux-x64-musl@16.2.11':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.10':
+  '@next/swc-win32-arm64-msvc@16.2.11':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.10':
+  '@next/swc-win32-x64-msvc@16.2.11':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4296,7 +4296,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5356,7 +5356,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -5368,9 +5368,9 @@ snapshots:
 
   nanoid@3.3.16: {}
 
-  next@16.2.10(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.11(@types/node@26.1.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.2.10
+      '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
@@ -5379,14 +5379,14 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.10
-      '@next/swc-darwin-x64': 16.2.10
-      '@next/swc-linux-arm64-gnu': 16.2.10
-      '@next/swc-linux-arm64-musl': 16.2.10
-      '@next/swc-linux-x64-gnu': 16.2.10
-      '@next/swc-linux-x64-musl': 16.2.10
-      '@next/swc-win32-arm64-msvc': 16.2.10
-      '@next/swc-win32-x64-msvc': 16.2.10
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
       sharp: 0.35.3(@types/node@26.1.1)
     transitivePeerDependencies:
       - '@babel/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,9 +23,10 @@ overrides:
   js-yaml: ^4.3.0
   markdown-it: ^14.2.0
   linkify-it: ^5.0.2
-  # GHSA-3jxr-9vmj-r5cp (brace-expansion DoS, patched 5.0.7): dev-only transitive via
-  # rimraf -> glob -> minimatch, which pulled 5.0.6.
-  brace-expansion: ^5.0.7
+  # GHSA-3jxr-9vmj-r5cp (brace-expansion DoS): dev-only transitive via
+  # rimraf -> glob -> minimatch, which pulled 5.0.6. Re-patched in 5.0.8 (the 5.0.7
+  # fix was incomplete — the advisory range now covers <=5.0.7).
+  brace-expansion: ^5.0.8
   # GHSA-f88m-g3jw-g9cj (libvips CVEs inherited by sharp <0.35.0): next pins sharp ^0.34.5,
   # so this override forces the patched line until next bumps. Verified via production build.
   sharp: ^0.35.3

--- a/src/modules/invoices/__tests__/unit/domain/invoice-status.validator.test.ts
+++ b/src/modules/invoices/__tests__/unit/domain/invoice-status.validator.test.ts
@@ -8,17 +8,17 @@ import { APP_ERROR_KEYS } from "@/shared/core/errors/core/catalog/app-error.regi
  * Allowed values are exactly "pending" and "paid".
  */
 describe("validateInvoiceStatus", () => {
-	it.each([
-		"pending",
-		"paid",
-	] as const)("accepts the valid status %j", (status) => {
-		const result = validateInvoiceStatus(status);
+	it.each(["pending", "paid"] as const)(
+		"accepts the valid status %j",
+		(status) => {
+			const result = validateInvoiceStatus(status);
 
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.value).toBe(status);
-		}
-	});
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toBe(status);
+			}
+		},
+	);
 
 	it("rejects an unknown status string with a validation AppError", () => {
 		const result = validateInvoiceStatus("cancelled");

--- a/src/shared/core/errors/__tests__/unit/app-error-entity.utils.test.ts
+++ b/src/shared/core/errors/__tests__/unit/app-error-entity.utils.test.ts
@@ -13,15 +13,12 @@ import {
  * so the result is always safe to freeze and log.
  */
 describe("deepFreeze", () => {
-	it.each([
-		42,
-		"x",
-		true,
-		null,
-		undefined,
-	])("returns primitive %p unchanged", (value) => {
-		expect(deepFreeze(value)).toBe(value);
-	});
+	it.each([42, "x", true, null, undefined])(
+		"returns primitive %p unchanged",
+		(value) => {
+			expect(deepFreeze(value)).toBe(value);
+		},
+	);
 
 	it("deep-freezes nested objects and returns the same reference", () => {
 		const obj = { a: 1, nested: { b: 2 } };

--- a/src/shared/core/errors/__tests__/unit/app-error.entity.test.ts
+++ b/src/shared/core/errors/__tests__/unit/app-error.entity.test.ts
@@ -68,15 +68,12 @@ describe("AppError entity", () => {
 			expect(isAppError(makeConflict())).toBe(true);
 		});
 
-		it.each([
-			new Error("x"),
-			{ key: "conflict" },
-			null,
-			"conflict",
-			42,
-		])("is false for non-AppError value %p", (value) => {
-			expect(isAppError(value)).toBe(false);
-		});
+		it.each([new Error("x"), { key: "conflict" }, null, "conflict", 42])(
+			"is false for non-AppError value %p",
+			(value) => {
+				expect(isAppError(value)).toBe(false);
+			},
+		);
 	});
 
 	describe("isAppErrorDto", () => {

--- a/src/shared/core/errors/__tests__/unit/error-metadata.value.test.ts
+++ b/src/shared/core/errors/__tests__/unit/error-metadata.value.test.ts
@@ -12,20 +12,19 @@ import {
  * fields.
  */
 describe("isValidationMetadata", () => {
-	it.each([
-		{ fieldErrors: { email: ["bad"] } },
-		{ formErrors: ["bad"] },
-	])("is true when validation fields are present: %p", (metadata) => {
-		expect(isValidationMetadata(metadata)).toBe(true);
-	});
+	it.each([{ fieldErrors: { email: ["bad"] } }, { formErrors: ["bad"] }])(
+		"is true when validation fields are present: %p",
+		(metadata) => {
+			expect(isValidationMetadata(metadata)).toBe(true);
+		},
+	);
 
-	it.each([
-		{},
-		{ reason: "x" },
-		{ pgCode: "23505" },
-	])("is false otherwise: %p", (metadata) => {
-		expect(isValidationMetadata(metadata)).toBe(false);
-	});
+	it.each([{}, { reason: "x" }, { pgCode: "23505" }])(
+		"is false otherwise: %p",
+		(metadata) => {
+			expect(isValidationMetadata(metadata)).toBe(false);
+		},
+	);
 });
 
 describe("isPgMetadata", () => {
@@ -33,11 +32,10 @@ describe("isPgMetadata", () => {
 		expect(isPgMetadata({ pgCode: "23505" })).toBe(true);
 	});
 
-	it.each([
-		{},
-		{ constraint: "x" },
-		{ reason: "x" },
-	])("is false when pgCode is absent: %p", (metadata) => {
-		expect(isPgMetadata(metadata)).toBe(false);
-	});
+	it.each([{}, { constraint: "x" }, { reason: "x" }])(
+		"is false when pgCode is absent: %p",
+		(metadata) => {
+			expect(isPgMetadata(metadata)).toBe(false);
+		},
+	);
 });

--- a/src/shared/core/errors/__tests__/unit/serialization.test.ts
+++ b/src/shared/core/errors/__tests__/unit/serialization.test.ts
@@ -10,17 +10,12 @@ import { redactNonSerializable } from "@/shared/core/errors/utils/serialization"
  * descriptor so logging never throws.
  */
 describe("redactNonSerializable", () => {
-	it.each([
-		null,
-		undefined,
-		"text",
-		42,
-		0,
-		true,
-		false,
-	])("returns primitive %p unchanged", (value) => {
-		expect(redactNonSerializable(value)).toBe(value);
-	});
+	it.each([null, undefined, "text", 42, 0, true, false])(
+		"returns primitive %p unchanged",
+		(value) => {
+			expect(redactNonSerializable(value)).toBe(value);
+		},
+	);
 
 	it("stringifies bigint (JSON cannot represent it)", () => {
 		expect(redactNonSerializable(10n)).toBe("10");

--- a/src/shared/core/errors/__tests__/unit/to-pg-error.test.ts
+++ b/src/shared/core/errors/__tests__/unit/to-pg-error.test.ts
@@ -87,12 +87,10 @@ describe("toPgError", () => {
 		expect(mapping.pgErrorMetadata.detail).toBe("connection refused");
 	});
 
-	it.each([
-		null,
-		undefined,
-		"raw string",
-		7,
-	])("falls back to unexpected for non-object input %p", (input) => {
-		expect(toPgError(input).appErrorKey).toBe(APP_ERROR_KEYS.unexpected);
-	});
+	it.each([null, undefined, "raw string", 7])(
+		"falls back to unexpected for non-object input %p",
+		(input) => {
+			expect(toPgError(input).appErrorKey).toBe(APP_ERROR_KEYS.unexpected);
+		},
+	);
 });

--- a/src/shared/core/result/__tests__/unit/result.test.ts
+++ b/src/shared/core/result/__tests__/unit/result.test.ts
@@ -30,21 +30,17 @@ describe("Result core", () => {
 			}
 		});
 
-		it.each([
-			0,
-			"",
-			null,
-			undefined,
-			false,
-			Number.NaN,
-		])("wraps falsy value %p without coercion", (value) => {
-			const result = Ok(value);
+		it.each([0, "", null, undefined, false, Number.NaN])(
+			"wraps falsy value %p without coercion",
+			(value) => {
+				const result = Ok(value);
 
-			expect(result.ok).toBe(true);
-			if (result.ok) {
-				expect(result.value).toBe(value);
-			}
-		});
+				expect(result.ok).toBe(true);
+				if (result.ok) {
+					expect(result.value).toBe(value);
+				}
+			},
+		);
 
 		it("returns a frozen object (immutable result)", () => {
 			expect(Object.isFrozen(Ok(1))).toBe(true);


### PR DESCRIPTION
Automated weekly maintenance run. **This one is security-motivated** — `pnpm audit` was showing 10 advisories (5 high / 5 moderate) and is now clean.

> [!NOTE]
> **Branch-model mismatch.** The repo moved to the single-branch local-first model on 2026-06-25 (no PRs; feature branches merge into `main` **locally**, and `ci.yml` only triggers on push to `main`). The weekly-maintenance routine still says "open a PR", so this is a PR — but **no CI will run on it**. Review the diff, then either merge it locally in the primary checkout or press Merge here and let CI run on the resulting `main` push. Worth updating the routine's spec to match the current model.

## What bumped

| Package | From | To | Why |
| --- | --- | --- | --- |
| `next` | 16.2.10 | **16.2.11** (exact) | 9 security advisories |
| `@biomejs/biome` | 2.5.2 | **2.5.5** | held-back 2.5.3 panic is fixed |
| `brace-expansion` (override) | ^5.0.7 | **^5.0.8** | GHSA-3jxr-9vmj-r5cp re-patch |

### next 16.2.11 — clears 9 advisories

4 high: App Router middleware/proxy bypass, SSRF in Server Actions, SSRF in rewrites, App Router Server-component DoS. 5 moderate: two response-body cache confusions, unbounded Edge Server Action payload, image-optimization DoS, unauthenticated disclosure of internal Server Function endpoints. All patched in `>=16.2.11`.

**Pinned exact, deliberately.** 16.2.11 shipped 2026-07-21 (6 days, passes the 3-day freshness rule), but 16.2.12 shipped 2026-07-25 (2 days — fails it), and a `^16.2.11` range resolves straight to 16.2.12. Exact-pinning was the only way to take the security fix without also taking a 2-day-old release. Tracked in `BACKLOG.md` → restore the caret once 16.2.12 has aged.

### biome 2.5.5 — the 2.5.3 hold is over

The 2.5.3 hold existed because it panicked on 8 form `.tsx` files while exiting 0 (silent lint loss). **Verified fixed:** 2.5.5 checks 615 files — identical to the 2.5.2 baseline — with zero `panicked` output.

- `biome migrate --write` → schema URL only.
- The 2.5.5 formatter reflows `it.each([...])(...)`; `biome format --write` reformatted 7 test files. Cosmetic, no assertions touched.

### `brace-expansion` override

The 5.0.7 fix was incomplete; the advisory range now covers `<=5.0.7`. Bumped to `^5.0.8` (published 2026-07-23, 4 days old). No other override needed lockstep changes — `next` isn't in `overrides`, and the `sharp ^0.35.3` override still resolves correctly under 16.2.11.

### No codemod run

16.2.10 → 16.2.11 is a patch, so `@next/codemod upgrade` doesn't apply.

## Verification

| Check | Result |
| --- | --- |
| `pnpm check:fast` | ✅ exit 0 (lint, md, typecheck, typegen, drift) |
| `pnpm test:unit` | ✅ 289/289 passed, 50 files |
| `pnpm audit` | ✅ 0 (was 5 high / 5 moderate) |
| `pnpm cy:e2e` | ⏭️ not run (routine excludes it) |
| production build | ⏭️ not run (needs env) |

Given this is a framework patch touching middleware and Server Actions, an e2e run before merging is a reasonable extra gate.

## Report-only findings

**Migration drift: clean.** dev/test/prod agree on the final schema (`customers`, `demo_user_counters`, `invoices`, `users`; all at `0006`).

**knip: no new findings.** Same 5 as the 2026-06-14 triage, all deliberate keeps — `statusEnum`, `TableFooter`/`TableCaption`, and `merienda`/`doto` (the font experiment already tracked in BACKLOG).

**5 new Biome warnings (not fixed here).** 2.5.5 widened `noUnnecessaryConditions` and flags redundant guards on non-nullable params: `invoice.service.ts:68`, `invoice.repository.ts:56`, and `if (!(db && id))` in the delete/read/update invoice DALs. Warnings only — `check:fast` stays green. Deleting runtime guards is a real code change, not a maintenance bump, so it's tracked in BACKLOG instead.

## Available but not taken

- `next` **16.2.12** (2 days) — too fresh; next week.
- `typescript` **7.0.2** — major. BACKLOG already has a TS 6.0 tsconfig-modernization item; a v7 jump deserves its own PR.
- `pnpm` 11.5.3 → **11.17.0**, `cypress` 15.18.1 → **15.19.0**, `react`/`react-dom` 19.2.7 → **19.2.8**, `knip` → 6.29.0, `markdownlint-cli2` → 0.23.2, `postcss` → 8.5.23. Report-only per the routine.
- Node `.nvmrc` 26 — unchanged.
