### PR TITLE
chore: weekly maintenance 2026-08-17

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -119,9 +119,11 @@ same commit. Convention in [`AGENTS.md`](AGENTS.md).
       upstream and **both deliberately not taken** — `output: process.env.VERCEL ? undefined :
       'standalone'` changes the build path that serves the live demo, and prefixing the Vercel
       build command with `NEXT_ADAPTER_PATH=` is an untracked dashboard setting nothing re-checks.
-      **Next step:** wait for 16.3.1 stable (none exists as of 2026-08-11; still reproducing on
-      `16.3.1-canary.7`), re-read the issue, then bump. The weekly-maintenance routine will
-      re-propose 16.3.x every Monday until it lands. Full mechanism in memory
+      **Next step — the condition originally written here is now MET ON ITS FACE AND STILL WRONG;
+      read the 2026-08-17 entry at the end of this item before acting.** It said "wait for 16.3.1
+      stable, re-read the issue, then bump": 16.3.1 shipped and #96646 is closed, and the hold
+      still stands. Lift it only for a stable release that **contains** the fix commit — never for
+      one that merely post-dates the issue closing. Full mechanism in memory
       (`project_next163_standalone_vercel_break`).
       **Re-checked and made structural 2026-08-11** (dependency-update lane): upstream #96646 is
       **still open**, last updated 2026-08-07, and there is still no 16.3.1 stable — canaries have
@@ -148,6 +150,53 @@ same commit. Convention in [`AGENTS.md`](AGENTS.md).
       Biome half (2.5.6 → 2.5.7) was split off and landed separately; the `next` bump and the two
       `pnpm-workspace.yaml` override-comment rewrites that describe 16.3.0 stayed behind on
       `claude/weekly-maintenance-2026-08-09` and travel together whenever the bump is retaken.
