### PR TITLE
fix(deps): repair frozen-lockfile break on main + prune obsolete overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   esbuild: ^0.28.1
   vite: ^7.3.5
-  postcss: ^8.5.19
+  postcss: ^8.5.23
   js-yaml: ^4.3.0
   markdown-it: ^14.2.0
   linkify-it: ^5.0.2
@@ -1946,9 +1946,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@26.1.1':
-    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
-
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
@@ -2339,11 +2336,6 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  baseline-browser-mapping@2.11.4:
-    resolution: {integrity: sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   baseline-browser-mapping@2.11.5:
     resolution: {integrity: sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==}
@@ -2769,9 +2761,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -4061,11 +4050,6 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
-
-  terser@5.46.1:
-    resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   terser@5.49.0:
     resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
@@ -6089,10 +6073,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@26.1.1':
-    dependencies:
-      undici-types: 8.3.0
-
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
@@ -6466,8 +6446,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.4: {}
-
   baseline-browser-mapping@2.11.5: {}
 
   bcrypt-pbkdf@1.0.2:
@@ -6497,7 +6475,7 @@ snapshots:
 
   browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.11.4
+      baseline-browser-mapping: 2.11.5
       caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.396
       node-releases: 2.0.51
@@ -6816,8 +6794,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@2.1.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -7195,7 +7171,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -7663,7 +7639,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.46.1
+      terser: 5.49.0
       webpack: 5.109.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)
     optionalDependencies:
       esbuild: 0.28.1
@@ -8260,20 +8236,12 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser@5.46.1:
-    dependencies:
-      '@jridgewell/source-map': 0.3.11
-      acorn: 8.17.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
-
   terser@5.49.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
-    optional: true
 
   throttleit@1.0.1: {}
 
@@ -8562,7 +8530,7 @@ snapshots:
       browserslist: 4.28.7
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.3
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.3.1
       eslint-scope: 5.1.1
       events: 3.3.0
       graceful-fs: 4.2.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ overrides:
   esbuild: ^0.28.1
   vite: ^7.3.5
   postcss: ^8.5.23
-  js-yaml: ^4.3.0
-  markdown-it: ^14.2.0
-  linkify-it: ^5.0.2
   brace-expansion: ^5.0.8
   sharp: ^0.35.3
 
@@ -3144,8 +3141,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -7193,7 +7190,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -7403,7 +7400,7 @@ snapshots:
   markdownlint-cli2@0.23.2(supports-color@8.1.1):
     dependencies:
       globby: 16.2.2
-      js-yaml: 4.3.0
+      js-yaml: 5.2.2
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ onlyBuiltDependencies:
 overrides:
   esbuild: ^0.28.1
   vite: ^7.3.5
-  postcss: ^8.5.19
+  postcss: ^8.5.23
   # Force patched transitive deps of markdownlint-cli2 (dev-only quadratic-complexity DoS fixes).
   # GHSA-h67p-54hq-rp68 + GHSA-52cp-r559-cp3m (js-yaml >=4.3.0), GHSA-6v5v-wf23-fmfq
   # (markdown-it >=14.2.0), GHSA-v245-v573-v5vm (linkify-it >=5.0.2).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,12 +17,6 @@ overrides:
   esbuild: ^0.28.1
   vite: ^7.3.5
   postcss: ^8.5.23
-  # Force patched transitive deps of markdownlint-cli2 (dev-only quadratic-complexity DoS fixes).
-  # GHSA-h67p-54hq-rp68 + GHSA-52cp-r559-cp3m (js-yaml >=4.3.0), GHSA-6v5v-wf23-fmfq
-  # (markdown-it >=14.2.0), GHSA-v245-v573-v5vm (linkify-it >=5.0.2).
-  js-yaml: ^4.3.0
-  markdown-it: ^14.2.0
-  linkify-it: ^5.0.2
   # GHSA-3jxr-9vmj-r5cp (brace-expansion DoS): dev-only transitive via
   # rimraf -> glob -> minimatch, which pulled 5.0.6. Re-patched in 5.0.8 (the 5.0.7
   # fix was incomplete — the advisory range now covers <=5.0.7).


### PR DESCRIPTION
## Summary

`main` is currently red: commit 73d528d1 bumped `postcss` to `^8.5.23` in package.json, but the `pnpm-workspace.yaml` override still forced `^8.5.19`, so `pnpm install --frozen-lockfile` fails with `ERR_PNPM_OUTDATED_LOCKFILE` in both CI jobs **and** the Vercel production deploy (the live site is still serving the previous deployment). Local verification passed because `check:fast`/unit/e2e never do a frozen install — same trap as PR #42 in June, same package.

Two commits:

1. **56b74b24** — bump the postcss override to `^8.5.23` in lockstep with the manifest. The override itself stays: `next` pins postcss 8.4.31 exact, so the override is what forces the patched 8.5.x line.
2. **2998a78c** — drop the `js-yaml`/`markdown-it`/`linkify-it` overrides, which markdownlint-cli2 0.23.2 (their sole consumer) has outgrown: it pins js-yaml **5.2.2** exactly (the `^4.3.0` override was actively *downgrading* it), pins markdown-it 14.3.0, and markdown-it itself declares `linkify-it: ^5.0.2`. Kept as still load-bearing: `esbuild` (vite's `^0.27.0` admits vulnerable 0.27.x, GHSA-g7r4-m6w7-qqqr), `vite` (holds major 7 — vitest's range would jump to 8), `brace-expansion` (minimatch's `^5.0.5` admits ≤5.0.7), `sharp` (next still pins `^0.34.5`).

## Type of change

- [x] Fix
- [x] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen)
- [x] `pnpm install --frozen-lockfile` under pnpm 11.17.0 — the exact command CI runs, green after each commit
- [ ] `pnpm test` / `pnpm cy:e2e` — not rerun; no source changes, deps functionally identical to what 73d528d1 already verified except js-yaml 4→5, which `md:lint` (inside check:fast) exercises

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (n/a — override comments in `pnpm-workspace.yaml` are the docs and were updated)
- [x] Focused change — preserves existing patterns and user-authored work

Reviewer notes: `pnpm peers check` reports two unmet peers (cypress-webpack-preprocessor 7 vs `^6`, tsconfck wanting TS `^5` vs TS 7) — both pre-exist on `main`, unrelated to this PR. After merge, dependabot PR #116 shrinks to just the Biome 2.5.6 bump.
