### PR TITLE
chore: weekly maintenance 2026-08-09

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
 	"assist": {
 		"actions": {
 			"preset": "recommended",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"date-fns": "^4.4.0",
 		"drizzle-orm": "^0.45.2",
 		"jose": "^6.2.6",
-		"next": "^16.2.12",
+		"next": "^16.3.0",
 		"pg": "^8.22.0",
 		"react": "^19.2.8",
 		"react-dom": "^19.2.8",
@@ -17,7 +17,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.6",
+		"@biomejs/biome": "2.5.7",
 		"@cypress/webpack-batteries-included-preprocessor": "^4.2.0",
 		"@cypress/webpack-preprocessor": "^7.1.1",
 		"@tailwindcss/postcss": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^6.2.6
         version: 6.2.6
       next:
-        specifier: ^16.2.12
-        version: 16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^16.3.0
+        version: 16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -58,8 +58,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.5.6
-        version: 2.5.6
+        specifier: 2.5.7
+        version: 2.5.7
       '@cypress/webpack-batteries-included-preprocessor':
         specifier: ^4.2.0
         version: 4.2.0(@cypress/webpack-preprocessor@7.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)))(supports-color@8.1.1)(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.25)(supports-color@8.1.1)(typescript@7.0.2)
@@ -751,59 +751,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.6':
-    resolution: {integrity: sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==}
+  '@biomejs/biome@2.5.7':
+    resolution: {integrity: sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.6':
-    resolution: {integrity: sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==}
+  '@biomejs/cli-darwin-arm64@2.5.7':
+    resolution: {integrity: sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.6':
-    resolution: {integrity: sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==}
+  '@biomejs/cli-darwin-x64@2.5.7':
+    resolution: {integrity: sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.6':
-    resolution: {integrity: sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.7':
+    resolution: {integrity: sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.6':
-    resolution: {integrity: sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==}
+  '@biomejs/cli-linux-arm64@2.5.7':
+    resolution: {integrity: sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.6':
-    resolution: {integrity: sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==}
+  '@biomejs/cli-linux-x64-musl@2.5.7':
+    resolution: {integrity: sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.6':
-    resolution: {integrity: sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==}
+  '@biomejs/cli-linux-x64@2.5.7':
+    resolution: {integrity: sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.6':
-    resolution: {integrity: sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==}
+  '@biomejs/cli-win32-arm64@2.5.7':
+    resolution: {integrity: sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.6':
-    resolution: {integrity: sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==}
+  '@biomejs/cli-win32-x64@2.5.7':
+    resolution: {integrity: sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1357,57 +1357,57 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@next/env@16.2.12':
-    resolution: {integrity: sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==}
+  '@next/env@16.3.0':
+    resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
 
-  '@next/swc-darwin-arm64@16.2.12':
-    resolution: {integrity: sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==}
+  '@next/swc-darwin-arm64@16.3.0':
+    resolution: {integrity: sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.12':
-    resolution: {integrity: sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==}
+  '@next/swc-darwin-x64@16.3.0':
+    resolution: {integrity: sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.12':
-    resolution: {integrity: sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==}
+  '@next/swc-linux-arm64-gnu@16.3.0':
+    resolution: {integrity: sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.12':
-    resolution: {integrity: sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==}
+  '@next/swc-linux-arm64-musl@16.3.0':
+    resolution: {integrity: sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.12':
-    resolution: {integrity: sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==}
+  '@next/swc-linux-x64-gnu@16.3.0':
+    resolution: {integrity: sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.12':
-    resolution: {integrity: sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==}
+  '@next/swc-linux-x64-musl@16.3.0':
+    resolution: {integrity: sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.12':
-    resolution: {integrity: sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==}
+  '@next/swc-win32-arm64-msvc@16.3.0':
+    resolution: {integrity: sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.12':
-    resolution: {integrity: sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==}
+  '@next/swc-win32-x64-msvc@16.3.0':
+    resolution: {integrity: sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3533,8 +3533,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next@16.2.12:
-    resolution: {integrity: sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==}
+  next@16.3.0:
+    resolution: {integrity: sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5224,39 +5224,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.5.6':
+  '@biomejs/biome@2.5.7':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.6
-      '@biomejs/cli-darwin-x64': 2.5.6
-      '@biomejs/cli-linux-arm64': 2.5.6
-      '@biomejs/cli-linux-arm64-musl': 2.5.6
-      '@biomejs/cli-linux-x64': 2.5.6
-      '@biomejs/cli-linux-x64-musl': 2.5.6
-      '@biomejs/cli-win32-arm64': 2.5.6
-      '@biomejs/cli-win32-x64': 2.5.6
+      '@biomejs/cli-darwin-arm64': 2.5.7
+      '@biomejs/cli-darwin-x64': 2.5.7
+      '@biomejs/cli-linux-arm64': 2.5.7
+      '@biomejs/cli-linux-arm64-musl': 2.5.7
+      '@biomejs/cli-linux-x64': 2.5.7
+      '@biomejs/cli-linux-x64-musl': 2.5.7
+      '@biomejs/cli-win32-arm64': 2.5.7
+      '@biomejs/cli-win32-x64': 2.5.7
 
-  '@biomejs/cli-darwin-arm64@2.5.6':
+  '@biomejs/cli-darwin-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.6':
+  '@biomejs/cli-darwin-x64@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.6':
+  '@biomejs/cli-linux-arm64-musl@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.6':
+  '@biomejs/cli-linux-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.6':
+  '@biomejs/cli-linux-x64-musl@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.6':
+  '@biomejs/cli-linux-x64@2.5.7':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.6':
+  '@biomejs/cli-win32-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.6':
+  '@biomejs/cli-win32-x64@2.5.7':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -5704,30 +5704,30 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@next/env@16.2.12': {}
+  '@next/env@16.3.0': {}
 
-  '@next/swc-darwin-arm64@16.2.12':
+  '@next/swc-darwin-arm64@16.3.0':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.12':
+  '@next/swc-darwin-x64@16.3.0':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.12':
+  '@next/swc-linux-arm64-gnu@16.3.0':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.12':
+  '@next/swc-linux-arm64-musl@16.3.0':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.12':
+  '@next/swc-linux-x64-gnu@16.3.0':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.12':
+  '@next/swc-linux-x64-musl@16.3.0':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.12':
+  '@next/swc-win32-arm64-msvc@16.3.0':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.12':
+  '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -7653,9 +7653,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.12(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@next/env': 16.2.12
+      '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.6
       caniuse-lite: 1.0.30001806
@@ -7664,14 +7664,14 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.8)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.12
-      '@next/swc-darwin-x64': 16.2.12
-      '@next/swc-linux-arm64-gnu': 16.2.12
-      '@next/swc-linux-arm64-musl': 16.2.12
-      '@next/swc-linux-x64-gnu': 16.2.12
-      '@next/swc-linux-x64-musl': 16.2.12
-      '@next/swc-win32-arm64-msvc': 16.2.12
-      '@next/swc-win32-x64-msvc': 16.2.12
+      '@next/swc-darwin-arm64': 16.3.0
+      '@next/swc-darwin-x64': 16.3.0
+      '@next/swc-linux-arm64-gnu': 16.3.0
+      '@next/swc-linux-arm64-musl': 16.3.0
+      '@next/swc-linux-x64-gnu': 16.3.0
+      '@next/swc-linux-x64-musl': 16.3.0
+      '@next/swc-win32-arm64-msvc': 16.3.0
+      '@next/swc-win32-x64-msvc': 16.3.0
       sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
       - '@babel/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,14 +14,19 @@ overrides:
   # Deliberate major-7 hold: vitest 4 accepts ^6||^7||^8 and would otherwise resolve
   # vite 8. Drop only as part of an intentional vite 8 migration.
   vite: ^7.3.5
-  # next pins postcss 8.4.31 exact (patched, but old); dedupe the graph to one 8.5.x copy.
-  # Still true as of next 16.2.12 — dropping this override forks the graph back into two copies.
+  # next pins postcss exact (8.5.23 as of next 16.3.0, was 8.4.31 through 16.2.12); dedupe the
+  # graph to one 8.5.x copy. Still needed — the pin moved forward but stays below the range
+  # below, so dropping this override forks the graph back into two copies.
   # ⚠ MUST equal the `postcss` devDependency range in package.json. Nothing bumps this when
   #   that one moves, so it silently falls behind (it sat a patch back from 2026-08-05 until
   #   2026-08-07). When a postcss bump lands in package.json, change it here in the same commit.
   postcss: ^8.5.25
-  # GHSA-f88m-g3jw-g9cj (libvips CVEs inherited by sharp <0.35.0): next pins sharp ^0.34.5,
-  # so this override forces the patched line until next bumps. Verified via production build.
+  # GHSA-f88m-g3jw-g9cj (libvips CVEs inherited by sharp <0.35.0). Written when next pinned
+  # sharp ^0.34.5, to force the patched line "until next bumps" — next 16.3.0 HAS now bumped,
+  # to ^0.35.3, exactly this value, so as of 2026-08-09 the override is redundant belt-and-braces
+  # rather than load-bearing. Kept, not deleted: removing it is a graph change that deserves a
+  # deliberate review, and it still pins the floor if a future next regresses. Retire it whenever
+  # next's own pin is comfortably ahead.
   sharp: ^0.35.3
 
 # Vetted peer combos that upstream ranges haven't caught up to (both at latest release):

--- a/src/modules/customers/presentation/actions/read-total-customers-count.action.ts
+++ b/src/modules/customers/presentation/actions/read-total-customers-count.action.ts
@@ -10,8 +10,8 @@ import { getAppDb } from "@/server/db/db.connection";
  * read-by-id actions beside it. It is still unreachable unauthenticated —
  * verified 2026-08-09 — because the `src/proxy.ts` matcher covers Server Action
  * POSTs to `/dashboard/*` and redirects them, and action ids resolve only on the
- * route they are registered for. Note that the middleware is therefore the
- * *only* thing guarding this one; prefer copying a guarded sibling.
+ * route they are registered for. Note that the middleware is therefore the only
+ * thing guarding this one; prefer copying a guarded sibling.
  */
 export async function readTotalCustomersCountAction(): Promise<number> {
 	const db = getAppDb();


### PR DESCRIPTION
Automated weekly maintenance run. Two bumps, two codemod passes, and two stale-comment corrections that `next@16.3.0` forced.

## What bumped

| Package | From | To | Published | Note |
| --- | --- | --- | --- | --- |
| `next` | 16.2.12 | **16.3.0** | 2026-08-03 | minor |
| `@biomejs/biome` | 2.5.6 | **2.5.7** | 2026-08-04 | patch |

**Held back by the 3-day freshness rule:** `pnpm` 11.21.0 published **today** (2026-08-09). Not bumped, and `packageManager` stays on 11.20.0.

Already at latest, nothing to do: `react` / `react-dom` 19.2.8, `drizzle-kit` 0.31.10, `drizzle-orm` 0.45.2, `vitest` 4.1.10, `typescript` 7.0.2.

Left for Dependabot (report-only scope): `cypress` 15.20.0, `postcss` 8.5.26, `knip` 6.32.0, `axe-core` 4.13.0, `pg` 8.23.0, `jose` 6.2.8, `tsx` 4.23.11, `@types/node` 26.2.0, `@types/pg` 8.21.0.

> **Correction to the routine's own prompt:** it says ".nvmrc currently 26". It is **24**, deliberately — aligned 2026-08-07 because Vercel reads `engines.node` (never `.nvmrc`) and tops out at 24.x. Nothing was changed here; `pnpm node:drift` confirms all four axes agree, including the running runtime.

## Codemods

**`@next/codemod` — 16.3 transforms scanned, none applied.** Both transforms Next 16.3 ships are opt-in *adoption helpers*, not migration requirements:

- `cache-components-instant-false` — only applies when enabling `cacheComponents`. `next.config.ts` does not set it, and the codemod would write `export const instant = false` plus a TODO comment into **every** `page`/`layout`/`default` file for a feature this project hasn't adopted.
- `remove-partial-prefetch` — only applies when enabling `partialPrefetching` globally. `src/app` has zero `prefetch` exports.

Verified by grep rather than assumed: no `prefetch`, no `export const instant`, no `cacheComponents` anywhere.

**`biome migrate --write` — applied.** Result was a `$schema` bump only (2.5.6 → 2.5.7); no rule renames or config restructuring.

## Findings that needed a code change

### 1. `next@16.3.0` falsified both `overrides` comments (lockstep check)

The lockstep rule sent me to `pnpm-workspace.yaml`, and both comments there encode an upstream fact that nothing re-checks:

- **`postcss`** — the comment said "next pins postcss 8.4.31 exact". As of 16.3.0 next pins **8.5.23**. The override still does real work (8.5.23 is below the `^8.5.25` devDependency range, so dropping it would fork the graph into two copies) — only the comment was wrong. Comment corrected; the override value is unchanged, and `pnpm deps:drift` still reports the overlap agreeing.
- **`sharp`** — the comment said the override forces the patched line *"until next bumps"*. **next 16.3.0 has now bumped**, to `^0.35.3` — exactly this override's value. So by its own stated retirement condition the override is now redundant belt-and-braces rather than load-bearing. **Kept, not deleted**, and the comment now records why: removing it is a dependency-graph change that deserves a deliberate review, and it still pins the floor if a future `next` regresses. **Retiring it is your call** — flagging it rather than taking it.

Confirmed one copy of each after install: `postcss@8.5.25`, `sharp@0.35.3`.

### 2. Biome 2.5.7 adds a rule that false-positives on markdown emphasis

`correctness/useSingleJsDocAsterisk` is new in the recommended set. It fired once, on `read-total-customers-count.action.ts:14`, where a JSDoc line read ` * *only* thing guarding this one` — the rule sees the emphasis marker as a doubled continuation asterisk. Its offered **unsafe fix deletes the opening `*` and leaves the emphasis unbalanced** (`only*`), so the line was **reworded** instead ("the only thing guarding this one").

Worth noting the detection path: Biome **infos do not change the exit code**, so this was found by *listing* diagnostics, not by reading `$?` — the repo's documented rule. Slate is back to **0 diagnostics across 687 files**.

## Verification

| Check | Result |
| --- | --- |
| `pnpm install` | clean, 7.8s |
| `pnpm check:fast` | **exit 0** |
| ↳ Biome | 0 diagnostics / 687 files |
| ↳ markdownlint + dprint | 0 issues / 82 files |
| ↳ typegen + typecheck (app + Cypress) | green |
| ↳ `node:drift` | OK — Node 24 across `.nvmrc`, `package.json`, `Dockerfile`; process on 24.19.0 |
| ↳ `deps:drift` | OK — 1 overlapping package agrees (`postcss`); 3 override-only |
| ↳ `db:drift` | OK — dev/test/prod describe the same final schema |
| `pnpm test:unit` | **465/465**, 72 files, exit 0 |
| `pnpm knip` | **exit 0** |

Exit codes were captured directly rather than through a pipe — `PIPESTATUS` is a bashism and reports empty under `zsh`, which is the same "misleading exit code" genre `AGENTS.md` warns about.

**Not run locally:** e2e (per routine policy — slow, plus the `$PORT`-reuse trap) and the production build (this worktree has no `.env.*` files). CI covers both: `ci.yml` now runs on `pull_request`, so this PR gets lint, types, all three drift gates, dead code, unit + coverage, the DB-backed integration lane, and a real production build with the CSP guard. E2E stays push-only by design and lands just after merge.

## Report-only

### `pnpm audit` — 2 high, both devDependency-only

**`pnpm audit --prod` is clean — no production exposure.**

| Advisory | Package | Resolved | Patched | Path |
| --- | --- | --- | --- | --- |
| [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | `fast-uri` | 3.1.4 | ≥3.1.5 | `@cypress/webpack-batteries-included-preprocessor` → … → `ajv` → `fast-uri` (48 paths) |
| [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | `brace-expansion` | 5.0.8 | ≥5.0.9 | `rimraf` → `glob` → `minimatch` → `brace-expansion` |

Each is exactly **one patch short**, and both patched versions are published — but the packages that pull them in are already at their own latest (`rimraf@6.1.3`, `@cypress/webpack-preprocessor@7.1.1`), so upstream hasn't widened its ranges yet. Neither was introduced by this change: the lockfile diff touches none of these paths. An `overrides` entry would clear both today, at the cost of two more hand-maintained pins in the block above — **not taken**, since step 4 is report-only and the exposure is test tooling.

### `pnpm knip` — clean

Exit 0. No unused files, exports, or dependencies. Only a pre-existing configuration hint (`.css` compiled extension excluded by project), which is not a finding. Nothing new to add to `BACKLOG.md`.

### Migration drift — none

Checked independently of the `db:drift` gate, comparing `meta/_journal.json` entry counts and the latest snapshot in each environment:

```
dev:  8 journal entries | 4 tables: customers(5), demo_user_counters(3), invoices(7), users(6)
test: 8 journal entries | 4 tables: customers(5), demo_user_counters(3), invoices(7), users(6)
prod: 8 journal entries | 4 tables: customers(5), demo_user_counters(3), invoices(7), users(6)
```

All three describe the same final schema. The 23503-on-fresh-prod-seed failure mode this check exists for is not present.

## `BACKLOG.md` untouched

Deliberate. The findings above are advisory and this PR is their review surface — the sharp-override retirement is the one that may deserve a backlog line, and that's your call to make when you read this rather than mine to write in a bot PR that might collide with parallel lane work.