+      **HOLD STAYS 2026-08-17 (weekly maintenance) — and the retirement signal this item told you to
+      wait for has arrived while being WRONG.** Both halves of the old condition are now true:
+      **`next@16.3.1` is stable** (published 2026-08-13T22:48:45Z) and **#96646 is CLOSED**
+      (2026-08-14T09:09:04Z). Neither means the bug is fixed. The fix is
+      [PR #97287](https://github.com/vercel/next.js/pull/97287) — it re-scopes the #93684 gate so the
+      whole-app server NFTs are still emitted when `output: 'standalone'` is set alongside an adapter,
+      and guards the `copyTracedFiles` read — and it merged **into `canary`** as `c7b87c23` at
+      **2026-08-14T09:09:02Z**, i.e. **~10 hours AFTER 16.3.1 was published**. The issue closed two
+      seconds later because that merge auto-closed it. Verified three ways rather than inferred:
+      16.3.1's release notes list 20 backports and **#97287 is not among them**; `npm view next
+      versions` shows **nothing newer than 16.3.1** on the 16.3.x line (no 16.3.2); and a search for a
+      backport PR onto the release branch returns **none**. So the fix is **canary-only** and
+      **16.3.1 still contains the deploy-breaking bug**.
+      **The generalisable trap — this is the same mistake as the "green Vercel check", one layer out.**
+      Twice now the tempting signal has been a _proxy_ for the fix rather than the fix: a green Vercel
+      check that never built 16.3.x, and now a closed issue plus a newer stable that predates the
+      merge. **A closed upstream issue is not a shipped fix, and a release that post-dates the closure
+      is not a release that contains it.** Retirement condition restated so it is directly
+      checkable: lift the pin when a **stable `next` release contains commit `c7b87c23`** (check the
+      release notes for #97287, or `npm view next@<v>` and confirm the emitted
+      `next-server.js.nft.json` guard is present) — then do the two-file edit, and let the **Vercel
+      check on a branch where both files moved** be the proof.
+      `.github/dependabot.yml`'s `next: ["16.3.x"]` ignore entry stays correct and its stated
+      retirement ("once 16.3.1+ ships the fix") still reads right — note it turns on _ships the fix_,
+      not on 16.3.1 existing. ⚠ When the fix does land in, say, 16.3.2, that ignore entry **also
+      blocks the good version**, so it must be retired in the same edit that lifts the pin.
+
+- [ ] **`node:drift`'s `@types/node` axis has a transitive blind spot — found 2026-08-17, NOT fixed.**
+      The fifth axis added on 2026-08-12 pins the **declared** `@types/node` range in `package.json` to
+      equal the runtime major (24). It cannot see a transitive open range, and there is one:
+      **`@types/pg@8.21.0` declares `"@types/node": "*"`**, so pnpm resolves it to **26.2.0**, and
+      `@types/pg/index.d.ts` line 1 is `/// <reference types="node" />`. Under pnpm's isolated layout
+      `@types/pg` gets its own symlink — verified pointing at `@types+node@26.2.0` — so a second,
+      Node-26 typings copy is physically installed and reachable through a **direct devDependency**
+      while `node:drift` reports `OK — @types/node ^24.13.3 matches Node 24`. The root
+      `node_modules/@types/node` correctly resolves to 24.13.3, and there are two `@types/node`
+      package entries in the lockfile (both were already on `main`; this is pre-existing, not new).
+      **Scoped honestly: reachability is proven, harm is not.** `pnpm typecheck` (app + Cypress) is
+      green, and TypeScript generally collapses duplicate global declarations to one copy, so no
+      Node-26-only API is currently being accepted. The concern is that the guard's stated invariant —
+      "tsc never sees an API surface production lacks" — is weaker than it reads, which is the same
+      shape as [PR #133](https://github.com/andrewpetersondev/nextjs-dashboard/pull/133): typing
+      against a superset of the runtime is not a type error, so nothing fails loudly.
+      Options if it is worth closing: a `@types/node` entry in `pnpm-workspace.yaml` `overrides` would
+      force one 24.x copy graph-wide (and would then be gated by `deps:drift` like `postcss`/`next`),
+      or extend `node:drift` to walk resolved `@types/node` copies rather than only the manifest.
+      Neither taken — this run is report-only on findings. **Andrew's call.**
 
 - [ ] **CSP follow-ups** ([#126](https://github.com/andrewpetersondev/nextjs-dashboard/issues/126))
       _(added 2026-08-03, from the security-headers lane — full
@@ -225,6 +274,37 @@ same commit. Convention in [`AGENTS.md`](AGENTS.md).
 ## Done
 
 Terse log — newest first. Full detail lives in the `project_*` memory files.
+
+- [x] **Weekly maintenance — Biome 2.5.8, and the `next` hold's retirement signal caught arriving
+      false** _(2026-08-17, `claude/weekly-maintenance-2026-08-17`)_ — the only bump taken was
+      **`@biomejs/biome` 2.5.7 → 2.5.8** (released 2026-08-11, clears the 3-day rule);
+      `biome migrate --write` touched **only the `$schema` URL**, so 2.5.8 needs no config
+      restructuring here. Release notes were grepped for `panicked` first, per the standing rule from
+      the 2.5.3 hold — the single hit is a **fix** for a `noUselessFragments` panic, not a new one.
+      Two rule-level risks were checked rather than assumed, because this repo enables `nursery` at
+      `preset: recommended` **and** `useSortedClasses: "on"`: 2.5.8 changes variant ordering in
+      `sort_v4` (#11249) and adds four nursery rules, yet the slate stayed at **0** across 687 files
+      and `useSortedClasses` rewrote nothing. Slate listed via the summary reporter, never read off an
+      exit code.
+      **The substantive find was not a bump.** `next@16.3.1` went stable and upstream #96646 closed —
+      the exact two conditions this list said to wait for — and the hold still stands, because the fix
+      merged to `canary` ~10h **after** 16.3.1 was cut. Details and the restated, directly-checkable
+      retirement condition are in the open `next` item above; the short version is that **a closed
+      upstream issue is not a shipped fix**, which is the "green Vercel check" lesson one layer out.
+      **Reported, not fixed** (audit is report-only in this routine): a **new high advisory**,
+      [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — `nanoid` <3.3.18
+      infinite-loops in custom generators at size zero — against the single installed `nanoid@3.3.17`,
+      reached via `next → postcss → nanoid` plus the cypress webpack chain (18 paths). Diagnosed to
+      save a step: `postcss@8.5.26` already declares `^3.3.17`, which **admits** the patched 3.3.18
+      (published 2026-08-07), so this is the **droppable stale-lockfile class** like `fast-uri` and
+      `brace-expansion` — a `pnpm-workspace.yaml` override is the only lever, since `pnpm update`
+      cannot move a transitive. Nothing in this repo imports `nanoid`, so the size-zero path is not
+      reachable from our code.
+      Validation: Biome slate **0**, markdownlint 0, dprint clean, typecheck (app + Cypress) green,
+      `node:drift` / `deps:drift` / `db:drift` all OK, knip clean, unit **465/465**. E2E not run (per
+      the routine). One environment gotcha re-confirmed: the non-interactive shell inherited **Node
+      26** because the `.nvmrc` chpwd hook is interactive-only, so the checks were run under
+      `nvm use 24` — otherwise `node:drift` fails for an environment reason and reads as a repo break.
 
 - [x] **Dependabot `ignore` rules for the two held packages** _(2026-08-16,
       `claude/open-prs-routines-378ac9`)_ — `.github/dependabot.yml` had grouping but no `ignore:`

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
 	"assist": {
 		"actions": {
 			"preset": "recommended",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.7",
+		"@biomejs/biome": "2.5.8",
 		"@cypress/webpack-batteries-included-preprocessor": "^4.2.0",
 		"@cypress/webpack-preprocessor": "^7.1.1",
 		"@tailwindcss/postcss": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.5.7
-        version: 2.5.7
+        specifier: 2.5.8
+        version: 2.5.8
       '@cypress/webpack-batteries-included-preprocessor':
         specifier: ^4.2.0
         version: 4.2.0(@cypress/webpack-preprocessor@7.1.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(babel-loader@10.1.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.26)))(supports-color@8.1.1)(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.26)))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.26)(supports-color@8.1.1)(typescript@7.0.2)
@@ -754,59 +754,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.7':
-    resolution: {integrity: sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==}
+  '@biomejs/biome@2.5.8':
+    resolution: {integrity: sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.7':
-    resolution: {integrity: sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==}
+  '@biomejs/cli-darwin-arm64@2.5.8':
+    resolution: {integrity: sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.7':
-    resolution: {integrity: sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==}
+  '@biomejs/cli-darwin-x64@2.5.8':
+    resolution: {integrity: sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.7':
-    resolution: {integrity: sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==}
+  '@biomejs/cli-linux-arm64-musl@2.5.8':
+    resolution: {integrity: sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.7':
-    resolution: {integrity: sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==}
+  '@biomejs/cli-linux-arm64@2.5.8':
+    resolution: {integrity: sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.7':
-    resolution: {integrity: sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==}
+  '@biomejs/cli-linux-x64-musl@2.5.8':
+    resolution: {integrity: sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.7':
-    resolution: {integrity: sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==}
+  '@biomejs/cli-linux-x64@2.5.8':
+    resolution: {integrity: sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.7':
-    resolution: {integrity: sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==}
+  '@biomejs/cli-win32-arm64@2.5.8':
+    resolution: {integrity: sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.7':
-    resolution: {integrity: sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==}
+  '@biomejs/cli-win32-x64@2.5.8':
+    resolution: {integrity: sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -5236,39 +5236,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.5.7':
+  '@biomejs/biome@2.5.8':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.7
-      '@biomejs/cli-darwin-x64': 2.5.7
-      '@biomejs/cli-linux-arm64': 2.5.7
-      '@biomejs/cli-linux-arm64-musl': 2.5.7
-      '@biomejs/cli-linux-x64': 2.5.7
-      '@biomejs/cli-linux-x64-musl': 2.5.7
-      '@biomejs/cli-win32-arm64': 2.5.7
-      '@biomejs/cli-win32-x64': 2.5.7
+      '@biomejs/cli-darwin-arm64': 2.5.8
+      '@biomejs/cli-darwin-x64': 2.5.8
+      '@biomejs/cli-linux-arm64': 2.5.8
+      '@biomejs/cli-linux-arm64-musl': 2.5.8
+      '@biomejs/cli-linux-x64': 2.5.8
+      '@biomejs/cli-linux-x64-musl': 2.5.8
+      '@biomejs/cli-win32-arm64': 2.5.8
+      '@biomejs/cli-win32-x64': 2.5.8
 
-  '@biomejs/cli-darwin-arm64@2.5.7':
+  '@biomejs/cli-darwin-arm64@2.5.8':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.7':
+  '@biomejs/cli-darwin-x64@2.5.8':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.7':
+  '@biomejs/cli-linux-arm64-musl@2.5.8':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.7':
+  '@biomejs/cli-linux-arm64@2.5.8':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.7':
+  '@biomejs/cli-linux-x64-musl@2.5.8':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.7':
+  '@biomejs/cli-linux-x64@2.5.8':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.7':
+  '@biomejs/cli-win32-arm64@2.5.8':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.7':
+  '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
   '@bramus/specificity@2.4.2':
@@ -7187,7 +7187,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 26.2.0
+      '@types/node': 24.13.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
## Summary

Weekly maintenance for 2026-08-17. One bump taken (**Biome 2.5.7 → 2.5.8**), plus a
BACKLOG reconciliation for the `next` hold — whose documented retirement condition
**came true this week while still being the wrong signal**.

### What bumped

| Package | From | To | Notes |
| --- | --- | --- | --- |
| `@biomejs/biome` | 2.5.7 | 2.5.8 | released 2026-08-11, clears the 3-day rule |

`pnpm biome migrate --write` changed **only the `$schema` URL** — 2.5.8 needs no config
restructuring here. Not in `pnpm-workspace.yaml` overrides, so no lockstep edit was required.

Two checks done rather than assumed, both from this repo's recorded gotchas:

- **Grepped the release notes for `panicked`** before bumping (standing rule from the 2.5.3
  hold). The single hit is a **fix** for a `noUselessFragments` panic, not a new one.
- This repo enables `nursery` at `preset: recommended` **and** `useSortedClasses: "on"`, and
  2.5.8 both changes `sort_v4` variant ordering (#11249) and adds four nursery rules — so a
  patch bump here can rewrite application source. Result: slate stayed at **0** across 687
  files and `useSortedClasses` rewrote nothing. Slate listed via the **summary reporter**,
  never read off an exit code.

### `next` — HOLD STAYS, and this week's signal was a false positive

The hold is in force (exact `16.2.12` pin + matching `pnpm-workspace.yaml` override), so no
bump, no codemod, no override "fix". Reporting as the routine requires:

- Current **16.2.12**; latest stable **16.3.1** (published 2026-08-13T22:48:45Z).
- **A 16.3.1 stable now exists**, and **upstream vercel/next.js#96646 is CLOSED**
  (2026-08-14T09:09:04Z) — i.e. *both halves* of the condition BACKLOG told us to wait for.

**Neither means the bug is fixed.** The fix is
[PR #97287](https://github.com/vercel/next.js/pull/97287) (commit `c7b87c23`), which re-scopes
the #93684 gate so whole-app server NFTs are still emitted when `output: 'standalone'` runs
alongside an adapter. It merged **into `canary`** at **2026-08-14T09:09:02Z** — **~10 hours
after 16.3.1 was published** — and the issue closed two seconds later *because* that merge
auto-closed it. Verified three ways:

1. 16.3.1's release notes list 20 backports; **#97287 is not among them**.
2. `npm view next versions` shows **nothing newer than 16.3.1** on the 16.3.x line — no 16.3.2.
3. A search for a backport PR onto the release branch returns **none**.

So the fix is **canary-only** and **16.3.1 still contains the deploy-breaking bug**.

This is the "green Vercel check" lesson one layer out: twice now the tempting signal has been a
**proxy** for the fix rather than the fix. BACKLOG's retirement condition is restated as
something directly checkable — *lift the pin when a stable release **contains** `c7b87c23`*.
Also flagged there: when the fix does ship (say 16.3.2), `.github/dependabot.yml`'s
`next: ["16.3.x"]` ignore entry **will also block the good version**, so it must be retired in
the same edit that lifts the pin.

### Release scan (report-only)

| Package | Current | Latest stable | Verdict |
| --- | --- | --- | --- |
| `next` | 16.2.12 | 16.3.1 | **HELD** — see above |
| `@biomejs/biome` | 2.5.7 | 2.5.8 | **bumped** |
| `pnpm` | 11.20.0 | 11.22.0 | 11.22.0 is 2 days old — **too fresh**; 11.21.0 eligible |
| Node | 24 | — | pinned deliberately; never propose a major |
| `react` / `react-dom` | 19.2.8 | 19.2.8 | current |
| `drizzle-orm` / `drizzle-kit` | 0.45.2 / 0.31.10 | same | current |
| `vitest` | 4.1.10 | 4.1.10 | current |
| `cypress` | 15.20.0 | 15.20.1 | minor patch available |
| `typescript` | 7.0.2 | 7.0.2 | current |

Other outdated directs left to Dependabot's grouped PRs: `jose` 6.2.9,
`@cypress/webpack-preprocessor` 7.1.2, `@tsconfig/bases` 1.0.27, `knip` 6.32.2.
`@types/node` 26.2.0 is correctly ignored (deliberate 24.x pin).

### Report-only findings

**1. New HIGH advisory — `nanoid`** ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), surfaced as Dependabot alert #50)

Custom generators loop indefinitely when size is zero; vulnerable `<3.3.18`. Single installed
copy is **`nanoid@3.3.17`**, reached via `next → postcss → nanoid` and the cypress webpack
chain (18 paths). **Not fixed here — `pnpm audit` is report-only in this routine.** Diagnosed
so it is one step to act on:

- `postcss@8.5.26` already declares `^3.3.17`, which **admits** the patched **3.3.18**
  (published 2026-08-07, clears the 3-day rule).
- That makes it the **droppable stale-lockfile class**, like `fast-uri` and `brace-expansion`
  — *not* the `esbuild`/`sharp` class where upstream pins below the patched line.
- A `pnpm-workspace.yaml` override is the only lever: `pnpm update` cannot move a transitive.
- **Nothing in this repo imports `nanoid`**, so the size-zero path is not reachable from our code.

**2. `node:drift`'s `@types/node` axis has a transitive blind spot** *(pre-existing, not introduced here)*

The fifth axis pins the **declared** range in `package.json`. It cannot see a transitive open
range, and there is one: **`@types/pg@8.21.0` declares `"@types/node": "*"`** → resolves
**26.2.0**, and `@types/pg/index.d.ts` line 1 is `/// <reference types="node" />`. Under pnpm's
isolated layout `@types/pg` gets its own symlink (verified → `@types+node@26.2.0`), so a Node-26
typings copy is installed and reachable through a **direct devDependency** while the guard
reports `OK — @types/node ^24.13.3 matches Node 24`.

Scoped honestly: **reachability is proven, harm is not.** Typecheck is green and TS generally
collapses duplicate globals. The concern is that the guard's invariant is weaker than it reads —
the same shape as #133, where typing against a superset of the runtime is not a type error.
Recorded in BACKLOG as **Andrew's call**, with two options (a `@types/node` override, which
`deps:drift` would then gate; or extend `node:drift` to walk resolved copies).

**3. `pnpm knip`** — clean. No new unused files or exports; only the pre-existing `.css`
configuration hint.

**4. Migration drift** — **no drift.** `pnpm db:drift` reports dev, test and prod describe the
same final schema (`customers`, `demo_user_counters`, `invoices`, `users`). Differing migration
*names* across the three (`0007_flowery_lyja` / `0007_pale_felicia_hardy` /
`0007_cultured_juggernaut`) are expected — names are randomly generated, and the guard compares
schema, which is the invariant that matters.

**5. Lockfile note** — `pnpm install` deduped one transitive edge (`jest-worker`'s `@types/node`
26.2.0 → 24.13.3). Checked whether this meant `main`'s lockfile was stale and would break CI's
`--frozen-lockfile`: **it would not.** The root importer already matched the manifest
(`^24.13.3` → `24.13.3`); both lockfiles still carry two `@types/node` package entries. This is
a dedupe, not a staleness fix.

## Type of change

- [x] Chore / tooling / docs

## How it was tested

- [x] `pnpm check:fast` — **exit 0** (Biome 0 diagnostics/687 files, markdownlint 0, dprint
      clean, typegen ok, typecheck app + Cypress green, `node:drift` / `deps:drift` / `db:drift`
      all OK)
- [x] `pnpm test` (unit) — **465/465 passing, 72 files**
- [ ] `pnpm e2e` — not run, per the routine (slow + known `$PORT`-reuse trap)
- [ ] Manually verified in the running app — n/a for a lint-toolchain bump

Environment note: the non-interactive shell inherited **Node 26** because the `.nvmrc` `chpwd`
hook is interactive-only. All checks were run under `nvm use 24` — otherwise `node:drift` fails
for an environment reason and reads as a repo break.

## Checklist

- [x] Follows the rules in `AGENTS.md` and `docs/standards/`
- [x] No secrets, `.env*` files, or generated artifacts committed — 4 files only
- [x] Docs / README updated if behaviour or setup changed — `BACKLOG.md` reconciled
- [x] Focused change — preserves existing patterns and user-authored work
