### PR TITLE
fix(devtools): read prod-db guard env per-key so CI/Vercel typecheck passes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -112,7 +112,13 @@ Terse log — newest first. Full detail lives in the `project_*` memory files.
       when `DATABASE_ENV` is `production` (missing/unrecognized fails closed) unless
       `CONFIRM_PROD_DB=yes` is set; blocked runs exit 1 via `runCli`. 17 unit tests (vitest
       unit lane now also picks up `devtools/**` tests); docs updated (drizzle, deployment,
-      getting-started, scripts guide, README).
+      getting-started, scripts guide, README). _Follow-up fix (same day): the guard's
+      `env = process.env` default failed TS2559 in CI/Vercel only — `experimental.typedEnv`
+      derives ProcessEnv's keys from the env files present, and CI has none — the first real
+      cross-lane **semantic** merge conflict (both lanes were green on their own bases; git
+      merged cleanly; the type contract broke). Fixed by reading the two keys individually,
+      matching `env-access.utils.ts`. Lane-map lesson: run `check:fast` on the merged tree
+      before pushing, not just on the branch._
 - [x] **Real landing page (first impression)** _(2026-07-30)_ — replaced the Next.js Learn
       boilerplate `/` (course welcome, course link, course hero screenshots) with a real
       portfolio landing: honest hero copy, one-click **Try the demo** (reuses

--- a/devtools/shared/db/prod-db.guard.ts
+++ b/devtools/shared/db/prod-db.guard.ts
@@ -50,7 +50,14 @@ export function isDestructiveDbTaskAllowed(env: DestructiveDbTaskEnv): boolean {
  */
 export function assertDestructiveDbTaskAllowed(
 	taskLabel: string,
-	env: DestructiveDbTaskEnv = process.env,
+	// Read keys individually instead of assigning `process.env` wholesale:
+	// with `experimental.typedEnv`, ProcessEnv's declared keys come from the
+	// env files present, so in CI/Vercel (no env files) the whole-object
+	// assignment fails TS2559 despite compiling locally.
+	env: DestructiveDbTaskEnv = {
+		CONFIRM_PROD_DB: process.env[PROD_DB_CONFIRM_VAR],
+		DATABASE_ENV: process.env.DATABASE_ENV,
+	},
 ): void {
 	if (isDestructiveDbTaskAllowed(env)) {
 		return;


### PR DESCRIPTION
## Summary

Fixes the CI type-check failure and the failed Vercel preview/production deploys on `main` (run [30541711850](https://github.com/andrewpetersondev/nextjs-dashboard/actions/runs/30541711850), commit 94596752).

The prod-DB guard defaulted its parameter to `process.env` wholesale (`env: DestructiveDbTaskEnv = process.env`). With `experimental.typedEnv`, TypeScript derives `ProcessEnv`'s declared keys from the env files present — locally `.env.*.local` exists so `DATABASE_ENV` is on the type and it compiles; CI/Vercel checkouts have no env files, so `process.env` shares zero properties with the all-optional guard interface → `TS2559`.

This was a **semantic merge conflict**: the `stoic-montalcini` lane verified green on its July-29 base, the rootfiles sweep landed in between, and git merged the lines cleanly while the type contract broke. The fix builds the default from individual key reads — the same pattern `env-access.utils.ts` has run green in CI for months. No behavior change. Also adds a BACKLOG note recording the lesson (validate the merged tree, not just the branch).

## Type of change

- [x] Fix

## How it was tested

- [x] `pnpm check:fast` (lint + typecheck + typegen)
- [x] `pnpm test` (unit — 306/306, including the 17 guard tests)
- [x] `pnpm next:build` (the Vercel build path)
- [ ] `pnpm cy:e2e` — not re-run; e2e passed in CI even on the broken commit (the failure was type-check only)

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed
- [x] Docs / README updated if behaviour or setup changed (BACKLOG note; no behavior change)
- [x] Focused change — preserves existing patterns and user-authored work

> Note: `ci.yml` triggers on push to `main` only, so no checks will appear on this PR — CI and the Vercel deploys run on the merge push. The commands above were all run locally on this exact tree (= `main` + this commit).
